### PR TITLE
Remove hardcoded paths

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,9 +17,6 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'require-corp',
       'Cross-Origin-Opener-Policy': 'same-origin',
     },
-    fs: {
-      allow: ['/Users/roeierez/breez/rust-spark/packages/wasm', '/Users/roeierez/breez/brez-wasm-wallet'],
-    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
This PR removes the `fs.allow` config with hardcoded local paths for the following reasons:

* The hardcoded `fs.allow` paths appear development-specific and unnecessary
* The published npm SDK includes all necessary deps