### PR TITLE
feat: Add fiat currency support

### DIFF
--- a/src/pages/FiatCurrenciesPage.tsx
+++ b/src/pages/FiatCurrenciesPage.tsx
@@ -1,0 +1,283 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { Transition } from '@headlessui/react';
+import { LoadingSpinner } from '../components/ui';
+import { useWallet } from '@/contexts/WalletContext';
+import { getFiatSettings, saveFiatSettings } from '../services/settings';
+import type { FiatCurrency } from '@breeztech/breez-sdk-spark';
+
+interface FiatCurrenciesPageProps {
+  onBack: () => void;
+}
+
+const FiatCurrenciesPage: React.FC<FiatCurrenciesPageProps> = ({ onBack }) => {
+  const wallet = useWallet();
+  const [isOpen, setIsOpen] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [currencies, setCurrencies] = useState<FiatCurrency[]>([]);
+  const [selectedCurrencies, setSelectedCurrencies] = useState<string[]>([]);
+  const [draggedItem, setDraggedItem] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        setIsLoading(true);
+        
+        // Load saved settings
+        const settings = getFiatSettings();
+        setSelectedCurrencies(settings.selectedCurrencies);
+        
+        // Load available currencies from SDK
+        const fiatCurrencies = await wallet.listFiatCurrencies();
+        setCurrencies(fiatCurrencies);
+      } catch (error) {
+        console.error('Failed to load fiat currencies:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    
+    loadData();
+  }, [wallet]);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setTimeout(onBack, 220);
+  };
+
+  const handleToggleCurrency = useCallback((currencyId: string) => {
+    setSelectedCurrencies(prev => {
+      let newSelection: string[];
+      if (prev.includes(currencyId)) {
+        // Remove currency
+        newSelection = prev.filter(id => id !== currencyId);
+      } else {
+        // Add currency at the end
+        newSelection = [...prev, currencyId];
+      }
+      // Save immediately
+      saveFiatSettings({ selectedCurrencies: newSelection });
+      return newSelection;
+    });
+  }, []);
+
+  const handleDragStart = useCallback((currencyId: string) => {
+    setDraggedItem(currencyId);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent, targetId: string) => {
+    e.preventDefault();
+    if (!draggedItem || draggedItem === targetId) return;
+    
+    setSelectedCurrencies(prev => {
+      const draggedIndex = prev.indexOf(draggedItem);
+      const targetIndex = prev.indexOf(targetId);
+      
+      if (draggedIndex === -1 || targetIndex === -1) return prev;
+      
+      const newOrder = [...prev];
+      newOrder.splice(draggedIndex, 1);
+      newOrder.splice(targetIndex, 0, draggedItem);
+      
+      // Save immediately
+      saveFiatSettings({ selectedCurrencies: newOrder });
+      return newOrder;
+    });
+  }, [draggedItem]);
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedItem(null);
+  }, []);
+
+  const handleMoveUp = useCallback((currencyId: string) => {
+    setSelectedCurrencies(prev => {
+      const index = prev.indexOf(currencyId);
+      if (index <= 0) return prev;
+      
+      const newOrder = [...prev];
+      [newOrder[index - 1], newOrder[index]] = [newOrder[index], newOrder[index - 1]];
+      
+      saveFiatSettings({ selectedCurrencies: newOrder });
+      return newOrder;
+    });
+  }, []);
+
+  const handleMoveDown = useCallback((currencyId: string) => {
+    setSelectedCurrencies(prev => {
+      const index = prev.indexOf(currencyId);
+      if (index === -1 || index >= prev.length - 1) return prev;
+      
+      const newOrder = [...prev];
+      [newOrder[index], newOrder[index + 1]] = [newOrder[index + 1], newOrder[index]];
+      
+      saveFiatSettings({ selectedCurrencies: newOrder });
+      return newOrder;
+    });
+  }, []);
+
+  // Get currency info helper
+  const getCurrencyInfo = (currencyId: string): FiatCurrency | undefined => {
+    return currencies.find(c => c.id === currencyId);
+  };
+
+  // Separate selected and unselected currencies
+  const selectedCurrencyList = selectedCurrencies
+    .map(id => getCurrencyInfo(id))
+    .filter((c): c is FiatCurrency => c !== undefined);
+  
+  const unselectedCurrencyList = currencies
+    .filter(c => !selectedCurrencies.includes(c.id))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  return (
+    <div className="absolute inset-0 z-50 overflow-hidden">
+      <Transition show={isOpen} appear as="div" className="absolute inset-0">
+        <Transition.Child
+          as="div"
+          enter="transform transition ease-out duration-300"
+          enterFrom="translate-x-full"
+          enterTo="translate-x-0"
+          leave="transform transition ease-in duration-200"
+          leaveFrom="translate-x-0"
+          leaveTo="translate-x-full"
+          className="absolute inset-0"
+        >
+          <div className="flex flex-col h-full bg-spark-surface">
+            {/* Header */}
+            <div className="relative px-4 py-4 border-b border-spark-border">
+              <button
+                onClick={handleClose}
+                className="absolute left-4 top-1/2 -translate-y-1/2 p-2 text-spark-text-muted hover:text-spark-text-primary rounded-lg hover:bg-white/5 transition-colors"
+                aria-label="Back"
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+              <h1 className="text-center font-display text-lg font-semibold text-spark-text-primary">
+                Fiat Currencies
+              </h1>
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 overflow-y-auto min-h-0">
+              {isLoading ? (
+                <div className="flex items-center justify-center py-12">
+                  <LoadingSpinner />
+                </div>
+              ) : (
+                <div className="p-4 space-y-2">
+                  {/* Selected currencies - with drag handles */}
+                  {selectedCurrencyList.map((currency, index) => (
+                    <div
+                      key={currency.id}
+                      draggable
+                      onDragStart={() => handleDragStart(currency.id)}
+                      onDragOver={(e) => handleDragOver(e, currency.id)}
+                      onDragEnd={handleDragEnd}
+                      className={`flex items-center gap-3 p-3 bg-spark-dark border border-spark-border rounded-xl transition-all ${
+                        draggedItem === currency.id ? 'opacity-50' : ''
+                      }`}
+                    >
+                      {/* Checkbox */}
+                      <button
+                        onClick={() => handleToggleCurrency(currency.id)}
+                        className="w-6 h-6 rounded border-2 border-spark-primary bg-spark-primary/20 flex items-center justify-center flex-shrink-0"
+                      >
+                        <svg className="w-4 h-4 text-spark-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                      </button>
+
+                      {/* Currency info */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-display font-semibold text-spark-text-primary">
+                            {currency.id}
+                          </span>
+                          {currency.info.symbol?.grapheme && (
+                            <span className="text-spark-text-muted">
+                              ({currency.info.symbol.grapheme})
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm text-spark-text-muted truncate">
+                          {currency.info.name}
+                        </p>
+                      </div>
+
+                      {/* Reorder buttons (mobile-friendly) */}
+                      <div className="flex flex-col gap-0.5">
+                        <button
+                          onClick={() => handleMoveUp(currency.id)}
+                          disabled={index === 0}
+                          className="p-1 text-spark-text-muted hover:text-spark-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
+                          aria-label="Move up"
+                        >
+                          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+                          </svg>
+                        </button>
+                        <button
+                          onClick={() => handleMoveDown(currency.id)}
+                          disabled={index === selectedCurrencyList.length - 1}
+                          className="p-1 text-spark-text-muted hover:text-spark-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
+                          aria-label="Move down"
+                        >
+                          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                          </svg>
+                        </button>
+                      </div>
+
+                      {/* Drag handle */}
+                      <div className="cursor-grab active:cursor-grabbing text-spark-text-muted hover:text-spark-text-secondary p-1">
+                        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M4 8h16M4 16h16" />
+                        </svg>
+                      </div>
+                    </div>
+                  ))}
+
+                  {/* Unselected currencies */}
+                  {unselectedCurrencyList.map((currency) => (
+                    <div
+                      key={currency.id}
+                      className="flex items-center gap-3 p-3 bg-spark-dark/50 border border-spark-border/50 rounded-xl"
+                    >
+                      {/* Checkbox (empty) */}
+                      <button
+                        onClick={() => handleToggleCurrency(currency.id)}
+                        className="w-6 h-6 rounded border-2 border-spark-border bg-transparent flex items-center justify-center flex-shrink-0 hover:border-spark-primary/50 transition-colors"
+                      >
+                        {/* Empty checkbox */}
+                      </button>
+
+                      {/* Currency info */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-display font-medium text-spark-text-secondary">
+                            {currency.id}
+                          </span>
+                          {currency.info.symbol?.grapheme && (
+                            <span className="text-spark-text-muted">
+                              ({currency.info.symbol.grapheme})
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm text-spark-text-muted truncate">
+                          {currency.info.name}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </Transition.Child>
+      </Transition>
+    </div>
+  );
+};
+
+export default FiatCurrenciesPage;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -11,9 +11,10 @@ const DEV_MODE_STORAGE_KEY = 'spark-dev-mode';
 interface SettingsPageProps {
   onBack: () => void;
   config: Config | null;
+  onOpenFiatCurrencies: () => void;
 }
 
-const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, config }) => {
+const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, config, onOpenFiatCurrencies }) => {
   const wallet = useWallet();
   const [isOpen, setIsOpen] = useState(true);
   const [isDevMode, setIsDevMode] = useState<boolean>(false);
@@ -239,6 +240,26 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, config }) => {
                     </FormGroup>
                   </div>
                 )}
+
+                {/* Fiat Currencies */}
+                <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+                  <h3 className="font-display font-semibold text-spark-text-primary mb-3">Display</h3>
+                  <button
+                    className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+                    type="button"
+                    onClick={onOpenFiatCurrencies}
+                  >
+                    <div className="flex items-center gap-3">
+                      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      <span>Fiat Currencies</span>
+                    </div>
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                </div>
 
                 {/* SDK Logs */}
                 <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -10,13 +10,14 @@ import PaymentDetailsDialog from '../components/PaymentDetailsDialog';
 import CollapsingWalletHeader from '../components/CollapsingWalletHeader';
 import SideMenu from '../components/SideMenu';
 import TransactionList from '../components/TransactionList';
-import { GetInfoResponse, Payment } from '@breeztech/breez-sdk-spark';
+import { GetInfoResponse, Payment, Rate, FiatCurrency } from '@breeztech/breez-sdk-spark';
 import { SendInput } from '@/types/domain';
 
 interface WalletPageProps {
   walletInfo: GetInfoResponse | null;
   transactions: Payment[];
-  usdRate: number | null;
+  fiatRates: Rate[];
+  fiatCurrencies: FiatCurrency[];
   refreshWalletData: (showLoading?: boolean) => Promise<void>;
   isRestoring: boolean;
   error: string | null;
@@ -31,7 +32,8 @@ interface WalletPageProps {
 const WalletPage: React.FC<WalletPageProps> = ({
   walletInfo,
   transactions,
-  usdRate,
+  fiatRates,
+  fiatCurrencies,
   refreshWalletData,
   isRestoring,
   onLogout,
@@ -116,7 +118,8 @@ const WalletPage: React.FC<WalletPageProps> = ({
       <div className="sticky top-0 z-10">
         <CollapsingWalletHeader
           walletInfo={walletInfo}
-          usdRate={usdRate}
+          fiatRates={fiatRates}
+          fiatCurrencies={fiatCurrencies}
           scrollProgress={scrollProgress}
           onOpenMenu={() => setIsMenuOpen(true)}
           hasUnclaimedDeposits={hasUnclaimedDeposits}

--- a/src/services/WalletAPI.ts
+++ b/src/services/WalletAPI.ts
@@ -19,6 +19,8 @@ import type {
   Fee,
   UserSettings,
   UpdateUserSettingsRequest,
+  FiatCurrency,
+  Rate,
 } from '@breeztech/breez-sdk-spark';
 
 export interface WalletAPI {
@@ -60,6 +62,10 @@ export interface WalletAPI {
   // User settings
   getUserSettings: () => Promise<UserSettings>;
   setUserSettings: (settings: UpdateUserSettingsRequest) => Promise<void>;
+
+  // Fiat currencies
+  listFiatCurrencies: () => Promise<FiatCurrency[]>;
+  listFiatRates: () => Promise<Rate[]>;
 
   // Logs
   getSdkLogs: () => string;

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -7,10 +7,20 @@ export interface UserSettings {
   preferSparkOverLightning?: boolean;
 }
 
+export interface FiatSettings {
+  // Ordered list of selected currency IDs (e.g., ['USD', 'EUR', 'GBP'])
+  selectedCurrencies: string[];
+}
+
 const SETTINGS_KEY = 'user_settings_v1';
+const FIAT_SETTINGS_KEY = 'fiat_settings_v1';
 
 const defaultSettings: UserSettings = {
   depositMaxFee: { type: 'rate', satPerVbyte: 1 },
+};
+
+const defaultFiatSettings: FiatSettings = {
+  selectedCurrencies: ['USD'],
 };
 
 export function getSettings(): UserSettings {
@@ -45,4 +55,23 @@ export function getSettings(): UserSettings {
 
 export function saveSettings(settings: UserSettings): void {
   localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+}
+
+export function getFiatSettings(): FiatSettings {
+  try {
+    const raw = localStorage.getItem(FIAT_SETTINGS_KEY);
+    if (!raw) return defaultFiatSettings;
+    const parsed = JSON.parse(raw) as Partial<FiatSettings>;
+    return {
+      selectedCurrencies: Array.isArray(parsed.selectedCurrencies) 
+        ? parsed.selectedCurrencies 
+        : defaultFiatSettings.selectedCurrencies,
+    };
+  } catch {
+    return defaultFiatSettings;
+  }
+}
+
+export function saveFiatSettings(settings: FiatSettings): void {
+  localStorage.setItem(FIAT_SETTINGS_KEY, JSON.stringify(settings));
 }

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -26,6 +26,8 @@ import {
   Fee,
   UserSettings,
   UpdateUserSettingsRequest,
+  FiatCurrency,
+  Rate,
 } from '@breeztech/breez-sdk-spark';
 import type { WalletAPI } from './WalletAPI';
 
@@ -140,6 +142,20 @@ export const setUserSettings = async (settings: UpdateUserSettingsRequest): Prom
   if (!sdk) throw new Error('SDK not initialized');
   await sdk.updateUserSettings(settings);
 };
+
+// Fiat currencies
+export const listFiatCurrencies = async (): Promise<FiatCurrency[]> => {
+  if (!sdk) throw new Error('SDK not initialized');
+  const response = await sdk.listFiatCurrencies();
+  return response.currencies;
+};
+
+export const listFiatRates = async (): Promise<Rate[]> => {
+  if (!sdk) throw new Error('SDK not initialized');
+  const response = await sdk.listFiatRates();
+  return response.rates;
+};
+
 // Logs accessors
 export const getSdkLogs = (): string => {
   return sdkLogs.join('\n');
@@ -330,6 +346,9 @@ export const walletApi: WalletAPI = {
   // User settings
   getUserSettings,
   setUserSettings,
+  // Fiat currencies
+  listFiatCurrencies,
+  listFiatRates,
   // Logs
   getSdkLogs,
 };


### PR DESCRIPTION
## Summary
Adds fiat currency support using the Breez SDK fiat currencies API.

## Features
- **Settings page**: New "Fiat Currencies" section under Display settings
- **Currency selection**: Users can select multiple currencies and reorder them by priority
- **Balance display**: Shows fiat equivalent under the BTC balance (tap to cycle through selected currencies)
- **Auto-refresh**: Fiat rates are fetched every 60 seconds

## Implementation
- Added `listFiatCurrencies()` and `listFiatRates()` to WalletAPI
- Created `FiatCurrenciesPage` with drag-to-reorder and mobile-friendly up/down buttons
- Fiat preferences stored in localStorage
- Fiat display hidden when balance is zero

## Reference
- [Breez SDK Fiat Currencies Documentation](https://sdk-doc-spark.breez.technology/guide/fiat_currencies.html)