### PR TITLE
Add safe area inset support for mobile webapp

### DIFF
--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -137,7 +137,7 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
       </div>
 
       {/* Header content */}
-      <div className="relative z-10 px-4 pt-4 pb-2">
+      <div className="relative z-10 px-4 pb-2" style={{ paddingTop: 'calc(1rem + env(safe-area-inset-top))' }}>
         {/* Top bar with menu and network */}
         <div className="flex items-center justify-between mb-4">
           {/* Menu button */}


### PR DESCRIPTION
## Summary
- Add top safe area padding to CollapsingWalletHeader for iOS notch/status bar support
- Uses `env(safe-area-inset-top)` which returns 0 on desktop, maintaining compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)