### PR TITLE
fix: adapt to PayAmount union type in SDK

### DIFF
--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -119,7 +119,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
     setIsLoading(true);
     setError(null);
     try {
-      const response = await wallet.prepareSendPayment({ paymentRequest, amount: BigInt(amountSats) });
+      const response = await wallet.prepareSendPayment({ paymentRequest, payAmount: { type: 'bitcoin', amountSats } });
       setPrepareResponse(response);
       // Always go to workflow; BTC fee selection happens inside the Bitcoin workflow
       setCurrentStep('workflow');
@@ -262,7 +262,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
             {prepareResponse && prepareResponse.paymentMethod.type === 'bolt11Invoice' && (
               <Bolt11Workflow
                 method={prepareResponse.paymentMethod}
-                amountSats={prepareResponse.amount}
+                amountSats={BigInt(prepareResponse.payAmount.type === 'bitcoin' ? prepareResponse.payAmount.amountSats : 0)}
                 onBack={() => setCurrentStep('input')}
                 onSend={handleSend}
               />
@@ -270,7 +270,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
             {prepareResponse && prepareResponse.paymentMethod.type === 'bitcoinAddress' && (
               <BitcoinWorkflow
                 method={prepareResponse.paymentMethod}
-                amountSats={prepareResponse.amount}
+                amountSats={BigInt(prepareResponse.payAmount.type === 'bitcoin' ? prepareResponse.payAmount.amountSats : 0)}
                 onBack={() => setCurrentStep('amount')}
                 onSend={handleSend}
               />
@@ -278,7 +278,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
             {prepareResponse && prepareResponse.paymentMethod.type === 'sparkAddress' && (
               <SparkWorkflow
                 method={prepareResponse.paymentMethod}
-                amountSats={prepareResponse.amount}
+                amountSats={BigInt(prepareResponse.payAmount.type === 'bitcoin' ? prepareResponse.payAmount.amountSats : 0)}
                 onBack={() => setCurrentStep('input')}
                 onSend={handleSend}
               />

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -69,7 +69,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, onBack, onRun, on
     setIsLoading(true);
     setError(null);
     try {
-      const resp = await onPrepare({ amountSats: sats, comment: comment ? comment : undefined, payRequest: parsed });
+      const resp = await onPrepare({ payAmount: { type: 'bitcoin', amountSats: sats }, comment: comment ? comment : undefined, payRequest: parsed });
       setPrepareResponse(resp);
       setStep('confirm');
     } catch (err) {


### PR DESCRIPTION
## Summary
- Updates payment preparation to use the new `PayAmount` union type
- `PrepareSendPaymentRequest`: use `payAmount` instead of `amount`
- `PrepareSendPaymentResponse`: access `payAmount.amountSats`
- `PrepareLnurlPayRequest`: use `payAmount` instead of `amountSats`

## Context
This adapts the app to SDK changes already merged after 0.7.10 release. These changes are not from SDK PR #579 but are part of SDK main branch updates.

## Test plan
- [ ] Test sending a Lightning payment (Bolt11)
- [ ] Test sending to a Bitcoin address
- [ ] Test sending to a Spark address
- [ ] Test LNURL-Pay workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)