### PR TITLE
fix: improve send bottom sheet height behavior

### DIFF
--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -579,24 +579,26 @@ export const StepPanelGroup: React.FC<{
 );
 
 /**
- * StepPanel - Container for step content with dynamic height
+ * StepPanel - Container for step content
  *
- * Must be used inside StepPanelGroup for consistent height behavior.
- * All panels stack in the same grid cell, with only the active one visible.
+ * Only renders content when active. Each step takes only the space it needs,
+ * so the container height adjusts per step.
  */
 export const StepPanel: React.FC<{
   children: ReactNode;
   isActive: boolean;
   className?: string;
-}> = ({ children, isActive, className = "" }) => (
-  <div
-    className={`col-start-1 row-start-1 transition-opacity duration-200 ${isActive ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'
-      } ${className}`}
-    aria-hidden={!isActive}
-  >
-    {children}
-  </div>
-);
+}> = ({ children, isActive, className = "" }) => {
+  if (!isActive) {
+    return null;
+  }
+
+  return (
+    <div className={className}>
+      {children}
+    </div>
+  );
+};
 
 // ============================================
 // BOTTOM SHEET COMPONENTS

--- a/src/features/send/steps/ResultStep.tsx
+++ b/src/features/send/steps/ResultStep.tsx
@@ -11,7 +11,7 @@ const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose }) => {
   const isSuccess = result === 'success';
 
   return (
-    <div className="flex flex-col items-center justify-center py-8">
+    <div className="flex flex-col items-center justify-center">
       {/* Result icon */}
       <div className="relative mb-6">
         {/* Glow effect */}


### PR DESCRIPTION
## Summary
- StepPanel now only renders active content instead of using CSS opacity/pointer-events, allowing each step to take only the space it needs
- Remove py-8 padding from ResultStep for consistency with other steps

## Test plan
- [ ] Test send flow with Lightning invoice
- [ ] Test send flow with Bitcoin address
- [ ] Verify bottom sheet height adjusts correctly per step
- [ ] Verify button positions are consistent across steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)