### PR TITLE
feat: add data-testid attributes to components

### DIFF
--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -120,6 +120,7 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
             onClick={onOpenMenu}
             className="p-2 -ml-2 text-spark-text-secondary hover:text-spark-text-primary transition-colors rounded-xl hover:bg-white/5"
             aria-label="Open menu"
+            data-testid="menu-button"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
@@ -153,7 +154,7 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
           </div>
 
           {/* Main balance */}
-          <div className="flex items-baseline justify-center gap-2">
+          <div className="flex items-baseline justify-center gap-2" data-testid="wallet-balance">
             <span className="balance-display">
               {formatWithThinSpaces(animatedBalance)}
             </span>

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -91,7 +91,7 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onPayme
 
   if (!transactions.length) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 px-6">
+      <div className="flex flex-col items-center justify-center py-20 px-6" data-testid="empty-state">
         <div className="w-20 h-20 rounded-2xl bg-spark-surface border border-spark-border flex items-center justify-center mb-6">
           {EmptyStateIcon}
         </div>
@@ -114,6 +114,7 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onPayme
         className="transaction-item flex items-center gap-3 px-3 py-3 rounded-xl cursor-pointer animate-list-item"
         style={{ animationDelay: `${Math.min(index * 50, 500)}ms` }}
         onClick={() => onPaymentSelected(tx)}
+        data-testid="transaction-item"
       >
         {/* Transaction type icon */}
         <div className={`
@@ -152,12 +153,15 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onPayme
         </div>
 
         {/* Amount - right aligned */}
-        <span className={`
-          font-mono font-semibold text-[15px] flex-shrink-0
-          ${isFailed ? 'text-spark-text-muted line-through' : ''}
-          ${!isFailed && isReceive ? 'text-spark-success' : ''}
-          ${!isFailed && !isReceive ? 'text-spark-electric' : ''}
-        `}>
+        <span
+          className={`
+            font-mono font-semibold text-[15px] flex-shrink-0
+            ${isFailed ? 'text-spark-text-muted line-through' : ''}
+            ${!isFailed && isReceive ? 'text-spark-success' : ''}
+            ${!isFailed && !isReceive ? 'text-spark-electric' : ''}
+          `}
+          data-testid="transaction-amount"
+        >
           {isReceive ? '+' : '-'}{formatWithSpaces(Number(tx.amount))}
         </span>
       </li>

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -267,7 +267,8 @@ export const CopyableText: React.FC<{
   textToCopy?: string;
   textToShare?: string;
   shareLabel?: string;
-}> = ({ text, truncate = false, showShare = false, onCopied, onShareError, label = 'Address', additionalActions, textColor = 'text-spark-text-muted', textToCopy, textToShare, shareLabel }) => {
+  'data-testid'?: string;
+}> = ({ text, truncate = false, showShare = false, onCopied, onShareError, label = 'Address', additionalActions, textColor = 'text-spark-text-muted', textToCopy, textToShare, shareLabel, 'data-testid': testId }) => {
   const [copied, setCopied] = React.useState(false);
   const [canShare, setCanShare] = React.useState(false);
 
@@ -307,7 +308,7 @@ export const CopyableText: React.FC<{
     : text;
 
   return (
-    <div className="flex flex-col items-center gap-4 w-full">
+    <div className="flex flex-col items-center gap-4 w-full" data-testid={testId}>
       {/* Clickable text display */}
       <button
         onClick={handleCopy}

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -287,13 +287,13 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
 
         <TabContainer>
           <TabList>
-            <Tab isActive={activeTab === 'lightning'} onClick={() => handleTabChange('lightning')}>
+            <Tab isActive={activeTab === 'lightning'} onClick={() => handleTabChange('lightning')} data-testid="lightning-tab">
               <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M13 3L4 14h7l-2 7 9-11h-7l2-7z" />
               </svg>
               Lightning
             </Tab>
-            <Tab isActive={activeTab === 'bitcoin'} onClick={() => handleTabChange('bitcoin')}>
+            <Tab isActive={activeTab === 'bitcoin'} onClick={() => handleTabChange('bitcoin')} data-testid="bitcoin-tab">
               <span className="font-bold text-sm">₿</span>
               Bitcoin
             </Tab>

--- a/src/features/receive/SparkAddressDisplay.tsx
+++ b/src/features/receive/SparkAddressDisplay.tsx
@@ -30,6 +30,7 @@ const SparkAddressDisplay: React.FC<Props> = ({ address, isLoading }) => {
         textColor="text-spark-primary"
         onCopied={() => showToast('success', 'Copied!')}
         onShareError={() => showToast('error', 'Failed to share')}
+        data-testid="spark-address-text"
       />
     </div>
   );

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -52,6 +52,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
           className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           disabled={isLoading}
           min={1}
+          data-testid="amount-input"
         />
         
         {/* Quick amount buttons */}

--- a/src/features/send/steps/InputStep.tsx
+++ b/src/features/send/steps/InputStep.tsx
@@ -39,6 +39,7 @@ const InputStep: React.FC<InputStepProps> = ({ paymentInput, isLoading, error, o
         className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 resize-none font-mono text-sm transition-all"
         rows={3}
         disabled={isLoading}
+        data-testid="payment-input"
       />
 
       {/* Error */}
@@ -80,6 +81,7 @@ const InputStep: React.FC<InputStepProps> = ({ paymentInput, isLoading, error, o
         onClick={() => onContinue(localPaymentInput)}
         disabled={isLoading || !localPaymentInput.trim()}
         className="w-full"
+        data-testid="continue-button"
       >
         {isLoading ? (
           <span className="flex items-center justify-center gap-2">

--- a/src/features/send/steps/ResultStep.tsx
+++ b/src/features/send/steps/ResultStep.tsx
@@ -11,7 +11,7 @@ const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose }) => {
   const isSuccess = result === 'success';
 
   return (
-    <div className="flex flex-col items-center justify-center">
+    <div className="flex flex-col items-center justify-center" data-testid={isSuccess ? 'payment-success' : 'payment-failure'}>
       {/* Result icon */}
       <div className="relative mb-6">
         {/* Glow effect */}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -103,6 +103,7 @@ const HomePage: React.FC<HomePageProps> = ({ onRestoreWallet, onCreateNewWallet 
           {/* Primary CTA */}
           <button
             onClick={onCreateNewWallet}
+            data-testid="create-wallet-button"
             className="button w-full py-4 text-base tracking-wider"
           >
             Get Started
@@ -111,6 +112,7 @@ const HomePage: React.FC<HomePageProps> = ({ onRestoreWallet, onCreateNewWallet 
           {/* Secondary CTA */}
           <button
             onClick={onRestoreWallet}
+            data-testid="restore-wallet-button"
             className="button-secondary w-full py-4 rounded-xl font-display font-semibold text-sm tracking-wide"
           >
             Restore from Backup

--- a/src/pages/RestorePage.tsx
+++ b/src/pages/RestorePage.tsx
@@ -36,6 +36,7 @@ const RestorePage: React.FC<RestorePageProps> = ({
         onClick={handleSubmit}
         disabled={!mnemonic.trim()}
         className="w-full"
+        data-testid="restore-confirm-button"
       >
         Restore Wallet
       </PrimaryButton>
@@ -64,6 +65,7 @@ const RestorePage: React.FC<RestorePageProps> = ({
             onChange={(e) => setMnemonic(e.target.value)}
             className="w-full h-36 px-4 py-3 text-spark-text-primary bg-spark-dark border border-spark-border rounded-xl focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20 resize-none font-mono text-sm"
             placeholder="word1 word2 word3 ..."
+            data-testid="mnemonic-input"
           />
         </div>
 

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -256,6 +256,7 @@ const WalletPage: React.FC<WalletPageProps> = ({
         <button
           onClick={() => setIsSendDialogOpen(true)}
           className="action-button action-button-send"
+          data-testid="send-button"
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M7 11l5-5m0 0l5 5m-5-5v12" />
@@ -268,6 +269,7 @@ const WalletPage: React.FC<WalletPageProps> = ({
           onClick={() => setIsQrScannerOpen(true)}
           className="action-button action-button-scan"
           aria-label="Scan QR Code"
+          data-testid="scan-button"
         >
           <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
             <path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM19 13h2v2h-2zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM15 19h2v2h-2zM17 17h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2zM19 19h2v2h-2z" />
@@ -278,6 +280,7 @@ const WalletPage: React.FC<WalletPageProps> = ({
         <button
           onClick={() => setIsReceiveDialogOpen(true)}
           className="action-button action-button-receive"
+          data-testid="receive-button"
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M17 13l-5 5m0 0l-5-5m5 5V6" />


### PR DESCRIPTION
## Summary
Add `data-testid` attributes to critical UI components for reliable E2E test selectors.

### Components updated:
- **HomePage**: `create-wallet-button`, `restore-wallet-button`
- **RestorePage**: `mnemonic-input`, `restore-confirm-button`
- **WalletPage**: `send-button`, `receive-button`, `scan-button`
- **CollapsingWalletHeader**: `wallet-balance`, `menu-button`
- **SendPaymentDialog steps**: `payment-input`, `amount-input`, `continue-button`, `payment-success`, `payment-failure`
- **ReceivePaymentDialog**: `lightning-tab`, `bitcoin-tab`, `spark-address-text`
- **TransactionList**: `transaction-item`, `transaction-amount`, `empty-state`
- **CopyableText**: Added `data-testid` prop support

## Test plan
- [x] Build passes: `npm run build`
- [x] No visual/functional changes - only added attributes

Closes #52

🤖 Generated with [Claude Code](https://claude.ai/code)