### PR TITLE
feat: address multiple open issues (#68, #69, #70, #71, #49, #14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,46 @@ grep "methodName" ~/Documents/GitHub/spark-sdk/packages/wasm/bundler/breez_sdk_s
 - `npm run build` may fail with linked packages (vite polyfill resolution)
 - Production builds require npm-published SDK version
 - Type check: `npx tsc --noEmit`
+
+## Logging Practices
+
+The app uses a structured logging service (`src/services/logger.ts`) following OWASP guidelines.
+
+### Log Levels
+- `DEBUG`: Detailed diagnostic info (dev only)
+- `INFO`: Normal operations (initialization, successful payments)
+- `WARN`: Recoverable issues (validation failures, retries)
+- `ERROR`: Failures requiring attention (SDK errors, payment failures)
+
+### Categories
+- `auth`: Authentication events
+- `payment`: Payment operations
+- `sdk`: SDK lifecycle and operations
+- `ui`: User interactions
+- `session`: Session start/end
+- `validation`: Input validation
+
+### Usage
+```typescript
+import { logger, LogCategory } from '../services/logger';
+
+// Basic logging
+logger.info(LogCategory.PAYMENT, 'Payment initiated', { type: 'lightning' });
+logger.error(LogCategory.SDK, 'Operation failed', { operation: 'sendPayment', error: errorMsg });
+
+// Security event helpers
+logger.authSuccess('mnemonic');
+logger.authFailure('mnemonic', 'Invalid format');
+logger.paymentInitiated('lightning');
+logger.paymentCompleted('lightning');
+logger.paymentFailed('lightning', errorMsg);
+```
+
+### Security Rules (NEVER log)
+- Mnemonics, seeds, private keys
+- Passwords, passphrases
+- API keys, tokens
+- Payment hashes, preimages
+- Full bolt11 invoices
+
+The logger automatically redacts these if accidentally passed in context.

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -8,6 +8,8 @@ export interface AmountStepProps {
   error: string | null;
   onBack: () => void;
   onNext: (amountSats: number) => void;
+  /** Handler for "Send All" / drain mode */
+  onDrain?: () => void;
 }
 
 const AmountStep: React.FC<AmountStepProps> = ({
@@ -17,6 +19,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
   error,
   onBack,
   onNext,
+  onDrain,
 }) => {
   const [localAmount, setLocalAmount] = useState<string>(amount || '');
 
@@ -71,6 +74,18 @@ const AmountStep: React.FC<AmountStepProps> = ({
             </button>
           ))}
         </div>
+
+        {/* Send All button for draining wallet */}
+        {onDrain && (
+          <button
+            onClick={onDrain}
+            disabled={isLoading}
+            className="w-full py-2 mt-2 rounded-lg text-sm font-medium transition-all bg-spark-warning/10 border border-spark-warning/30 text-spark-warning hover:bg-spark-warning/20 hover:border-spark-warning/50"
+            data-testid="send-all-button"
+          >
+            Send All
+          </button>
+        )}
       </div>
 
       <FormError error={error} />

--- a/src/hooks/useKeyboardHeight.ts
+++ b/src/hooks/useKeyboardHeight.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook to detect virtual keyboard height using the Visual Viewport API.
+ * Returns the keyboard height in pixels when visible, 0 otherwise.
+ *
+ * Used by bottom sheets to adjust their position when keyboard appears (#71).
+ */
+export function useKeyboardHeight(): number {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const handleResize = () => {
+      // Calculate keyboard height as difference between window and viewport
+      const kbHeight = window.innerHeight - viewport.height;
+      // Use threshold to filter out minor viewport changes (e.g., address bar)
+      setKeyboardHeight(kbHeight > 100 ? kbHeight : 0);
+    };
+
+    viewport.addEventListener('resize', handleResize);
+    viewport.addEventListener('scroll', handleResize);
+
+    return () => {
+      viewport.removeEventListener('resize', handleResize);
+      viewport.removeEventListener('scroll', handleResize);
+    };
+  }, []);
+
+  return keyboardHeight;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -246,6 +246,11 @@ h6 {
   flex-shrink: 0;
 }
 
+.action-button-send,
+.action-button-receive {
+  min-width: 7em; /* Equal width for Send/Receive buttons (#70) */
+}
+
 .action-button-send {
   background: linear-gradient(135deg, var(--spark-electric) 0%, #0099cc 100%);
   color: #000;

--- a/src/services/WalletAPI.ts
+++ b/src/services/WalletAPI.ts
@@ -69,4 +69,5 @@ export interface WalletAPI {
 
   // Logs
   getSdkLogs: () => string;
+  getAppLogs: () => string;
 }

--- a/src/services/logger.test.ts
+++ b/src/services/logger.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { logger, LogCategory } from './logger';
+
+describe('logger', () => {
+  beforeEach(() => {
+    logger.clear();
+  });
+
+  it('logs info messages to buffer', () => {
+    logger.info(LogCategory.AUTH, 'Test message');
+
+    const logs = logger.getLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0].level).toBe('INFO');
+    expect(logs[0].category).toBe('auth');
+    expect(logs[0].message).toBe('Test message');
+  });
+
+  it('logs with context', () => {
+    logger.info(LogCategory.PAYMENT, 'Payment', { amount: 1000 });
+
+    const logs = logger.getLogs();
+    expect(logs[0].context).toEqual({ amount: 1000 });
+  });
+
+  it('redacts sensitive mnemonic data', () => {
+    logger.info(LogCategory.AUTH, 'Login', { mnemonic: 'secret words here' });
+
+    const logs = logger.getLogs();
+    expect(logs[0].context?.mnemonic).toBe('[REDACTED]');
+  });
+
+  it('redacts sensitive password data', () => {
+    logger.info(LogCategory.AUTH, 'Login', { password: 'mypassword' });
+
+    const logs = logger.getLogs();
+    expect(logs[0].context?.password).toBe('[REDACTED]');
+  });
+
+  it('redacts nested sensitive data', () => {
+    logger.info(LogCategory.AUTH, 'Data', { user: { apiKey: 'secret123' } });
+
+    const logs = logger.getLogs();
+    expect((logs[0].context?.user as Record<string, unknown>)?.apiKey).toBe('[REDACTED]');
+  });
+
+  it('respects buffer limit', () => {
+    for (let i = 0; i < 1100; i++) {
+      logger.debug(LogCategory.UI, `Message ${i}`);
+    }
+
+    expect(logger.getLogs().length).toBe(1000);
+  });
+
+  it('logs auth success events', () => {
+    logger.authSuccess('wallet');
+
+    const logs = logger.getLogs();
+    expect(logs[0].category).toBe('auth');
+    expect(logs[0].message).toBe('Authentication succeeded');
+    expect(logs[0].context).toEqual({ method: 'wallet' });
+  });
+
+  it('logs auth failure events', () => {
+    logger.authFailure('wallet', 'invalid mnemonic');
+
+    const logs = logger.getLogs();
+    expect(logs[0].level).toBe('WARN');
+    expect(logs[0].category).toBe('auth');
+  });
+
+  it('logs payment events', () => {
+    logger.paymentInitiated('lightning');
+    logger.paymentCompleted('lightning');
+
+    const logs = logger.getLogs();
+    expect(logs).toHaveLength(2);
+    expect(logs[0].message).toBe('Payment initiated');
+    expect(logs[1].message).toBe('Payment completed');
+  });
+
+  it('filters logs by level', () => {
+    logger.info(LogCategory.UI, 'Info');
+    logger.error(LogCategory.UI, 'Error');
+    logger.warn(LogCategory.UI, 'Warn');
+
+    const errors = logger.getLogsByLevel('ERROR');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe('Error');
+  });
+
+  it('filters logs by category', () => {
+    logger.info(LogCategory.AUTH, 'Auth log');
+    logger.info(LogCategory.PAYMENT, 'Payment log');
+
+    const authLogs = logger.getLogsByCategory(LogCategory.AUTH);
+    expect(authLogs).toHaveLength(1);
+    expect(authLogs[0].message).toBe('Auth log');
+  });
+
+  it('exports logs as string', () => {
+    logger.info(LogCategory.SDK, 'Test');
+
+    const str = logger.getLogsAsString();
+    expect(str).toContain('[sdk]');
+    expect(str).toContain('Test');
+  });
+
+  it('clears the buffer', () => {
+    logger.info(LogCategory.UI, 'Test');
+    logger.clear();
+
+    expect(logger.getLogs()).toHaveLength(0);
+  });
+});

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,0 +1,187 @@
+/**
+ * Structured logging service for Glow wallet.
+ *
+ * Features:
+ * - Log levels: DEBUG, INFO, WARN, ERROR
+ * - Categorized logging for filtering
+ * - In-memory ring buffer for export/debugging
+ * - Automatic sensitive data redaction
+ * - Security event helpers (OWASP compliant)
+ */
+
+export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  category: string;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+/** Log categories for filtering and organization */
+export const LogCategory = {
+  AUTH: 'auth',
+  PAYMENT: 'payment',
+  SDK: 'sdk',
+  UI: 'ui',
+  NETWORK: 'network',
+  SESSION: 'session',
+  VALIDATION: 'validation',
+} as const;
+
+export type LogCategoryType = (typeof LogCategory)[keyof typeof LogCategory];
+
+/** Maximum log entries to keep in memory */
+const MAX_LOG_ENTRIES = 1000;
+
+/** In-memory log buffer */
+const logBuffer: LogEntry[] = [];
+
+/** Keys that should never be logged */
+const SENSITIVE_KEYS = [
+  'mnemonic',
+  'seed',
+  'privateKey',
+  'password',
+  'passphrase',
+  'secret',
+  'token',
+  'apiKey',
+  'paymentHash',
+  'preimage',
+  'bolt11',
+  'invoice',
+];
+
+/** Sanitize context object by redacting sensitive values */
+function sanitizeContext(ctx?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!ctx) return undefined;
+
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(ctx)) {
+    const lowerKey = key.toLowerCase();
+    const isSensitive = SENSITIVE_KEYS.some((k) => lowerKey.includes(k.toLowerCase()));
+
+    if (isSensitive) {
+      sanitized[key] = '[REDACTED]';
+    } else if (typeof value === 'object' && value !== null) {
+      sanitized[key] = sanitizeContext(value as Record<string, unknown>);
+    } else {
+      sanitized[key] = value;
+    }
+  }
+
+  return sanitized;
+}
+
+/** Core logging function */
+function log(
+  level: LogLevel,
+  category: string,
+  message: string,
+  context?: Record<string, unknown>
+): void {
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    level,
+    category,
+    message,
+    context: sanitizeContext(context),
+  };
+
+  // Add to buffer (ring buffer behavior)
+  logBuffer.push(entry);
+  if (logBuffer.length > MAX_LOG_ENTRIES) {
+    logBuffer.shift();
+  }
+
+  // Console output
+  const formatted = `[${entry.timestamp}] ${entry.level} [${entry.category}] ${entry.message}`;
+
+  switch (level) {
+    case 'ERROR':
+      console.error(formatted, context ? sanitizeContext(context) : '');
+      break;
+    case 'WARN':
+      console.warn(formatted, context ? sanitizeContext(context) : '');
+      break;
+    case 'DEBUG':
+      console.debug(formatted, context ? sanitizeContext(context) : '');
+      break;
+    default:
+      console.log(formatted, context ? sanitizeContext(context) : '');
+  }
+}
+
+/** Structured logger API */
+export const logger = {
+  // Core log methods
+  debug: (category: string, message: string, context?: Record<string, unknown>) =>
+    log('DEBUG', category, message, context),
+
+  info: (category: string, message: string, context?: Record<string, unknown>) =>
+    log('INFO', category, message, context),
+
+  warn: (category: string, message: string, context?: Record<string, unknown>) =>
+    log('WARN', category, message, context),
+
+  error: (category: string, message: string, context?: Record<string, unknown>) =>
+    log('ERROR', category, message, context),
+
+  // Security event helpers (OWASP logging guidelines)
+  authSuccess: (method: string) =>
+    log('INFO', LogCategory.AUTH, `Authentication succeeded`, { method }),
+
+  authFailure: (method: string, reason: string) =>
+    log('WARN', LogCategory.AUTH, `Authentication failed`, { method, reason }),
+
+  sessionStart: () => log('INFO', LogCategory.SESSION, 'Session started'),
+
+  sessionEnd: (reason?: string) =>
+    log('INFO', LogCategory.SESSION, 'Session ended', reason ? { reason } : undefined),
+
+  validationFailure: (field: string, reason: string) =>
+    log('WARN', LogCategory.VALIDATION, `Validation failed`, { field, reason }),
+
+  paymentInitiated: (type: string) =>
+    log('INFO', LogCategory.PAYMENT, `Payment initiated`, { type }),
+
+  paymentCompleted: (type: string) =>
+    log('INFO', LogCategory.PAYMENT, `Payment completed`, { type }),
+
+  paymentFailed: (type: string, error: string) =>
+    log('ERROR', LogCategory.PAYMENT, `Payment failed`, { type, error }),
+
+  sdkInitialized: () => log('INFO', LogCategory.SDK, 'SDK initialized'),
+
+  sdkError: (operation: string, error: string) =>
+    log('ERROR', LogCategory.SDK, `SDK error`, { operation, error }),
+
+  // Buffer access for debugging/export
+  getLogs: (): LogEntry[] => [...logBuffer],
+
+  getLogsAsString: (): string =>
+    logBuffer
+      .map((e) => {
+        const ctx = e.context ? ` ${JSON.stringify(e.context)}` : '';
+        return `[${e.timestamp}] ${e.level} [${e.category}] ${e.message}${ctx}`;
+      })
+      .join('\n'),
+
+  getLogsByLevel: (level: LogLevel): LogEntry[] => logBuffer.filter((e) => e.level === level),
+
+  getLogsByCategory: (category: string): LogEntry[] =>
+    logBuffer.filter((e) => e.category === category),
+
+  clear: () => {
+    logBuffer.length = 0;
+  },
+
+  /** Export logs for bug reports */
+  exportForBugReport: (): string => {
+    const header = `Glow Wallet Log Export\nGenerated: ${new Date().toISOString()}\nEntries: ${logBuffer.length}\n${'='.repeat(50)}\n\n`;
+    return header + logger.getLogsAsString();
+  },
+};

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -30,6 +30,7 @@ import {
   Rate,
 } from '@breeztech/breez-sdk-spark';
 import type { WalletAPI } from './WalletAPI';
+import { logger, LogCategory } from './logger';
 
 class WebLogger {
   log = (logEntry: LogEntry) => {
@@ -41,7 +42,7 @@ class WebLogger {
 }
 // Private SDK instance - not exposed outside this module
 let sdk: BreezSdk | null = null;
-let logger: WebLogger | null = null;
+let sdkLogger: WebLogger | null = null;
 // In-memory log buffer (ring buffer)
 const MAX_LOG_LINES = 100000;
 const sdkLogs: string[] = [];
@@ -56,19 +57,22 @@ function appendLog(line: string) {
 export const initWallet = async (mnemonic: string, config: Config): Promise<void> => {
   // If already connected, do nothing
   if (sdk) {
-    console.warn('initWallet called but SDK is already initialized; skipping');
+    logger.warn(LogCategory.SDK, 'initWallet called but SDK is already initialized; skipping');
     return;
   }
 
   try {
-    if (!logger) {
-      logger = new WebLogger();
-      initLogging(logger);
+    if (!sdkLogger) {
+      sdkLogger = new WebLogger();
+      initLogging(sdkLogger);
     }
     sdk = await connect({ config, seed: { type: "mnemonic", mnemonic }, storageDir: "spark-wallet-example" });
-    console.log('Wallet initialized successfully');
+    logger.sdkInitialized();
+    logger.authSuccess('mnemonic');
   } catch (error) {
-    console.error('Failed to initialize wallet:', error);
+    const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+    logger.sdkError('initWallet', errorMsg);
+    logger.authFailure('mnemonic', errorMsg);
     throw error;
   }
 };
@@ -176,10 +180,10 @@ export const addEventListener = async (
 
     // Add event listener to SDK and return its ID
     const listenerId = await sdk.addEventListener(listener);
-    console.log('Event listener added with ID:', listenerId);
+    logger.debug(LogCategory.SDK, 'Event listener added', { listenerId });
     return listenerId;
   } catch (error) {
-    console.error('Failed to add event listener:', error);
+    logger.sdkError('addEventListener', error instanceof Error ? error.message : 'Unknown error');
     throw error;
   }
 };
@@ -192,9 +196,9 @@ export const removeEventListener = async (listenerId: string): Promise<void> => 
 
   try {
     await sdk.removeEventListener(listenerId);
-    console.log('Event listener removed:', listenerId);
+    logger.debug(LogCategory.SDK, 'Event listener removed', { listenerId });
   } catch (error) {
-    console.error(`Failed to remove event listener ${listenerId}:`, error);
+    logger.sdkError('removeEventListener', error instanceof Error ? error.message : 'Unknown error');
     throw error;
   }
 };
@@ -208,7 +212,7 @@ export const getWalletInfo = async (): Promise<GetInfoResponse | null> => {
     const request: GetInfoRequest = {};
     return await sdk.getInfo(request);
   } catch (error) {
-    console.error('Failed to get wallet info:', error);
+    logger.sdkError('getWalletInfo', error instanceof Error ? error.message : 'Unknown error');
     throw error;
   }
 };
@@ -226,7 +230,7 @@ export const getTransactions = async (): Promise<Payment[]> => {
     const response: ListPaymentsResponse = await sdk.listPayments(request);
     return response.payments;
   } catch (error) {
-    console.error('Failed to get transactions:', error);
+    logger.sdkError('getTransactions', error instanceof Error ? error.message : 'Unknown error');
     throw error;
   }
 };
@@ -237,9 +241,9 @@ export const disconnect = async (): Promise<void> => {
       // Disconnect SDK (this will clean up all listeners registered with it)
       await sdk.disconnect();
       sdk = null;
-      // Remove reference to window.sdk
+      logger.sessionEnd('disconnect');
     } catch (error) {
-      console.error('Failed to disconnect wallet:', error);
+      logger.sdkError('disconnect', error instanceof Error ? error.message : 'Unknown error');
       throw error;
     }
   }
@@ -272,7 +276,7 @@ export const getLightningAddress = async (): Promise<breezSdk.LightningAddressIn
     const result = await sdk.getLightningAddress();
     return result ?? null;
   } catch (error) {
-    console.error('Failed to get lightning address:', error);
+    logger.sdkError('getLightningAddress', error instanceof Error ? error.message : 'Unknown error');
     return null;
   }
 };
@@ -282,7 +286,7 @@ export const checkLightningAddressAvailable = async (username: string): Promise<
   try {
     return await sdk.checkLightningAddressAvailable({ username });
   } catch (error) {
-    console.error('Failed to check lightning address availability:', error);
+    logger.sdkError('checkLightningAddressAvailable', error instanceof Error ? error.message : 'Unknown error');
     throw error;
   }
 };
@@ -291,8 +295,9 @@ export const registerLightningAddress = async (username: string, description: st
   if (!sdk) throw new Error('SDK not initialized');
   try {
     await sdk.registerLightningAddress({ username, description });
+    logger.info(LogCategory.SDK, 'Lightning address registered');
   } catch (error) {
-    console.error('Failed to register lightning address:', error);
+    logger.sdkError('registerLightningAddress', error instanceof Error ? error.message : 'Unknown error');
     throw error;
   }
 };
@@ -301,8 +306,9 @@ export const deleteLightningAddress = async (): Promise<void> => {
   if (!sdk) throw new Error('SDK not initialized');
   try {
     await sdk.deleteLightningAddress();
+    logger.info(LogCategory.SDK, 'Lightning address deleted');
   } catch (error) {
-    console.error('Failed to delete lightning address:', error);
+    logger.sdkError('deleteLightningAddress', error instanceof Error ? error.message : 'Unknown error');
     throw error;
   }
 };
@@ -351,4 +357,5 @@ export const walletApi: WalletAPI = {
   listFiatRates,
   // Logs
   getSdkLogs,
+  getAppLogs: () => logger.getLogsAsString(),
 };

--- a/src/test/mocks/mockWalletApi.ts
+++ b/src/test/mocks/mockWalletApi.ts
@@ -237,6 +237,7 @@ export function createMockWalletApi(overrides?: Partial<WalletAPI>): WalletAPI {
 
     // Logs
     getSdkLogs: vi.fn().mockReturnValue(''),
+    getAppLogs: vi.fn().mockReturnValue(''),
   };
 
   return { ...defaultMock, ...overrides };


### PR DESCRIPTION
## Summary

This PR addresses 6 open issues:

### Bottom Sheet Fixes
- **#68**: Fix gesture conflict between sheet drag and content scroll when full-screen
  - Skip body drag capture in full-screen mode to allow scrolling
- **#71**: Fix bottom sheet content not visible when typing
  - Add `useKeyboardHeight` hook using Visual Viewport API
  - Adjust sheet height when keyboard appears
- **#69**: Fix nested bottom sheet styling breaks on PWAs
  - Add `BottomSheetContext` to track parent sheet state
  - Force backdrop and proper z-index for nested sheets in full-screen parent

### UI Fixes
- **#70**: Fix misaligned bottom bar buttons
  - Add `min-width: 7em` to Send/Receive buttons for equal width

### Infrastructure
- **#49**: Add structured logging service
  - New `src/services/logger.ts` with DEBUG, INFO, WARN, ERROR levels
  - Categories: AUTH, PAYMENT, SDK, UI, SESSION, VALIDATION
  - In-memory ring buffer (1000 entries) for export/debugging
  - Automatic sensitive data redaction (mnemonic, keys, etc.)
  - OWASP-compliant security event helpers
  - Integrated into walletService and SendPaymentDialog
  - Added logging practices to CLAUDE.md

### Feature Prep
- **#14**: Drain funds support (partial)
  - Added "Send All" button UI in AmountStep
  - Full drain requires SDK update with PayAmount type
  - Shows placeholder error until SDK supports `{ type: 'drain' }`

## Test plan

### Bottom Sheet Tests
1. Open sheet with form input
2. Focus input field (keyboard appears)
3. Verify sheet content remains visible above keyboard
4. Expand sheet to full-screen
5. Scroll content - verify no sheet collapse
6. Drag handle - verify sheet collapses
7. Open nested sheet (e.g., AmountPanel) - verify styling intact

### Button Alignment Test
1. Open wallet page
2. Verify Send and Receive buttons have equal width

### Logger Tests
- All 13 logger tests pass ✓

### Drain Test
1. Enter destination address
2. Click "Send All"
3. Verify error message about SDK update requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)