### PR TITLE
fix: bottom sheet gesture, keyboard, and nested styling issues

### DIFF
--- a/src/hooks/useKeyboardHeight.ts
+++ b/src/hooks/useKeyboardHeight.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook to detect virtual keyboard height using the Visual Viewport API.
+ * Returns the keyboard height in pixels when visible, 0 otherwise.
+ *
+ * Used by bottom sheets to adjust their position when keyboard appears (#71).
+ */
+export function useKeyboardHeight(): number {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const handleResize = () => {
+      // Calculate keyboard height as difference between window and viewport
+      const kbHeight = window.innerHeight - viewport.height;
+      // Use threshold to filter out minor viewport changes (e.g., address bar)
+      setKeyboardHeight(kbHeight > 100 ? kbHeight : 0);
+    };
+
+    viewport.addEventListener('resize', handleResize);
+    viewport.addEventListener('scroll', handleResize);
+
+    return () => {
+      viewport.removeEventListener('resize', handleResize);
+      viewport.removeEventListener('scroll', handleResize);
+    };
+  }, []);
+
+  return keyboardHeight;
+}


### PR DESCRIPTION
## Summary

Fixes three related bottom sheet issues:

### #68: Gesture conflict between sheet drag and content scroll
- Skip body drag capture when `isFullScreen` is true
- Allows content scrolling in full-screen mode while handle still works

### #71: Bottom sheet content not visible when typing
- New `useKeyboardHeight` hook using Visual Viewport API
- Detects keyboard height and adjusts sheet's available height
- Content stays visible above the keyboard

### #69: Nested bottom sheet styling breaks on PWAs
- Add `BottomSheetContext` to track parent sheet state
- Force backdrop and higher z-index for nested sheets in full-screen parent
- Preserve rounded corners on nested sheets

## Test plan

1. Open sheet with form input (e.g., Send dialog)
2. Focus input field - verify keyboard doesn't cover content
3. Expand sheet to full-screen
4. Try scrolling content - should scroll, not collapse sheet
5. Drag handle - should still collapse/dismiss sheet
6. Open Receive → Create Invoice (nested sheet)
7. Verify nested sheet has proper styling and backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)