### PR TITLE
feat: add drain support (send all funds)

### DIFF
--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -134,6 +134,30 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
     setAmount(String(amountNum));
     await prepareSendPayment(paymentInput?.rawInput || '', amountNum);
   };
+
+  // Drain handler: send entire wallet balance
+  const onDrain = async () => {
+    if (!paymentInput?.rawInput) {
+      setError('Please enter a payment destination first');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await wallet.prepareSendPayment({
+        paymentRequest: paymentInput.rawInput,
+        payAmount: { type: 'drain' }
+      });
+      setPrepareResponse(response);
+      setCurrentStep('workflow');
+    } catch (err) {
+      console.error('Failed to prepare drain payment:', err);
+      setError(`Failed to prepare drain: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   // Get payment method display name
   const getPaymentMethodName = (): string => {
     if (!paymentInput) return '';
@@ -241,6 +265,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
             error={error}
             onBack={() => setCurrentStep('input')}
             onNext={onAmountNext}
+            onDrain={onDrain}
           />
         )}
 

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -8,6 +8,7 @@ export interface AmountStepProps {
   error: string | null;
   onBack: () => void;
   onNext: (amountSats: number) => void;
+  onDrain?: () => void;
 }
 
 const AmountStep: React.FC<AmountStepProps> = ({
@@ -17,6 +18,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
   error,
   onBack,
   onNext,
+  onDrain,
 }) => {
   const [localAmount, setLocalAmount] = useState<string>(amount || '');
 
@@ -71,6 +73,18 @@ const AmountStep: React.FC<AmountStepProps> = ({
             </button>
           ))}
         </div>
+
+        {/* Send All button (drain) */}
+        {onDrain && (
+          <button
+            onClick={onDrain}
+            disabled={isLoading}
+            className="w-full mt-3 py-2 rounded-lg text-sm font-medium transition-all bg-transparent border border-spark-warning text-spark-warning hover:bg-spark-warning/10 disabled:opacity-50"
+            data-testid="send-all-button"
+          >
+            Send All (Drain Wallet)
+          </button>
+        )}
       </div>
 
       <FormError error={error} />


### PR DESCRIPTION
## Summary

Adds ability to drain wallet (send all funds) to a destination address.

Fixes #14

## Changes

- `src/features/send/steps/AmountStep.tsx`: Added `onDrain` callback and "Send All (Drain Wallet)" button
- `src/features/send/SendPaymentDialog.tsx`: Added drain handler using `payAmount: { type: 'drain' }`

## Dependencies

This PR requires:
- SDK with `PayAmount` union type support (includes PR #41 changes)
- Not yet available in npm release

## Status

**DRAFT** - TypeScript errors expected until SDK is updated with PayAmount support.

## Test plan

1. Link local SDK with PayAmount support
2. Enter destination address (BTC or Spark)
3. Click "Send All (Drain Wallet)" button
4. Verify confirmation shows full wallet balance
5. Confirm and verify all funds are sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)