### PR TITLE
fix: Prevent autofill bar on all Receive input fields

### DIFF
--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -58,14 +58,22 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
             <label className="block text-spark-text-secondary text-sm font-medium mb-2">Amount</label>
             <div className="flex items-center bg-spark-dark border border-spark-border rounded-xl overflow-hidden focus-within:border-spark-primary focus-within:ring-2 focus-within:ring-spark-primary/20 transition-all">
               <input
-                type="number"
+                type="text"
+                inputMode="decimal"
+                pattern="[0-9]*"
                 min={limits.min}
                 max={limits.max}
                 value={amount}
-                onChange={(e) => setAmount(e.target.value)}
+                onChange={(e) => setAmount(e.target.value.replace(/[^0-9]/g, ''))}
                 placeholder="0"
                 disabled={isLoading}
-                className="flex-1 bg-transparent px-4 py-3 text-spark-text-primary text-lg font-mono placeholder-spark-text-muted focus:outline-none"
+                className="flex-1 bg-transparent px-4 py-3 text-spark-text-primary text-lg font-mono placeholder-spark-text-muted focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                autoComplete="off"
+                autoCorrect="off"
+                spellCheck={false}
+                data-form-type="other"
+                data-lpignore="true"
+                data-1p-ignore="true"
                 data-testid="invoice-amount-input"
               />
               <span className="px-4 py-3 text-spark-text-muted font-medium text-sm">sats</span>
@@ -98,11 +106,18 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
             <label className="block text-spark-text-secondary text-sm font-medium mb-2">Description (optional)</label>
             <input
               type="text"
+              inputMode="text"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What's this for?"
               disabled={isLoading}
               className="w-full bg-spark-dark border border-spark-border rounded-xl px-4 py-3 text-spark-text-primary placeholder-spark-text-muted focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20 focus:outline-none transition-all"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              data-form-type="other"
+              data-lpignore="true"
+              data-1p-ignore="true"
             />
           </div>
 


### PR DESCRIPTION
- Add anti-autofill attributes to all inputs in receive flow
- Use inputMode instead of type=number to avoid keyboard suggestions
- Add data attributes to ignore password managers (1Password, LastPass)
- Matches behavior of Send inputs which don't show autofill bar