### PR TITLE
fix: Persistent bottom gap after keyboard dismisses on iOS

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import {
   showPaymentReceivedNotification,
   showDepositClaimedNotification,
 } from './services/notificationService';
+import { useIOSViewportFix } from './hooks/useIOSViewportFix';
 
 // Main App without toast functionality
 const AppContent: React.FC = () => {
@@ -52,6 +53,9 @@ const AppContent: React.FC = () => {
   const [refundAnimationDirection, setRefundAnimationDirection] = useState<'left' | 'up'>('left');
 
   const { showToast } = useToast();
+
+  // Fix iOS Safari viewport bug where gap appears after keyboard dismisses
+  useIOSViewportFix();
 
   useEffect(() => {
     const lnurlEnabled = config?.lnurlDomain ? 'true' : 'false';

--- a/src/hooks/useIOSViewportFix.ts
+++ b/src/hooks/useIOSViewportFix.ts
@@ -1,0 +1,60 @@
+import { useEffect } from 'react';
+
+/**
+ * Hook to fix iOS Safari viewport bug where a gap appears at the bottom
+ * after the keyboard dismisses. This happens because iOS doesn't properly
+ * recalculate the viewport height after keyboard hide.
+ *
+ * The fix works by:
+ * 1. Listening to visualViewport resize events
+ * 2. When viewport height increases (keyboard hiding), forcing a layout recalculation
+ * 3. Using a small scroll trick to force Safari to recalculate the viewport
+ */
+export const useIOSViewportFix = (): void => {
+  useEffect(() => {
+    // Only apply on iOS
+    const isIOS = /iphone|ipad|ipod/i.test(navigator.userAgent);
+    if (!isIOS) return;
+
+    const visualViewport = window.visualViewport;
+    if (!visualViewport) return;
+
+    let previousHeight = visualViewport.height;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const handleResize = () => {
+      const currentHeight = visualViewport.height;
+
+      // Keyboard is hiding (viewport getting larger)
+      if (currentHeight > previousHeight) {
+        // Clear any pending timeout
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
+        // Delay to let iOS finish its animation
+        timeoutId = setTimeout(() => {
+          // Force layout recalculation by triggering a minimal scroll
+          // This tricks Safari into recalculating the viewport
+          window.scrollTo(0, window.scrollY);
+
+          // Also force a reflow on the document element
+          document.documentElement.style.height = '100%';
+          void document.documentElement.offsetHeight; // Force reflow
+          document.documentElement.style.height = '';
+        }, 100);
+      }
+
+      previousHeight = currentHeight;
+    };
+
+    visualViewport.addEventListener('resize', handleResize);
+
+    return () => {
+      visualViewport.removeEventListener('resize', handleResize);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, []);
+};

--- a/src/index.css
+++ b/src/index.css
@@ -51,9 +51,18 @@
 html,
 body,
 #root {
-  height: 100vh;
+  height: 100dvh;
+  height: 100vh; /* Fallback for browsers without dvh support */
   min-height: -webkit-fill-available;
   overflow: hidden;
+}
+
+@supports (height: 100dvh) {
+  html,
+  body,
+  #root {
+    height: 100dvh;
+  }
 }
 
 body {
@@ -74,7 +83,7 @@ body {
    ============================================ */
 
 .main-wrapper {
-  height: 100vh;
+  height: 100dvh;
   background:
     radial-gradient(ellipse 80% 50% at 50% -20%, rgba(139, 92, 246, 0.15), transparent),
     radial-gradient(ellipse 60% 40% at 100% 0%, rgba(247, 147, 26, 0.08), transparent),
@@ -778,7 +787,7 @@ select {
 .app-shell {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100dvh;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- Fix iOS Safari viewport bug where a gap appears at the bottom after the keyboard dismisses
- Use dynamic viewport height (`dvh`) instead of `vh` for responsive viewport sizing
- Add `useIOSViewportFix` hook that forces layout recalculation when keyboard hides

## Screenshot
<img width="50%" height="2081" alt="image" src="https://github.com/user-attachments/assets/bc7dda24-11a0-4f72-8da1-6f3c5f17383b" />

## Test plan
- [x] Open the app on iOS Safari (or iOS PWA)
- [x] Open a bottom sheet with an input field (e.g., Send or Receive)
- [x] Tap the input field to bring up the keyboard
- [x] Dismiss the keyboard by tapping outside or pressing "Done"
- [x] Verify no persistent gap appears at the bottom
- [x] Navigate to home page and verify no gap remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)