### PR TITLE
fix: iOS scroll issues on PageLayout and SlideInPage

### DIFF
--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -17,10 +17,10 @@ const PageLayout: React.FC<PageLayoutProps> = ({
   showHeader = true,
 }) => {
   return (
-    <div className="h-full w-full flex flex-col bg-spark-surface relative overflow-hidden">
+    <div className="min-h-dvh h-dvh w-full flex flex-col bg-spark-surface relative">
       {showHeader && (
         <header
-          className="relative z-10 border-b border-spark-border bg-spark-surface/80 backdrop-blur-sm"
+          className="relative z-10 flex-shrink-0 border-b border-spark-border bg-spark-surface/80 backdrop-blur-sm"
           style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
         >
           <div className="relative px-4 py-4 flex items-center justify-center">
@@ -42,19 +42,23 @@ const PageLayout: React.FC<PageLayoutProps> = ({
         </header>
       )}
 
-      <main className="relative z-10 flex items-center flex-col w-full mx-auto flex-grow overflow-hidden">
-        <div className="flex-1 w-full overflow-y-auto p-4">
-          {children}
-        </div>
-        <div
-          className="flex-shrink-0 w-full border-t border-spark-border bg-spark-surface/80 backdrop-blur-sm"
-          style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
-        >
-          <div className="px-4 py-4">
-            {footer}
-          </div>
-        </div>
+      {/* Scrollable content area */}
+      <main 
+        className="relative z-10 flex-1 w-full overflow-y-auto p-4"
+        style={{ WebkitOverflowScrolling: 'touch' }}
+      >
+        {children}
       </main>
+
+      {/* Fixed footer */}
+      <footer
+        className="relative z-10 flex-shrink-0 w-full border-t border-spark-border bg-spark-surface/80 backdrop-blur-sm"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      >
+        <div className="px-4 py-4">
+          {footer}
+        </div>
+      </footer>
     </div>
   );
 };

--- a/src/components/layout/SlideInPage.tsx
+++ b/src/components/layout/SlideInPage.tsx
@@ -49,7 +49,7 @@ const SlideInPage: React.FC<SlideInPageProps> = ({
   const { from, to } = slideTransforms[slideFrom];
 
   return (
-    <div className="h-full w-full flex flex-col bg-spark-surface relative overflow-hidden">
+    <div className="min-h-dvh h-dvh w-full flex flex-col bg-spark-surface relative">
       <Transition show={isOpen} appear as="div" className="absolute inset-0">
         <Transition.Child
           as="div"
@@ -92,7 +92,10 @@ const SlideInPage: React.FC<SlideInPageProps> = ({
           </header>
 
           {/* Scrollable content */}
-          <div className="flex-1 overflow-y-auto min-h-0">
+          <div 
+            className="flex-1 overflow-y-auto min-h-0"
+            style={{ WebkitOverflowScrolling: 'touch' }}
+          >
             {children}
           </div>
 


### PR DESCRIPTION
## Summary
- Use dvh (dynamic viewport height) instead of h-full for iOS Safari
- Remove overflow-hidden from containers that blocked scroll
- Add -webkit-overflow-scrolling: touch for iOS momentum scrolling

## Affected screens
- GeneratePage (seed phrase) - button was hidden
- RestorePage
- BackupPage
- SettingsPage
- FiatCurrenciesPage
- GetRefundPage

## Root cause
The h-full class relies on parent containers having explicit heights, which breaks on iOS Safari with its dynamic address bar. Using dvh ensures the viewport height is calculated correctly.