### PR TITLE
chore: update @breeztech/breez-sdk-spark to 0.7.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "wasm-example-app",
       "version": "0.1.0",
       "dependencies": {
-        "@breeztech/breez-sdk-spark": "^0.7.10",
+        "@breeztech/breez-sdk-spark": "^0.7.17",
         "@headlessui/react": "^1.7.17",
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@breeztech/breez-sdk-spark": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.7.14.tgz",
-      "integrity": "sha512-5yGh77GLaZGk4sN2VXmCn4H0usH440dCq4EO/gFXnLH5pDOZQ6VcKNT585yzBQtcIqlJQVjUoof8nNXwU1NWpA==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.7.17.tgz",
+      "integrity": "sha512-nv70QeiLIaTmnpHDR+a5YZ40PjicW/13elCIoRFV3v6IH+2h40dFQoubRyd99NuCloJhkpb6tIZ7fsSrHh0Qtg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
-    "@breeztech/breez-sdk-spark": "^0.7.10",
+    "@breeztech/breez-sdk-spark": "^0.7.17",
     "@headlessui/react": "^1.7.17",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",


### PR DESCRIPTION
## Summary
- Bump `@breeztech/breez-sdk-spark` from `^0.7.10` to `^0.7.17`
- Includes SDK bug fixes: static deposit refunds, missing connector tx on coop exit
- Performance improvements: greedy leaf selection algorithm, lock-free tree store
- Type check passes cleanly (`npx tsc --noEmit`)

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run dev` loads without errors
- [ ] Wallet connects and syncs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)