### PR TITLE
fix: use MaxFee type for deposit claims

### DIFF
--- a/src/pages/UnclaimedDepositDetailsPage.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useWallet } from '../contexts/WalletContext';
-import type { DepositInfo, Fee } from '@breeztech/breez-sdk-spark';
+import type { DepositInfo, MaxFee } from '@breeztech/breez-sdk-spark';
 import { BottomSheetContainer, BottomSheetCard, DialogHeader, PrimaryButton, SecondaryButton, PaymentInfoCard, CollapsibleCodeField } from '../components/ui';
 import { FeeBreakdownCard } from '../components/FeeBreakdownCard';
 import { SpinnerIcon, WarningIcon } from '../components/Icons';
@@ -29,19 +29,19 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
   useEffect(() => {
     if (!deposit) return;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK deposit type doesn't expose claimError
-    const depositAny = deposit as any;
-    const claimErrorData = depositAny.claimError;
+    const claimErrorData = deposit.claimError;
 
     if (claimErrorData) {
       if (claimErrorData.type === 'maxDepositClaimFeeExceeded') {
         // Fee exceeded - show required fee for user approval
         setRequiredFeeSats(claimErrorData.requiredFeeSats || 0);
         setClaimError(null);
+      } else if (claimErrorData.type === 'generic') {
+        setClaimError(claimErrorData.message || 'Automatic claim failed');
+        setRequiredFeeSats(null);
       } else {
-        // Other error - can only reject
-        const errorMsg = claimErrorData.message || claimErrorData.error || 'Automatic claim failed';
-        setClaimError(errorMsg);
+        // missingUtxo or other error - can only reject
+        setClaimError('Automatic claim failed');
         setRequiredFeeSats(null);
       }
     } else {
@@ -56,8 +56,8 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
     setClaimError(null);
     setIsProcessing(true);
     try {
-      const fee: Fee = { type: 'fixed', amount: requiredFeeSats };
-      await wallet.claimDeposit(deposit.txid, deposit.vout, fee);
+      const maxFee: MaxFee = { type: 'fixed', amount: requiredFeeSats };
+      await wallet.claimDeposit(deposit.txid, deposit.vout, maxFee);
       // Remove from rejected list if it was there
       removeRejectedDeposit(deposit.txid, deposit.vout);
       onChanged?.();

--- a/src/services/WalletAPI.ts
+++ b/src/services/WalletAPI.ts
@@ -17,6 +17,8 @@ import type {
   LnurlPayResponse,
   DepositInfo,
   Fee,
+  MaxFee,
+  ClaimDepositResponse,
   UserSettings,
   UpdateUserSettingsRequest,
   FiatCurrency,
@@ -37,7 +39,7 @@ export interface WalletAPI {
   sendPayment: (params: SendPaymentRequest) => Promise<SendPaymentResponse>;
   receivePayment: (params: ReceivePaymentRequest) => Promise<ReceivePaymentResponse>;
   unclaimedDeposits: () => Promise<DepositInfo[]>;
-  claimDeposit: (txid: string, vout: number, maxFee: Fee) => Promise<void>;
+  claimDeposit: (txid: string, vout: number, maxFee?: MaxFee) => Promise<ClaimDepositResponse>;
   refundDeposit: (txid: string, vout: number, destinationAddress: string, fee: Fee) => Promise<void>;
 
   // Data

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -24,6 +24,8 @@ import {
   LnurlPayResponse,
   DepositInfo,
   Fee,
+  MaxFee,
+  ClaimDepositResponse,
   UserSettings,
   UpdateUserSettingsRequest,
   FiatCurrency,
@@ -121,9 +123,9 @@ export const unclaimedDeposits = async (): Promise<DepositInfo[]> => {
   return (await sdk.listUnclaimedDeposits({})).deposits;
 };
 
-export const claimDeposit = async (txid: string, vout: number, maxFee: Fee): Promise<void> => {
+export const claimDeposit = async (txid: string, vout: number, maxFee?: MaxFee): Promise<ClaimDepositResponse> => {
   if (!sdk) throw new Error('SDK not initialized');
-  await sdk.claimDeposit({ txid, vout, maxFee });
+  return await sdk.claimDeposit({ txid, vout, maxFee });
 };
 
 export const refundDeposit = async (txid: string, vout: number, destinationAddress: string, fee: Fee): Promise<void> => {

--- a/src/test/mocks/mockWalletApi.ts
+++ b/src/test/mocks/mockWalletApi.ts
@@ -182,7 +182,7 @@ export function createMockWalletApi(overrides?: Partial<WalletAPI>): WalletAPI {
 
     // Unclaimed deposits
     unclaimedDeposits: vi.fn().mockResolvedValue([] as DepositInfo[]),
-    claimDeposit: vi.fn().mockResolvedValue(undefined),
+    claimDeposit: vi.fn().mockResolvedValue({ payment: createMockPayment('receive') }),
     refundDeposit: vi.fn().mockResolvedValue(undefined),
 
     // Data


### PR DESCRIPTION
## Summary
- Update `claimDeposit` to use SDK's `MaxFee` type (supports `fixed`, `rate`, and `networkRecommended` variants) instead of the simpler `Fee` type
- Remove `as any` cast on `deposit.claimError` — SDK 0.7.17 properly types `DepositClaimError` with discriminated union (`maxDepositClaimFeeExceeded | missingUtxo | generic`)
- Return `ClaimDepositResponse` (contains `payment`) instead of `void`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Deposit claim flow works with fee-exceeded deposits
- [x] Deposit error states display correctly for `generic` and `missingUtxo` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)