### PR TITLE
feat: instant wallet load with background sync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ const AppContent: React.FC = () => {
 
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [isRestoring, setIsRestoring] = useState<boolean>(false);
+  const [isSyncing, setIsSyncing] = useState<boolean>(false);
 
   // Track if this is the initial app load (splash screen handles this)
   const isInitialLoadRef = useRef<boolean>(true);
@@ -124,6 +124,18 @@ const AppContent: React.FC = () => {
   }, [wallet]);
 
 
+  // Manual refresh: user-triggered sync + data reload
+  const handleManualRefresh = useCallback(async () => {
+    if (!isConnected) return;
+    try {
+      await wallet.syncWallet();
+      await refreshWalletData(false);
+      await fetchUnclaimedDeposits();
+    } catch (err) {
+      logger.warn(LogCategory.SDK, 'Manual refresh failed', { error: formatError(err) });
+    }
+  }, [isConnected, wallet, refreshWalletData, fetchUnclaimedDeposits]);
+
   // SDK event handler with toast notifications and auto-close of receive dialog
   const handleSdkEvent = useCallback((event: SdkEvent) => {
     logger.debug(LogCategory.SDK, 'SDK event received', {
@@ -133,10 +145,10 @@ const AppContent: React.FC = () => {
     if (event.type === 'synced') {
       logger.debug(LogCategory.SDK, 'Synced event received; refreshing data');
 
-      // If this is the first sync event after connecting, mark restoration as complete
-      if (isRestoring) {
-        logger.info(LogCategory.SESSION, 'Restoration sync complete; hiding overlay');
-        setIsRestoring(false);
+      // If this is the first sync event after connecting, mark syncing as complete
+      if (isSyncing) {
+        logger.info(LogCategory.SESSION, 'Initial sync complete');
+        setIsSyncing(false);
       }
 
       // Set sync indicator for e2e tests
@@ -206,7 +218,7 @@ const AppContent: React.FC = () => {
       // Refresh the list as some may remain unclaimed
       fetchUnclaimedDeposits();
     }
-  }, [refreshWalletData, showToast, isRestoring, fetchUnclaimedDeposits]);
+  }, [refreshWalletData, showToast, isSyncing, fetchUnclaimedDeposits]);
 
   // Fetch fiat rates from SDK
   const fetchFiatData = useCallback(async () => {
@@ -259,7 +271,6 @@ const AppContent: React.FC = () => {
           setIsLoading(true);
           await connectWallet(savedMnemonic, false);
           logger.info(LogCategory.SDK, 'Connected to wallet with saved mnemonic');
-          setCurrentScreen('wallet'); // Navigate to wallet screen
         } catch (error) {
           logger.error(LogCategory.SDK, 'Failed to connect with saved mnemonic', {
             error: formatError(error),
@@ -335,7 +346,7 @@ const AppContent: React.FC = () => {
       logger.debug(LogCategory.SDK, 'Starting wallet connection workflow', {
         restore,
       });
-      setIsRestoring(restore); // Mark that we're restoring data      
+      setIsSyncing(true); // Mark that we're syncing data
       setError(null);
 
       // Initialize wallet with mnemonic
@@ -383,28 +394,29 @@ const AppContent: React.FC = () => {
       // Save mnemonic for future use
       wallet.saveMnemonic(mnemonic);
 
-      // Get wallet info and transactions in parallel (async-parallel optimization)
-      const [info, txns] = await Promise.all([
-        wallet.getWalletInfo(),
-        wallet.getTransactions(),
-      ]);
-
+      // Quick local-state read (fast, reads cached data)
+      const info = await wallet.getWalletInfo();
       setWalletInfo(info);
-      setTransactions(txns);
 
+      // Navigate to wallet immediately — don't block on transactions/deposits
       setIsConnected(true);
-      // Fetch unclaimed deposits indicator after connect
-      await fetchUnclaimedDeposits();
-      setCurrentScreen('wallet'); // Navigate to wallet screen
-      // We'll keep isLoading true until first sync for new wallets
+      setCurrentScreen('wallet');
       setIsLoading(false);
+
+      // Background: fetch transactions and deposits (don't block UI)
+      wallet.getTransactions()
+        .then(txns => setTransactions(txns))
+        .catch(err => logger.warn(LogCategory.SDK, 'Background transaction fetch failed', { error: formatError(err) }));
+
+      fetchUnclaimedDeposits()
+        .catch(err => logger.warn(LogCategory.SDK, 'Background deposit fetch failed', { error: formatError(err) }));
 
     } catch (error) {
       logger.error(LogCategory.SDK, 'Error connecting wallet', {
         error: formatError(error),
       });
       setError('Failed to connect wallet. Please check your mnemonic and try again.');
-      setIsRestoring(false);
+      setIsSyncing(false);
       setIsLoading(false);
       setConfig(null);
     }
@@ -534,7 +546,8 @@ const AppContent: React.FC = () => {
             fiatRates={fiatRates}
             fiatCurrencies={fiatCurrencies}
             refreshWalletData={refreshWalletData}
-            isRestoring={isRestoring}
+            isSyncing={isSyncing}
+            onManualRefresh={handleManualRefresh}
             error={error}
             onClearError={clearError}
             onLogout={handleLogout}

--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -12,6 +12,8 @@ interface CollapsingWalletHeaderProps {
   onOpenMenu: () => void;
   hasUnclaimedDeposits: boolean;
   onOpenGetRefund: () => void;
+  isSyncing?: boolean;
+  onManualRefresh?: () => Promise<void>;
 }
 
 const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
@@ -21,9 +23,22 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
   fiatCurrencies,
   onOpenMenu,
   hasUnclaimedDeposits,
-  onOpenGetRefund
+  onOpenGetRefund,
+  isSyncing = false,
+  onManualRefresh,
 }) => {
   const [activeFiatIndex, setActiveFiatIndex] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(async () => {
+    if (!onManualRefresh || isRefreshing) return;
+    setIsRefreshing(true);
+    try {
+      await onManualRefresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [onManualRefresh, isRefreshing]);
 
   // Build lookup maps for O(1) access (js-index-maps optimization)
   const ratesMap = useMemo(() => {
@@ -174,6 +189,20 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
 
           {/* Action buttons */}
           <div className="flex items-center gap-3">
+            {/* Manual refresh button (hidden while syncing) */}
+            {onManualRefresh && !isSyncing && (
+              <button
+                type="button"
+                className="flex items-center justify-center w-9 h-9 rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+                title="Refresh wallet data"
+                aria-label="Refresh wallet data"
+                onClick={handleRefresh}
+              >
+                <svg className={`w-5 h-5 ${isRefreshing ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              </button>
+            )}
             {/* Rejected deposits warning */}
             {hasUnclaimedDeposits && (
               <button
@@ -195,7 +224,14 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
         <div className="text-center">
           {/* Label */}
           <div className="text-spark-text-muted text-xs font-display font-medium tracking-widest uppercase mb-1">
-            Balance<span className="text-spark-text-muted/50 mx-1.5">·</span><span className="text-spark-text-muted/50">sats</span>
+            {isSyncing ? (
+              <span className="inline-flex items-center gap-1.5">
+                <span className="w-1.5 h-1.5 rounded-full bg-spark-primary animate-pulse" />
+                Syncing
+              </span>
+            ) : (
+              <>Balance<span className="text-spark-text-muted/50 mx-1.5">·</span><span className="text-spark-text-muted/50">sats</span></>
+            )}
           </div>
 
           {/* Main balance */}

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -1,8 +1,5 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { useWallet } from '../contexts/WalletContext';
-import {
-  LoadingSpinner
-} from '../components/ui';
 import { logger, LogCategory } from '@/services/logger';
 import CollapsingWalletHeader from '../components/CollapsingWalletHeader';
 import SideMenu from '../components/SideMenu';
@@ -23,7 +20,8 @@ interface WalletPageProps {
   fiatRates: Rate[];
   fiatCurrencies: FiatCurrency[];
   refreshWalletData: (showLoading?: boolean) => Promise<void>;
-  isRestoring: boolean;
+  isSyncing: boolean;
+  onManualRefresh?: () => Promise<void>;
   error: string | null;
   onClearError: () => void;
   onLogout: () => void;
@@ -41,7 +39,8 @@ const WalletPage: React.FC<WalletPageProps> = ({
   fiatRates,
   fiatCurrencies,
   refreshWalletData,
-  isRestoring,
+  isSyncing,
+  onManualRefresh,
   onLogout,
   hasUnclaimedDeposits,
   onOpenGetRefund,
@@ -166,13 +165,6 @@ const WalletPage: React.FC<WalletPageProps> = ({
         <div className="absolute bottom-1/4 right-0 w-[300px] h-[300px] bg-gradient-radial from-spark-primary/10 to-transparent blur-3xl" />
       </div>
 
-      {/* Restoration overlay */}
-      {isRestoring && (
-        <div className="absolute inset-0 bg-spark-void/90 backdrop-blur-sm z-50 flex items-center justify-center">
-          <LoadingSpinner text="Loading..." />
-        </div>
-      )}
-
       {/* Fixed header */}
       <div className="sticky top-0 z-10">
         <CollapsingWalletHeader
@@ -183,6 +175,8 @@ const WalletPage: React.FC<WalletPageProps> = ({
           onOpenMenu={() => setIsMenuOpen(true)}
           hasUnclaimedDeposits={hasUnclaimedDeposits}
           onOpenGetRefund={() => onOpenGetRefund('icon')}
+          isSyncing={isSyncing}
+          onManualRefresh={onManualRefresh}
         />
       </div>
 

--- a/src/services/WalletAPI.ts
+++ b/src/services/WalletAPI.ts
@@ -40,6 +40,9 @@ export interface WalletAPI {
   claimDeposit: (txid: string, vout: number, maxFee: Fee) => Promise<void>;
   refundDeposit: (txid: string, vout: number, destinationAddress: string, fee: Fee) => Promise<void>;
 
+  // Sync
+  syncWallet: () => Promise<void>;
+
   // Data
   getWalletInfo: () => Promise<GetInfoResponse | null>;
   getTransactions: () => Promise<Payment[]>;

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -309,6 +309,17 @@ export const removeEventListener = async (listenerId: string): Promise<void> => 
   }
 };
 
+export const syncWallet = async (): Promise<void> => {
+  if (!sdk) throw new Error('SDK not initialized');
+  try {
+    await sdk.syncWallet({});
+    logger.debug(LogCategory.SDK, 'Manual sync completed');
+  } catch (error) {
+    logger.sdkError('syncWallet', error instanceof Error ? error.message : 'Unknown error');
+    throw error;
+  }
+};
+
 export const getWalletInfo = async (): Promise<GetInfoResponse | null> => {
   if (!sdk) {
     return null;
@@ -436,6 +447,9 @@ export const walletApi: WalletAPI = {
   unclaimedDeposits,
   claimDeposit,
   refundDeposit,
+
+  // Sync
+  syncWallet,
 
   // Data
   getWalletInfo,

--- a/src/test/mocks/mockWalletApi.ts
+++ b/src/test/mocks/mockWalletApi.ts
@@ -180,6 +180,9 @@ export function createMockWalletApi(overrides?: Partial<WalletAPI>): WalletAPI {
       } as ReceivePaymentResponse;
     }),
 
+    // Sync
+    syncWallet: vi.fn().mockResolvedValue(undefined),
+
     // Unclaimed deposits
     unclaimedDeposits: vi.fn().mockResolvedValue([] as DepositInfo[]),
     claimDeposit: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
- Show wallet UI immediately after SDK init instead of blocking behind a full-screen "Loading..." overlay until the `synced` event (which can take minutes for wallets with lots of history)
- `getWalletInfo()` (fast local read) is awaited for initial balance; `getTransactions()` and `fetchUnclaimedDeposits()` run in the background
- Replace blocking overlay with a subtle "Syncing" indicator (pulsing dot + text) in the wallet header
- Add a manual refresh button in the header for user-triggered sync

## Changes
- **App.tsx**: Rename `isRestoring` → `isSyncing`, restructure `connectWallet` to be non-blocking, add `handleManualRefresh` callback using `syncWallet()`
- **WalletPage.tsx**: Remove full-screen restoration overlay, pass `isSyncing` and `onManualRefresh` to header
- **CollapsingWalletHeader.tsx**: Add syncing indicator (replaces "Balance · sats" label) and refresh button (with spin animation)
- **WalletAPI.ts / walletService.ts**: Add `syncWallet()` method
- **mockWalletApi.ts**: Add `syncWallet` mock

## Test plan
- [ ] Restore wallet with significant history → wallet UI appears immediately (may show 0 sats briefly) → balance updates within seconds
- [ ] "Syncing" indicator with pulsing dot shows while background sync runs
- [ ] Once `synced` event fires, indicator disappears and balance/transactions are up to date
- [ ] Manual refresh button appears after sync completes → tap → icon spins → data refreshes
- [ ] Fresh wallet creation still works normally
- [ ] Page refresh on connected wallet → loads instantly without blocking overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)