### PR TITLE
feat: Add Buy Bitcoin button to wallet header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,6 @@ import GetRefundPage from './pages/GetRefundPage';
 import BackupPage from './pages/BackupPage';
 import SettingsPage from './pages/SettingsPage';
 import FiatCurrenciesPage from './pages/FiatCurrenciesPage';
-import BuyBitcoinPage from './pages/BuyBitcoinPage';
 import { getSettings } from './services/settings';
 import { isDepositRejected } from './services/depositState';
 import {
@@ -32,7 +31,7 @@ import { useIOSViewportFix } from './hooks/useIOSViewportFix';
 const AppContent: React.FC = () => {
   const formatError = (err: unknown): string => (err instanceof Error ? err.message : String(err));
   // Screen navigation state
-  const [currentScreen, setCurrentScreen] = useState<'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyBitcoin'>('home');
+  const [currentScreen, setCurrentScreen] = useState<'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies'>('home');
 
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -448,6 +447,19 @@ const AppContent: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- wallet excluded to avoid re-creating on every render
   }, [isConnected, showToast]);
 
+  // Buy Bitcoin - call SDK and open MoonPay directly
+  const handleBuyBitcoin = useCallback(async () => {
+    try {
+      const response = await wallet.buyBitcoin({});
+      window.open(response.url, '_blank', 'noopener,noreferrer');
+    } catch (e) {
+      logger.error(LogCategory.SDK, 'Failed to open Buy Bitcoin', {
+        error: formatError(e),
+      });
+      showToast('error', 'Buy Bitcoin', 'Failed to open MoonPay. Please try again.');
+    }
+  }, [wallet, showToast]);
+
   // Navigation handlers
   const navigateToRestore = () => setCurrentScreen('restore');
   const navigateToGenerate = () => setCurrentScreen('generate');
@@ -506,11 +518,6 @@ const AppContent: React.FC = () => {
           <BackupPage onBack={() => setCurrentScreen('wallet')} />
         );
 
-      case 'buyBitcoin':
-        return (
-          <BuyBitcoinPage onBack={() => setCurrentScreen('wallet')} />
-        );
-
       case 'restore':
         return (
           <RestorePage
@@ -550,7 +557,7 @@ const AppContent: React.FC = () => {
             }}
             onOpenSettings={() => setCurrentScreen('settings')}
             onOpenBackup={() => setCurrentScreen('backup')}
-            onOpenBuyBitcoin={() => setCurrentScreen('buyBitcoin')}
+            onOpenBuyBitcoin={handleBuyBitcoin}
             onDepositChanged={fetchUnclaimedDeposits}
           />
         );

--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -10,8 +10,7 @@ interface CollapsingWalletHeaderProps {
   fiatCurrencies: FiatCurrency[];
   scrollProgress: number;
   onOpenMenu: () => void;
-  hasUnclaimedDeposits: boolean;
-  onOpenGetRefund: () => void;
+  onOpenBuyBitcoin?: () => void;
 }
 
 const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
@@ -20,8 +19,7 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
   fiatRates,
   fiatCurrencies,
   onOpenMenu,
-  hasUnclaimedDeposits,
-  onOpenGetRefund
+  onOpenBuyBitcoin
 }) => {
   const [activeFiatIndex, setActiveFiatIndex] = useState(0);
 
@@ -173,19 +171,18 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
           </button>
 
           {/* Action buttons */}
-          <div className="flex items-center gap-3">
-            {/* Rejected deposits warning */}
-            {hasUnclaimedDeposits && (
+          <div className="flex items-center gap-2">
+            {/* Buy Bitcoin */}
+            {onOpenBuyBitcoin && (
               <button
                 type="button"
-                className="flex items-center justify-center w-9 h-9 rounded-xl bg-spark-warning/15 text-spark-warning border border-spark-warning/30 hover:bg-spark-warning/25 transition-colors"
-                title="Rejected deposits need refund"
-                aria-label="Get refund for rejected deposits"
-                onClick={onOpenGetRefund}
+                className="flex items-center gap-1.5 h-9 px-3 rounded-xl text-spark-text-secondary hover:text-spark-text-primary border border-white/10 hover:border-white/20 hover:bg-white/5 transition-colors text-sm font-medium"
+                onClick={onOpenBuyBitcoin}
               >
-                <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.72-1.36 3.485 0l6.518 11.6c.75 1.336-.213 3.001-1.742 3.001H3.48c-1.53 0-2.492-1.665-1.742-3.001l6.52-11.6zM11 13a1 1 0 10-2 0 1 1 0 002 0zm-1-2a1 1 0 01-1-1V7a1 1 0 112 0v3a1 1 0 01-1 1z" clipRule="evenodd" />
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
+                <span>Buy</span>
               </button>
             )}
           </div>

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -20,11 +20,10 @@ interface SideMenuProps {
   onOpenSettings: () => void;
   onOpenBackup: () => void;
   onOpenRefund?: () => void;
-  onOpenBuyBitcoin?: () => void;
   hasRejectedDeposits?: boolean;
 }
 
-const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSettings, onOpenBackup, onOpenRefund, onOpenBuyBitcoin, hasRejectedDeposits = false }) => {
+const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSettings, onOpenBackup, onOpenRefund, hasRejectedDeposits = false }) => {
   const [leftOffset, setLeftOffset] = useState<number | null>(null);
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
   const [starsAnimating, setStarsAnimating] = useState(false);
@@ -77,16 +76,6 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
       label: 'Get Refund',
       onClick: () => { onOpenRefund(); onClose(); },
       highlight: true
-    }] : []),
-    // Buy Bitcoin
-    ...(onOpenBuyBitcoin ? [{
-      icon: (
-        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      ),
-      label: 'Buy Bitcoin',
-      onClick: () => { onOpenBuyBitcoin(); onClose(); }
     }] : []),
     {
       icon: (

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -183,8 +183,7 @@ const WalletPage: React.FC<WalletPageProps> = ({
           fiatCurrencies={fiatCurrencies}
           scrollProgress={scrollProgress}
           onOpenMenu={() => setIsMenuOpen(true)}
-          hasUnclaimedDeposits={hasUnclaimedDeposits}
-          onOpenGetRefund={() => onOpenGetRefund('icon')}
+          onOpenBuyBitcoin={onOpenBuyBitcoin}
         />
       </div>
 
@@ -291,7 +290,6 @@ const WalletPage: React.FC<WalletPageProps> = ({
         onOpenSettings={onOpenSettings}
         onOpenBackup={onOpenBackup}
         onOpenRefund={() => onOpenGetRefund('menu')}
-        onOpenBuyBitcoin={onOpenBuyBitcoin}
         hasRejectedDeposits={hasUnclaimedDeposits}
       />
     </div>


### PR DESCRIPTION
## Changes

- Add compact **[ $ Buy ]** button in the wallet header top-right corner
- Clicking calls \wallet.buyBitcoin()\ and opens MoonPay directly in a new tab (no intermediate screen)
- Remove the \BuyBitcoinPage\ intermediate screen
- Remove Buy Bitcoin from the sidebar menu
- Remove unclaimed deposits warning icon from the header

> **Note:** The SDK \uyBitcoin()\ method is pending [breez/spark-sdk#578]. Until merged, clicking Buy will show an error toast.