### PR TITLE
fix: support zero-amount bolt11 invoices

### DIFF
--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -138,7 +138,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
 
   // Common prepare for all input types
   const prepareSendPayment = async (paymentRequest: string, amountSats: number, feePolicy?: FeePolicy) => {
-    if (amountSats < 0) {
+    if (amountSats <= 0) {
       setError('Please enter a valid amount');
       return;
     }
@@ -161,7 +161,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
   };
 
   const onAmountNext = async (amountNum: number, includeFees?: boolean) => {
-    if (amountNum < 0) {
+    if (!amountNum || amountNum <= 0) {
       setError('Please enter a valid amount');
       return;
     }

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -27,7 +27,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
     setLocalAmount(amount || '');
   }, [amount]);
 
-  const validAmount = localAmount !== '' && parseInt(localAmount) >= 0;
+  const validAmount = localAmount !== '' && parseInt(localAmount) > 0;
   const amountNum = parseInt(localAmount) || 0;
 
   const isSendAll = balanceSats !== undefined && balanceSats > 0 && amountNum === balanceSats && feesIncluded;
@@ -56,7 +56,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
           placeholder="Enter amount in satoshis"
           className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           disabled={isLoading}
-          min={0}
+          min={1}
           data-testid="amount-input"
         />
         


### PR DESCRIPTION
## Summary

- Route zero-amount bolt11 invoices to the amount step so users can specify how much to pay (was incorrectly falling through to "Invalid payment destination")

## Test plan

- [ ] Paste a zero-amount bolt11 invoice → should route to amount entry screen
- [ ] Enter an amount > 0 and confirm → payment should proceed normally
- [ ] Paste a normal (fixed-amount) bolt11 invoice → should still skip amount step and go straight to confirm
- [ ] Paste a bitcoin/spark address → send-all and amount entry should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)