### PR TITLE
fix: keep bottom sheet above on-screen keyboard

### DIFF
--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -98,6 +98,8 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   // Body dismiss translateY
   const [bodyDragY, setBodyDragY] = useState(0);
   const [animating, setAnimating] = useState(false);
+  // Track visual viewport height to account for on-screen keyboard
+  const [viewportHeight, setViewportHeight] = useState(() => window.visualViewport?.height ?? window.innerHeight);
 
   const dragging = useRef(false);
   const startY = useRef(0);
@@ -106,9 +108,18 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   const wrapperRef = useRef<HTMLDivElement>(null);
   const contentHeight = useRef(0);
 
+  // Keep viewportHeight in sync with the visual viewport (shrinks when keyboard opens)
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const onResize = () => setViewportHeight(vv.height);
+    vv.addEventListener('resize', onResize);
+    return () => vv.removeEventListener('resize', onResize);
+  }, []);
+
   const maxPx = useCallback(() => {
-    return window.innerHeight * (maxHeightVh / 100);
-  }, [maxHeightVh]);
+    return viewportHeight * (maxHeightVh / 100);
+  }, [viewportHeight, maxHeightVh]);
 
   const getSnapPoints = useCallback((): number[] => {
     const content = contentHeight.current;
@@ -258,7 +269,8 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
     <Transition
       show={isOpen}
       as="div"
-      className="absolute inset-0 z-50 overflow-hidden flex flex-col justify-end pointer-events-none"
+      className="absolute inset-x-0 top-0 z-50 overflow-hidden flex flex-col justify-end pointer-events-none"
+      style={{ height: `${viewportHeight}px` }}
     >
       {showBackdrop && (
         <Transition.Child


### PR DESCRIPTION
## Summary

- Bottom sheet action buttons (e.g. Back/Continue) were hidden behind the on-screen keyboard when a text input was focused
- Fixed by subscribing to the [Visual Viewport API](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API) `resize` event, which fires when the keyboard opens/closes
- The sheet container now uses the visual viewport height instead of `window.innerHeight`, so it shrinks to the available space above the keyboard
- `maxPx()` also uses the visual viewport height, keeping snap point calculations correct

Affects all bottom sheets with text inputs: Send (amount/input/LNURL), Receive, Get Refund.

## Test plan

- [ ] Open Send dialog and focus the amount input → Back/Continue buttons should remain visible above the keyboard
- [ ] Open Receive dialog and focus the amount input → same
- [ ] Dismiss keyboard → sheet should return to normal size
- [ ] Drag-to-dismiss and snap gestures should still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)