### PR TITLE
fix: show error on restore with invalid mnemonic checksum

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -406,6 +406,7 @@ const AppContent: React.FC = () => {
       setIsRestoring(false);
       setIsLoading(false);
       setConfig(null);
+      throw error;
     }
   };
 

--- a/src/pages/RestorePage.tsx
+++ b/src/pages/RestorePage.tsx
@@ -4,7 +4,7 @@ import { PrimaryButton } from '../components/ui';
 import { SimpleAlert } from '../components/AlertCard';
 
 interface RestorePageProps {
-  onConnect: (mnemonic: string) => void;
+  onConnect: (mnemonic: string) => Promise<void>;
   onBack: () => void;
   onClearError: () => void;
 }
@@ -17,7 +17,7 @@ const RestorePage: React.FC<RestorePageProps> = ({
   const [mnemonic, setMnemonic] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const cleaned = mnemonic.trim().replace(/\s+/g, ' ');
     const wordCount = cleaned.split(' ').length;
 
@@ -27,7 +27,11 @@ const RestorePage: React.FC<RestorePageProps> = ({
     }
 
     setError(null);
-    onConnect(cleaned);
+    try {
+      await onConnect(cleaned);
+    } catch (err) {
+      setError('Invalid recovery phrase. Please check your words and try again.');
+    }
   };
 
   const footer = (


### PR DESCRIPTION
Fixes #101

## Root Cause

`RestorePage` only validated word count (12 or 24). A mnemonic with valid word count but invalid checksum (e.g. 11 correct words + 1 wrong last word) passed validation and was sent to `connectWallet()`, which threw on `wallet.initWallet()`. The error was caught and set in App-level state, but was never passed back to `RestorePage` — so the user saw nothing.

## Fix

- `connectWallet` now re-throws after handling the error internally, so callers can react to it
- `RestorePage.handleSubmit` is now `async` and wraps `onConnect` in a try/catch, setting its local `error` state with a user-friendly message on failure
- `onConnect` prop type updated to `Promise<void>`

## Test plan

- [ ] Enter a 12-word mnemonic with a wrong last word → should show "Invalid recovery phrase. Please check your words and try again."
- [ ] Enter a completely invalid mnemonic → same error
- [x] Enter a valid 12 or 24-word mnemonic → should restore successfully
- [x] Enter fewer than 12 words → should show the existing word count error

🤖 Generated with [Claude Code](https://claude.com/claude-code)