### PR TITLE
fix: show error on restore with invalid mnemonic checksum

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -475,7 +475,7 @@ const AppContent: React.FC = () => {
       return null;
     }
 
-    if (isLoading) {
+    if (isLoading && currentScreen !== 'restore') {
       return (
         <div className="absolute inset-0 bg-spark-void/95 backdrop-blur-sm z-50 flex items-center justify-center">
           <LoadingSpinner />
@@ -525,6 +525,7 @@ const AppContent: React.FC = () => {
             onConnect={(mnemonic) => connectWallet(mnemonic, true)}
             onBack={navigateToHome}
             onClearError={clearError}
+            isLoading={isLoading}
           />
         );
 

--- a/src/pages/RestorePage.tsx
+++ b/src/pages/RestorePage.tsx
@@ -7,12 +7,14 @@ interface RestorePageProps {
   onConnect: (mnemonic: string) => Promise<void>;
   onBack: () => void;
   onClearError: () => void;
+  isLoading?: boolean;
 }
 
 const RestorePage: React.FC<RestorePageProps> = ({
   onConnect,
   onBack,
-  onClearError
+  onClearError,
+  isLoading = false,
 }) => {
   const [mnemonic, setMnemonic] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
@@ -38,11 +40,11 @@ const RestorePage: React.FC<RestorePageProps> = ({
     <div className="max-w-xl mx-auto">
       <PrimaryButton
         onClick={handleSubmit}
-        disabled={!mnemonic.trim()}
+        disabled={!mnemonic.trim() || isLoading}
         className="w-full"
         data-testid="restore-confirm-button"
       >
-        Restore Wallet
+        {isLoading ? 'Restoring...' : 'Restore Wallet'}
       </PrimaryButton>
     </div>
   );


### PR DESCRIPTION
Fixes #101

## Root Cause (actual)

The previous fix (#104) was incomplete. The real issue: when "Restore Wallet" is tapped, `connectWallet` sets `isLoading=true` which causes `App` to render a full-screen spinner **instead of** `RestorePage`. This unmounts `RestorePage`, resetting all local state. When `connectWallet` fails and sets `isLoading=false`, `RestorePage` remounts fresh — no error, no mnemonic.

## Fix

- Skip the full-screen loading spinner when `currentScreen === 'restore'` so `RestorePage` stays mounted
- Pass `isLoading` as a prop to `RestorePage` so the button shows "Restoring..." and is disabled while in-flight
- When `connectWallet` fails and re-throws, `RestorePage`'s `catch` block now actually executes and shows the error inline

## Test plan

- [ ] Enter a 12-word mnemonic with a wrong last word → should show error inline
- [ ] Enter a completely invalid mnemonic → same
- [ ] Enter a valid mnemonic → should restore successfully 
- [ ] Enter fewer than 12 words → existing word count error still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)