### PR TITLE
feat: upgrade @breeztech/breez-sdk-spark to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "wasm-example-app",
       "version": "0.1.0",
       "dependencies": {
-        "@breeztech/breez-sdk-spark": "0.9.0",
+        "@breeztech/breez-sdk-spark": "0.10.0",
         "@headlessui/react": "^1.7.17",
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
@@ -407,9 +407,10 @@
       }
     },
     "node_modules/@breeztech/breez-sdk-spark": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.9.0.tgz",
-      "integrity": "sha512-+O4iXeFA+FUuIFtH8P/6eT6VYNj0Do/Ai5FdgtZUJ/gbEYGHGHY+VhIl61/APNegFGVcrH7gnk6Rq/zf5dwIFw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.10.0.tgz",
+      "integrity": "sha512-eBsh0oX2B8uGuWfCMmtH3SNXmSkED5du/CiWQKh1Ei1r0LsO6jlVnUmh94j7R5W4siIi7M6CC7ywll3FQ47rYQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=22"
       },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
-    "@breeztech/breez-sdk-spark": "0.9.0",
+    "@breeztech/breez-sdk-spark": "0.10.0",
     "@headlessui/react": "^1.7.17",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -351,6 +351,7 @@ const AppContent: React.FC = () => {
       const config: Config = defaultConfig(network);
       config.apiKey = breezApiKey;
       config.privateEnabledDefault = false;
+      config.supportLnurlVerify = true;
 
       // Apply persisted user settings to config
       try {


### PR DESCRIPTION
## Summary
- Upgrades `@breeztech/breez-sdk-spark` from 0.9.0 to 0.10.0
- Enables LNURL verify support by setting `config.supportLnurlVerify = true`

## Test plan
- [x] `tsc --noEmit` passes with no type errors
- [x] `npm run build` succeeds
- [x] All 44 unit tests pass
- [ ] Manual smoke test: connect wallet, send/receive payments, LNURL pay

Closes #109