### PR TITLE
fix: use in-memory mnemonic for backup page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,7 @@ const AppContent: React.FC = () => {
 
       case 'backup':
         return (
-          <BackupPage onBack={() => setCurrentScreen('wallet')} />
+          <BackupPage onBack={() => setCurrentScreen('wallet')} mnemonic={sdk.walletMnemonic} />
         );
 
       case 'restore':

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -67,6 +67,7 @@ export interface BreezSdkState {
   hasRejectedDeposits: boolean;
   celebrationAmount: number | null;
   prfAvailable: boolean;
+  walletMnemonic: string | null;
 }
 
 export interface BreezSdkActions {
@@ -101,6 +102,7 @@ export function useBreezSdk(
   const [hasRejectedDeposits, setHasRejectedDeposits] = useState(false);
   const [celebrationAmount, setCelebrationAmount] = useState<number | null>(null);
   const [prfAvailable, setPrfAvailable] = useState(false);
+  const [walletMnemonic, setWalletMnemonic] = useState<string | null>(null);
 
   // Refs
   const isInitialLoadRef = useRef(true);
@@ -247,6 +249,9 @@ export function useBreezSdk(
       logger.authSuccess(seed.type);
       logger.info(LogCategory.SDK, 'Wallet connected successfully');
 
+      if (seed.type === 'mnemonic') {
+        setWalletMnemonic(seed.mnemonic);
+      }
       if (passkeyLabel != null) {
         setPasskeyMode(passkeyLabel);
       } else if (seed.type === 'mnemonic') {
@@ -308,6 +313,7 @@ export function useBreezSdk(
 
     // Always reset all state — even if disconnect threw
     setSdk(null);
+    setWalletMnemonic(null);
     clearMnemonic();
     clearPasskeyMode();
     releasePasskey();
@@ -445,6 +451,7 @@ export function useBreezSdk(
     hasRejectedDeposits,
     celebrationAmount,
     prfAvailable,
+    walletMnemonic,
     // Actions
     connectWallet,
     refreshWalletData,

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -1,48 +1,19 @@
-import React, { useEffect, useState } from 'react';
-import { WarningIcon, SpinnerIcon, EyeIcon, FingerprintIcon } from '../components/Icons';
+import React, { useState } from 'react';
+import { WarningIcon, EyeIcon, FingerprintIcon } from '../components/Icons';
 import SlideInPage from '../components/layout/SlideInPage';
-import { isPasskeyMode, getWallet } from '@/services/passkeyService';
+import { isPasskeyMode } from '@/services/passkeyService';
 import { logger, LogCategory } from '@/services/logger';
 
 interface BackupPageProps {
   onBack: () => void;
+  mnemonic: string | null;
 }
 
-const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
-  const [mnemonic, setMnemonic] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+const BackupPage: React.FC<BackupPageProps> = ({ onBack, mnemonic }) => {
   const [isRevealed, setIsRevealed] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const isPasskey = isPasskeyMode();
-
-  useEffect(() => {
-    if (!isPasskey) {
-      setMnemonic(localStorage.getItem('walletMnemonic'));
-    }
-  }, [isPasskey]);
-
-  const handleRevealPasskey = async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const w = await getWallet();
-      if (w.seed.type === 'mnemonic' && w.seed.mnemonic) {
-        setMnemonic(w.seed.mnemonic);
-        setIsRevealed(true);
-      } else {
-        setError('Could not derive recovery phrase');
-      }
-    } catch (e) {
-      logger.error(LogCategory.AUTH, 'Failed to derive mnemonic from passkey', {
-        error: e instanceof Error ? e.message : String(e),
-      });
-      setError(e instanceof Error ? e.message : 'Failed to authenticate');
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   const handleCopy = async () => {
     if (!mnemonic) return;
@@ -57,44 +28,31 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
     }
   };
 
-  const handleHide = () => {
-    setIsRevealed(false);
-    if (isPasskey) {
-      setMnemonic(null);
-    }
-  };
-
   const words = mnemonic ? mnemonic.split(' ') : [];
 
   return (
     <SlideInPage title="Backup" onClose={onBack} slideFrom="left">
       <div className="p-4">
         <div className="max-w-xl mx-auto w-full space-y-6">
-          {/* Reveal button — passkey mode */}
-          {isPasskey && !isRevealed && !mnemonic && (
-            <button
-              onClick={handleRevealPasskey}
-              disabled={isLoading}
-              className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
-            >
-              <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-                {isLoading ? (
-                  <SpinnerIcon size="xl" className="text-spark-primary" />
-                ) : (
-                  <EyeIcon size="xl" className="text-spark-primary" />
-                )}
+          {/* Passkey info card */}
+          {isPasskey && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-6">
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-xl bg-spark-primary/20 flex items-center justify-center flex-shrink-0">
+                  <FingerprintIcon size="md" className="text-spark-primary" />
+                </div>
+                <div>
+                  <h4 className="font-medium text-spark-text-primary mb-1">Passkey Protected</h4>
+                  <p className="text-spark-text-muted text-sm">
+                    Your recovery phrase is derived from your passkey. To restore on another device, use your passkey or the recovery phrase below.
+                  </p>
+                </div>
               </div>
-              <span className="font-display font-semibold text-spark-text-primary">
-                {isLoading ? 'Authenticating...' : 'Tap to reveal phrase'}
-              </span>
-              <span className="text-sm text-spark-text-muted">
-                {isLoading ? 'Complete passkey authentication' : 'Requires passkey authentication'}
-              </span>
-            </button>
+            </div>
           )}
 
-          {/* Reveal button — mnemonic mode */}
-          {!isPasskey && !isRevealed && mnemonic && (
+          {/* Reveal button */}
+          {mnemonic && !isRevealed && (
             <button
               onClick={() => setIsRevealed(true)}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors"
@@ -107,21 +65,14 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </button>
           )}
 
-          {/* Error message (passkey only) */}
-          {error && (
-            <div className="bg-spark-error/10 border border-spark-error/30 rounded-xl p-4 text-center">
-              <p className="text-spark-error text-sm">{error}</p>
-            </div>
-          )}
-
-          {/* Mnemonic word grid (shared) */}
-          {isRevealed && mnemonic && (
+          {/* Mnemonic word grid */}
+          {mnemonic && isRevealed && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-4 space-y-4">
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium text-spark-text-secondary">Recovery Phrase</span>
                 <div className="flex items-center gap-2">
                   <button
-                    onClick={handleHide}
+                    onClick={() => setIsRevealed(false)}
                     className="px-3 py-1.5 text-sm font-medium text-spark-text-muted hover:text-spark-text-primary border border-spark-border rounded-lg hover:bg-white/5 transition-colors"
                   >
                     Hide
@@ -129,13 +80,13 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
                   <button
                     onClick={handleCopy}
                     className={`
-                      px-3 py-1.5 text-sm font-medium rounded-lg transition-all
-                      ${copied
-                        ? 'bg-spark-success/20 text-spark-success border border-spark-success/30'
-                        : 'bg-spark-primary text-white hover:bg-spark-primary-light'
-                      }
-                    `}
-                  >
+                    px-3 py-1.5 text-sm font-medium rounded-lg transition-all
+                    ${copied
+                      ? 'bg-spark-success/20 text-spark-success border border-spark-success/30'
+                      : 'bg-spark-primary text-white hover:bg-spark-primary-light'
+                    }
+                  `}
+                >
                     {copied ? 'Copied!' : 'Copy'}
                   </button>
                 </div>
@@ -159,25 +110,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </div>
           )}
 
-          {/* Passkey info card */}
-          {isPasskey && (
-            <div className="bg-spark-dark border border-spark-border rounded-2xl p-6">
-              <div className="flex items-start gap-4">
-                <div className="w-10 h-10 rounded-xl bg-spark-primary/20 flex items-center justify-center flex-shrink-0">
-                  <FingerprintIcon size="md" className="text-spark-primary" />
-                </div>
-                <div>
-                  <h4 className="font-medium text-spark-text-primary mb-1">Passkey Protected</h4>
-                  <p className="text-spark-text-muted text-sm">
-                    Your recovery phrase is derived from your passkey. To restore on another device, use your passkey or the recovery phrase above.
-                  </p>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* No backup found (mnemonic mode only) */}
-          {!isPasskey && !mnemonic && (
+          {/* No backup found */}
+          {!mnemonic && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-8 text-center">
               <div className="w-16 h-16 rounded-2xl bg-spark-error/20 flex items-center justify-center mx-auto mb-4">
                 <WarningIcon size="xl" className="text-spark-error" />


### PR DESCRIPTION
## Summary

- Store mnemonic in React state (in-memory only) during wallet connection for both passkey and mnemonic modes
- BackupPage receives mnemonic as a prop instead of reading from localStorage or re-authenticating via passkey
- Passkey users no longer need to re-authenticate to view their recovery phrase — it's available in-memory for the session
- Simplified BackupPage: removed passkey auth flow, loading/error states; unified tap-to-reveal for both modes
- localStorage persistence remains mnemonic-mode only (passkey mode stores nothing)

## Test plan

- [ ] Mnemonic mode: open Backup → tap to reveal → 12 words shown → Copy works → Hide works
- [ ] Passkey mode: open Backup → passkey info card shown → tap to reveal → 12 words shown
- [ ] Logout clears mnemonic from memory
- [ ] Page refresh for passkey user: auto-reconnect re-derives mnemonic, backup page still works