### PR TITLE
feat: password-encrypted seed storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "eslint": "^10.0.0",
         "eslint-plugin-react-hooks": "^7.0.0",
         "eslint-plugin-react-refresh": "^0.5.0",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.0.0",
         "happy-dom": "^20.3.9",
         "postcss": "^8.4.27",
@@ -4121,6 +4122,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^10.0.0",
     "eslint-plugin-react-hooks": "^7.0.0",
     "eslint-plugin-react-refresh": "^0.5.0",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.0.0",
     "happy-dom": "^20.3.9",
     "postcss": "^8.4.27",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense, lazy } from 'react';
+import { Capacitor } from '@capacitor/core';
 import { WalletProvider, WalletInfoProvider } from './contexts/WalletContext';
 import LoadingSpinner from './components/LoadingSpinner';
 import PaymentReceivedCelebration from './components/PaymentReceivedCelebration';
@@ -22,6 +23,14 @@ import FiatCurrenciesPage from './pages/FiatCurrenciesPage';
 import BuyProvidersPage from './pages/BuyProvidersPage';
 import UnlockPage from './pages/UnlockPage';
 import UnlockingPage from './pages/UnlockingPage';
+import SetPasswordPage from './pages/SetPasswordPage';
+import VaultUnlockPage from './pages/VaultUnlockPage';
+import { createVault, createVaultFromMaterial, deriveVaultKey, type VaultKeyMaterial } from './services/vault';
+import { isPasswordPwned } from './utils/password';
+
+const PWNED_MESSAGE = 'This password has appeared in a data breach. Please choose a different one.';
+import { logger, LogCategory } from './services/logger';
+import { formatError } from './utils/formatError';
 // Dev-gated Passkey & Labels hub + the AAGUID lookup database it pulls
 // in (~245 KB JSON). Code-split so neither the main bundle nor any
 // non-dev user pays the parse cost; loads on first navigation into the
@@ -38,7 +47,11 @@ import { STATUS_BAR_LOADING } from './utils/statusBarManager';
 import { useBackButton } from './hooks/useBackButton';
 import type { Seed, Payment } from '@breeztech/breez-sdk-spark';
 
-type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'unlock' | 'unlocking' | 'passkeySettings' | 'passkeyManagement' | 'labels' | 'passkeyLocalState';
+type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'unlock' | 'unlocking' | 'passkeySettings' | 'passkeyManagement' | 'labels' | 'passkeyLocalState' | 'setPassword' | 'vaultUnlock' | 'migrate';
+
+// Password vault flow is web-only; matches useBreezSdk.isWeb.
+const isWeb = !Capacitor.isNativePlatform();
+const LEGACY_MNEMONIC_KEY = 'walletMnemonic';
 
 // Full-screen dim spinner shown while sdk.isLoading is true (logout in
 // progress, SDK reconnect, etc). Wrapped as its own component so the
@@ -78,6 +91,15 @@ const AppContent: React.FC = () => {
   // cross-device QR picker on the first click of a fresh-user
   // onboarding. Read by PasskeyPage as the `skipDetection` prop.
   const [passkeySkipDetection, setPasskeySkipDetection] = useState(false);
+  // Vault flow state shared across SetPasswordPage / GeneratePage / RestorePage.
+  // Holds derived key material (CryptoKey is non-extractable) instead of
+  // the plaintext password so the password doesn't sit in heap during
+  // the seed-confirmation step.
+  const [pendingMnemonic, setPendingMnemonic] = useState<string | null>(null);
+  const [pendingKeyMaterial, setPendingKeyMaterial] = useState<VaultKeyMaterial | null>(null);
+  const [pendingIsRestore, setPendingIsRestore] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordLoading, setPasswordLoading] = useState(false);
   const { showToast } = useToast();
   const formatPaymentAmountRef = useRef<((payment: Payment) => string) | undefined>(undefined);
 
@@ -92,14 +114,143 @@ const AppContent: React.FC = () => {
   const currentScreen: Screen = useMemo(() => {
     if (sdk.startupState === 'native-unlocking') return 'unlocking';
     if (sdk.startupState === 'native-locked') return 'unlock';
+    if (sdk.startupState === 'vault-locked') return 'vaultUnlock';
+    if (sdk.startupState === 'needs-migration') return 'migrate';
     if (sdk.isConnected && userScreen === 'home') return 'wallet';
     return userScreen;
   }, [sdk.startupState, sdk.isConnected, userScreen]);
 
-  // Navigate to wallet after successful connect
-  const handleConnect = async (mnemonic: string, restore: boolean) => {
+  // Connect with a mnemonic and land on the wallet screen. Used after
+  // every flow that already has the seed in hand (vault unlock,
+  // migration, post-vault-create).
+  const openWallet = async (mnemonic: string, restore = false) => {
     await sdk.connectWallet({ type: 'mnemonic', mnemonic }, restore);
     setUserScreen('wallet');
+  };
+
+  // Wraps a vault-related submit step with the loading / try-catch /
+  // error-banner shell that SetPasswordPage and the migrate screen
+  // both need. `failureMsg` is shown to the user AND logged.
+  const runPasswordStep = async (
+    work: () => Promise<void>,
+    failureMsg: string,
+  ): Promise<void> => {
+    setPasswordError(null);
+    setPasswordLoading(true);
+    try {
+      await work();
+    } catch (e) {
+      logger.error(LogCategory.AUTH, failureMsg, { error: formatError(e) });
+      setPasswordError(failureMsg);
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  // Web routes through SetPasswordPage so the vault is created before
+  // connectWallet runs. Native skips it: secure storage handles the seed.
+  const handleConnect = async (mnemonic: string, restore: boolean) => {
+    if (isWeb) {
+      setPendingMnemonic(mnemonic);
+      setPendingIsRestore(restore);
+      setPasswordError(null);
+      setUserScreen('setPassword');
+      return;
+    }
+    await openWallet(mnemonic, restore);
+  };
+
+  // SetPasswordPage submit. Two flows share the form:
+  //   - Restore: pendingMnemonic is set, encrypt + connect inline.
+  //   - Create: derive key now (drop plaintext), defer encryption to
+  //             GeneratePage once the user confirms the new mnemonic.
+  const handlePasswordSet = async (password: string) => {
+    await runPasswordStep(async () => {
+      if (await isPasswordPwned(password)) {
+        setPasswordError(PWNED_MESSAGE);
+        return;
+      }
+      if (pendingMnemonic) {
+        await createVault(pendingMnemonic, password);
+        const mnemonic = pendingMnemonic;
+        const restore = pendingIsRestore;
+        setPendingMnemonic(null);
+        setPendingIsRestore(false);
+        await openWallet(mnemonic, restore);
+      } else {
+        setPendingKeyMaterial(await deriveVaultKey(password));
+        setUserScreen('generate');
+      }
+    }, 'Failed to set up Glow. Please try again.');
+  };
+
+  // GeneratePage confirm. Web non-passkey: encrypt with the key
+  // material captured on SetPasswordPage. Native: hand off to handleConnect.
+  const handleGenerateConfirm = async (mnemonic: string) => {
+    if (!isWeb) {
+      await handleConnect(mnemonic, false);
+      return;
+    }
+    if (!pendingKeyMaterial) {
+      setUserScreen('setPassword');
+      return;
+    }
+    setPasswordLoading(true);
+    try {
+      await createVaultFromMaterial(mnemonic, pendingKeyMaterial);
+      setPendingKeyMaterial(null);
+      await openWallet(mnemonic);
+    } catch (e) {
+      logger.error(LogCategory.AUTH, 'Failed to create vault after seed confirmation', { error: formatError(e) });
+      showToast('error', 'Setup Failed', 'Failed to secure Glow. Please try again.');
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  // Migrate legacy plaintext mnemonic into the vault. Order matters:
+  // vault is durable before plaintext goes away, and plaintext goes
+  // away before connectWallet so a crash in the connect window can't
+  // leave a vault + plaintext pair. A connect failure leaves the
+  // vault in place; next launch hits 'vault-locked' for retry.
+  const handleMigratePassword = async (password: string) => {
+    await runPasswordStep(async () => {
+      if (await isPasswordPwned(password)) {
+        setPasswordError(PWNED_MESSAGE);
+        return;
+      }
+      const mnemonic = localStorage.getItem(LEGACY_MNEMONIC_KEY);
+      if (!mnemonic) {
+        setPasswordError('No setup found to migrate.');
+        return;
+      }
+      const wordCount = mnemonic.trim().split(/\s+/).length;
+      if (wordCount !== 12 && wordCount !== 24) {
+        setPasswordError('Stored recovery phrase is invalid. Please restore manually.');
+        return;
+      }
+      await createVault(mnemonic, password);
+      localStorage.removeItem(LEGACY_MNEMONIC_KEY);
+      await openWallet(mnemonic);
+    }, 'Failed to migrate. Please try again.');
+  };
+
+  // VaultUnlockPage owns its own loading + wrong-password feedback;
+  // here we just wire the post-decrypt connect with a toast on failure.
+  const handleVaultUnlocked = async (mnemonic: string) => {
+    try {
+      await openWallet(mnemonic);
+    } catch (e) {
+      logger.error(LogCategory.SDK, 'Failed to connect after vault unlock', { error: formatError(e) });
+      showToast('error', 'Failed to open Glow', 'Please try again.');
+    }
+  };
+
+  const handleSetPasswordBack = () => {
+    setPendingMnemonic(null);
+    setPendingKeyMaterial(null);
+    setPasswordError(null);
+    setUserScreen(pendingMnemonic ? 'restore' : 'home');
   };
 
   // Navigate to wallet after passkey connect
@@ -162,7 +313,12 @@ const AppContent: React.FC = () => {
       case 'restore':
       case 'generate':
       case 'passkey':
+      case 'setPassword':
         setUserScreen('home');
+        return true;
+      case 'vaultUnlock':
+      case 'migrate':
+        // Startup-driven; absorb so back doesn't minimise mid-unlock.
         return true;
       case 'unlock':
       case 'unlocking':
@@ -211,7 +367,10 @@ const AppContent: React.FC = () => {
       currentScreen !== 'restore' &&
       currentScreen !== 'passkey' &&
       currentScreen !== 'unlock' &&
-      currentScreen !== 'unlocking'
+      currentScreen !== 'unlocking' &&
+      currentScreen !== 'vaultUnlock' &&
+      currentScreen !== 'setPassword' &&
+      currentScreen !== 'migrate'
     ) {
       return <GlobalLoadingOverlay />;
     }
@@ -230,7 +389,18 @@ const AppContent: React.FC = () => {
         return (
           <HomePage
             onRestoreWallet={() => setUserScreen('restore')}
-            onCreateNewWallet={() => setUserScreen('generate')}
+            onCreateNewWallet={() => {
+              if (isWeb) {
+                // Web: capture password first, GeneratePage consumes it on confirm.
+                setPendingMnemonic(null);
+                setPendingKeyMaterial(null);
+                setPendingIsRestore(false);
+                setPasswordError(null);
+                setUserScreen('setPassword');
+              } else {
+                setUserScreen('generate');
+              }
+            }}
             onUsePasskey={() => { setPasskeySkipDetection(false); setUserScreen('passkey'); }}
             onCreatePasskey={() => { setPasskeySkipDetection(true); setUserScreen('passkey'); }}
             prfAvailable={sdk.prfAvailable}
@@ -300,7 +470,18 @@ const AppContent: React.FC = () => {
         return (
           <HomePage
             onRestoreWallet={() => setUserScreen('restore')}
-            onCreateNewWallet={() => setUserScreen('generate')}
+            onCreateNewWallet={() => {
+              if (isWeb) {
+                // Web: capture password first, GeneratePage consumes it on confirm.
+                setPendingMnemonic(null);
+                setPendingKeyMaterial(null);
+                setPendingIsRestore(false);
+                setPasswordError(null);
+                setUserScreen('setPassword');
+              } else {
+                setUserScreen('generate');
+              }
+            }}
             onUsePasskey={() => { setPasskeySkipDetection(false); setUserScreen('passkey'); }}
             onCreatePasskey={() => { setPasskeySkipDetection(true); setUserScreen('passkey'); }}
             prfAvailable={sdk.prfAvailable}
@@ -471,10 +652,33 @@ const AppContent: React.FC = () => {
       case 'generate':
         return (
           <GeneratePage
-            onMnemonicConfirmed={(mnemonic) => handleConnect(mnemonic, false)}
-            onBack={() => setUserScreen('home')}
+            onMnemonicConfirmed={handleGenerateConfirm}
+            onBack={() => setUserScreen(isWeb ? 'setPassword' : 'home')}
             error={sdk.error}
             onClearError={sdk.clearError}
+          />
+        );
+
+      case 'setPassword':
+        return (
+          <SetPasswordPage
+            onPasswordSet={handlePasswordSet}
+            onBack={handleSetPasswordBack}
+            isLoading={passwordLoading}
+            error={passwordError}
+          />
+        );
+
+      case 'vaultUnlock':
+        return <VaultUnlockPage onUnlocked={handleVaultUnlocked} />;
+
+      case 'migrate':
+        return (
+          <SetPasswordPage
+            mode="migrate"
+            onPasswordSet={handleMigratePassword}
+            isLoading={passwordLoading}
+            error={passwordError}
           />
         );
 

--- a/src/components/PasswordForm.tsx
+++ b/src/components/PasswordForm.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { FormError } from './ui/forms';
+import PasswordInput from './PasswordInput';
+import PasswordStrengthMeter from './PasswordStrengthMeter';
+import {
+  PASSWORD_MIN_LENGTH,
+  validatePasswordSetup,
+  validatePasswordUnlock,
+} from '../utils/password';
+
+interface PasswordFormProps {
+  mode: 'setup' | 'unlock';
+  onSubmit: (password: string) => void;
+  isLoading?: boolean;
+  error?: string | null;
+  /** Set an id on the <form> so an external button can submit via form="id". */
+  formId?: string;
+  /** Hide the inline submit button (use with formId for external submit). */
+  hideSubmit?: boolean;
+}
+
+function useShakeOnNewError(error: string | null): boolean {
+  const [shaking, setShaking] = useState(false);
+  const prev = useRef<string | null>(null);
+  useEffect(() => {
+    if (error && error !== prev.current) {
+      setShaking(true);
+      const t = setTimeout(() => setShaking(false), 400);
+      return () => clearTimeout(t);
+    }
+    prev.current = error;
+  }, [error]);
+  return shaking;
+}
+
+const PasswordForm: React.FC<PasswordFormProps> = ({
+  mode,
+  onSubmit,
+  isLoading = false,
+  error = null,
+  formId,
+  hideSubmit = false,
+}) => {
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [show, setShow] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const isSetup = mode === 'setup';
+  const displayError = validationError || error;
+  const shaking = useShakeOnNewError(displayError);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const err = isSetup
+      ? validatePasswordSetup(password, confirm)
+      : validatePasswordUnlock(password);
+    setValidationError(err);
+    if (!err) onSubmit(password);
+  };
+
+  const onPasswordChange = (val: string) => {
+    setPassword(val);
+    setValidationError(null);
+  };
+  const onConfirmChange = (val: string) => {
+    setConfirm(val);
+    setValidationError(null);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" id={formId}>
+      {/* Hidden username field anchors password-manager autofill. */}
+      <input
+        type="text"
+        name="username"
+        value="glow-label-username"
+        autoComplete="username"
+        aria-hidden="true"
+        tabIndex={-1}
+        readOnly
+        style={{ position: 'absolute', opacity: 0, pointerEvents: 'none', width: 0, height: 0 }}
+      />
+
+      <div className={shaking ? 'animate-shake' : ''}>
+        <PasswordInput
+          name="password"
+          value={password}
+          onChange={onPasswordChange}
+          onAutofill={isSetup ? setConfirm : undefined}
+          placeholder={isSetup ? 'Create a password' : 'Enter password'}
+          autoComplete={isSetup ? 'new-password' : 'current-password'}
+          minLength={isSetup ? PASSWORD_MIN_LENGTH : undefined}
+          disabled={isLoading}
+          autoFocus
+          hasError={!!displayError}
+          show={show}
+          onToggleShow={() => setShow(!show)}
+        />
+        {isSetup && <PasswordStrengthMeter password={password} />}
+      </div>
+
+      {isSetup && (
+        <PasswordInput
+          name="confirm-password"
+          value={confirm}
+          onChange={onConfirmChange}
+          onAutofill={setPassword}
+          placeholder="Confirm password"
+          autoComplete="new-password"
+          disabled={isLoading}
+          hasError={!!displayError}
+          show={show}
+        />
+      )}
+
+      <FormError error={displayError} />
+
+      {!hideSubmit && (
+        <>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className={`button w-full ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+          >
+            {isLoading
+              ? (isSetup ? 'Encrypting...' : 'Unlocking...')
+              : (isSetup ? 'Set Password' : 'Unlock')}
+          </button>
+          {isSetup && (
+            <p className="text-xs text-spark-text-muted text-center">
+              Use your password manager to generate a strong password
+            </p>
+          )}
+        </>
+      )}
+    </form>
+  );
+};
+
+export default PasswordForm;

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { EyeIcon } from './Icons';
+import { sanitizePasswordInput, PASSWORD_MAX_LENGTH } from '../utils/password';
+
+const baseClasses = 'w-full bg-spark-dark border rounded-xl px-4 py-3 text-spark-text-primary placeholder-spark-text-muted focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20 transition-all';
+
+// Distinguishes paste / autofill from ordinary typing so cross-syncing
+// the confirm field can't corrupt state on fast typing or multi-char delete.
+function isPasteOrAutofill(e: Event): boolean {
+  const t = (e as InputEvent).inputType;
+  return t === 'insertFromPaste' || t === 'insertReplacementText';
+}
+
+interface PasswordInputProps {
+  name: string;
+  value: string;
+  onChange: (val: string) => void;
+  /** Fires on paste / password-manager autofill. The recipient typically mirrors the value into the sibling field. */
+  onAutofill?: (val: string) => void;
+  placeholder: string;
+  autoComplete: 'new-password' | 'current-password';
+  minLength?: number;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  hasError?: boolean;
+  show: boolean;
+  /** Renders the eye toggle when provided. */
+  onToggleShow?: () => void;
+}
+
+const PasswordInput: React.FC<PasswordInputProps> = ({
+  name,
+  value,
+  onChange,
+  onAutofill,
+  placeholder,
+  autoComplete,
+  minLength,
+  disabled,
+  autoFocus,
+  hasError,
+  show,
+  onToggleShow,
+}) => (
+  <div className="relative">
+    <input
+      type={show ? 'text' : 'password'}
+      name={name}
+      value={value}
+      onChange={(e) => {
+        const val = sanitizePasswordInput(e.target.value);
+        onChange(val);
+        if (onAutofill && val.length > 0 && isPasteOrAutofill(e.nativeEvent)) onAutofill(val);
+      }}
+      autoComplete={autoComplete}
+      placeholder={placeholder}
+      minLength={minLength}
+      maxLength={PASSWORD_MAX_LENGTH}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      className={`${baseClasses} ${hasError ? 'border-spark-error' : 'border-spark-border'} ${onToggleShow ? 'pr-12' : ''}`}
+    />
+    {onToggleShow && (
+      <button
+        type="button"
+        onClick={onToggleShow}
+        aria-label={show ? 'Hide password' : 'Show password'}
+        tabIndex={-1}
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-spark-text-muted hover:text-spark-text-primary transition-colors"
+      >
+        <EyeIcon size="md" />
+      </button>
+    )}
+  </div>
+);
+
+export default PasswordInput;

--- a/src/components/PasswordStrengthMeter.tsx
+++ b/src/components/PasswordStrengthMeter.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { type PasswordStrength, passwordStrength } from '../utils/password';
+
+const colors: Record<PasswordStrength, string> = {
+  weak: 'bg-spark-error',
+  medium: 'bg-spark-warning',
+  strong: 'bg-spark-success',
+};
+
+const widths: Record<PasswordStrength, string> = {
+  weak: 'w-1/3',
+  medium: 'w-2/3',
+  strong: 'w-full',
+};
+
+const labels: Record<PasswordStrength, string> = {
+  weak: 'Weak',
+  medium: 'Medium',
+  strong: 'Strong',
+};
+
+const PasswordStrengthMeter: React.FC<{ password: string }> = ({ password }) => {
+  if (password.length === 0) return null;
+  const level = passwordStrength(password);
+  return (
+    <div className="mt-2 space-y-1">
+      <div className="h-1 w-full bg-spark-border rounded-full overflow-hidden">
+        <div className={`h-full ${colors[level]} ${widths[level]} rounded-full transition-all duration-300`} />
+      </div>
+      <p className="text-xs text-spark-text-muted">{labels[level]}</p>
+    </div>
+  );
+};
+
+export default PasswordStrengthMeter;

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -6,8 +6,8 @@ import { STATUS_BAR_SURFACE } from '../../utils/statusBarManager';
 
 interface PageLayoutProps {
   children: ReactNode;
-  footer: ReactNode
-  onBack: () => void | null;
+  footer: ReactNode;
+  onBack?: () => void;
   title?: string;
   showHeader?: boolean;
   onClearError?: () => void;
@@ -17,32 +17,27 @@ const PageLayout: React.FC<PageLayoutProps> = ({
   children,
   title,
   footer,
-  onBack = null,
+  onBack,
   showHeader = true,
 }) => {
-  // Generic PageLayout screens (get refund, etc.) use a solid
-  // spark-surface background; match the system bars to that tone.
   useStatusBarColor(STATUS_BAR_SURFACE);
 
   return (
-    <div className="min-h-dvh h-dvh w-full flex flex-col bg-spark-surface relative">
+    <div className="relative h-dvh flex flex-col bg-spark-surface">
       {showHeader && (
         <header
           className="relative z-10 shrink-0 border-b border-spark-border bg-spark-surface/80 backdrop-blur-sm"
           style={{ paddingTop: safeAreaTop }}
         >
-          {/* Fixed h-14 (56dp) Material toolbar height, matching the
-              wallet page CollapsingWalletHeader top row so the back button
-              lands at the same screen y coordinate when navigating. */}
-          <div className="relative px-4 h-14 flex items-center justify-center">
-            <h1 className="text-center font-display text-xl font-bold text-spark-text-primary">
-              {title || "Glow"}
+          <div className="relative flex h-14 items-center justify-center px-4">
+            <h1 className="font-display text-xl font-bold text-spark-text-primary">
+              {title || 'Glow'}
             </h1>
             {onBack && (
               <button
                 onClick={onBack}
-                className="absolute left-4 top-1/2 -translate-y-1/2 p-2 text-spark-text-muted hover:text-spark-text-primary rounded-lg hover:bg-white/5 transition-colors"
                 aria-label="Go back"
+                className="absolute left-4 top-1/2 -translate-y-1/2 p-2 text-spark-text-muted hover:text-spark-text-primary rounded-lg hover:bg-white/5 transition-colors"
               >
                 <BackIcon />
               </button>
@@ -51,23 +46,19 @@ const PageLayout: React.FC<PageLayoutProps> = ({
         </header>
       )}
 
-      {/* Scrollable content area */}
-      <main 
-        className="relative z-10 flex-1 w-full overflow-y-auto p-4"
+      <main
+        className="relative z-10 flex-1 overflow-y-auto p-4"
         style={{ WebkitOverflowScrolling: 'touch' }}
       >
         {children}
       </main>
 
-      {/* Fixed footer */}
       {footer && (
         <footer
-          className="relative z-10 shrink-0 w-full border-t border-spark-border bg-spark-surface/80 backdrop-blur-sm"
+          className="relative z-10 shrink-0 border-t border-spark-border bg-spark-surface/80 backdrop-blur-sm"
           style={{ paddingBottom: safeAreaBottom }}
         >
-          <div className="px-4 py-4">
-            {footer}
-          </div>
+          <div className="p-4">{footer}</div>
         </footer>
       )}
     </div>

--- a/src/components/ui/forms/index.tsx
+++ b/src/components/ui/forms/index.tsx
@@ -130,17 +130,22 @@ export const FormTextarea: React.FC<FormTextareaProps> = ({
   />
 );
 
+// Fixed-height slot prevents layout jump as the error toggles.
 export const FormError: React.FC<{
   error: string | null;
-}> = ({ error }) => {
-  if (!error) return null;
-  return (
-    <div className="flex items-center gap-2 text-spark-error text-sm mt-2">
-      <ErrorIcon className="shrink-0" />
-      <span>{error}</span>
-    </div>
-  );
-};
+}> = ({ error }) => (
+  <div
+    aria-live="polite"
+    className={`flex items-center gap-2 text-spark-error text-sm min-h-5 transition-opacity duration-200 ${error ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+  >
+    {error && (
+      <>
+        <ErrorIcon className="shrink-0" />
+        <span>{error}</span>
+      </>
+    )}
+  </div>
+);
 
 export const FormHint: React.FC<{
   children: ReactNode;

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -36,6 +36,10 @@ import {
 } from '../services/passkeyService';
 import { secureStorage, deviceOnlyStorage, SecureStorageError } from '../services/secureStorage';
 import { passkeyPrfProvider } from '../services/passkeyPrfProvider';
+import { hasVault, deleteVault } from '../services/vault';
+
+// Password vault is web-only; native uses biometric / deviceOnlyStorage.
+const isWeb = !Capacitor.isNativePlatform();
 
 
 // ============================================
@@ -68,9 +72,9 @@ function initSdkLogging() {
 // ============================================
 
 const MNEMONIC_KEY = 'walletMnemonic';
-const saveMnemonic = (m: string) => localStorage.setItem(MNEMONIC_KEY, m);
 const getSavedMnemonic = () => localStorage.getItem(MNEMONIC_KEY);
 const clearMnemonic = () => localStorage.removeItem(MNEMONIC_KEY);
+const hasLegacyMnemonic = (): boolean => getSavedMnemonic() !== null;
 
 // ============================================
 // Legacy mnemonic → secure storage migration
@@ -127,8 +131,11 @@ async function migrateLegacyMnemonicIfNeeded(): Promise<void> {
  *   `UnlockingPage` placeholder (Glow logo + "Authenticating…" spinner)
  *   as a branded backdrop behind the OS prompt either way.
  * - `'native-locked'`: the auto-triggered biometric was cancelled or hit the
- *   biometric lockout — router shows the interactive `UnlockPage` from which
+ *   biometric lockout. Router shows the interactive `UnlockPage` from which
  *   the user can retry biometric or abandon the locked wallet and re-onboard.
+ * - `'vault-locked'`: web non-passkey, vault exists. Router shows VaultUnlockPage.
+ * - `'needs-migration'`: web non-passkey, legacy plaintext mnemonic without
+ *   a vault yet. Router shows the set-password migration flow.
  * - `'connected'`: the SDK is connected to a wallet.
  */
 export type StartupState =
@@ -136,6 +143,8 @@ export type StartupState =
   | 'no-wallet'
   | 'native-unlocking'
   | 'native-locked'
+  | 'vault-locked'
+  | 'needs-migration'
   | 'connected';
 
 export interface BreezSdkState {
@@ -483,26 +492,27 @@ export function useBreezSdk(
           try {
             await secureStorage.storeSeed(seed);
           } catch {
-            // Intentionally swallowed — see comment above.
+            // Intentionally swallowed, see comment above.
           } finally {
             clearTimeout(flipTimer);
             if (flipped) setIsSecuringSeed(false);
           }
         } else if (deviceOnlyStorage.isSupported()) {
           // Non-passkey on native: encrypted-at-rest storage with no
-          // biometric prompt. No `isSecuringSeed` flip — this path is
+          // biometric prompt. No `isSecuringSeed` flip, this path is
           // silent by design.
           try {
             await deviceOnlyStorage.storeSeed(seed);
           } catch {
-            // Intentionally swallowed — see comment above.
+            // Intentionally swallowed, see comment above.
           }
         } else if (passkeyLabel != null) {
           // Web passkey mode: never cache the PRF-derived seed; wipe
           // any stale plaintext from older builds.
           clearMnemonic();
         } else if (seed.type === 'mnemonic') {
-          saveMnemonic(seed.mnemonic);
+          // Web non-passkey: vault (written by App layer) owns persistence.
+          clearMnemonic();
         }
       }
 
@@ -566,22 +576,29 @@ export function useBreezSdk(
       logger.warn(LogCategory.SESSION, 'Failed to end log session', { error: formatError(e) });
     }
 
-    // Wipe BOTH secure-storage tiers. Failure is non-fatal — the user
+    // Wipe BOTH secure-storage tiers. Failure is non-fatal, the user
     // is still logged out either way. Each tier emits its own typed
     // error breadcrumb on failure, so we don't double-log here.
     if (secureStorage.isSupported()) {
       try {
         await secureStorage.clearSeed();
       } catch {
-        // Intentionally swallowed — see comment above.
+        // Intentionally swallowed, see comment above.
       }
     }
     if (deviceOnlyStorage.isSupported()) {
       try {
         await deviceOnlyStorage.clearSeed();
       } catch {
-        // Intentionally swallowed — see comment above.
+        // Intentionally swallowed, see comment above.
       }
+    }
+    // Unconditional: cheap no-op when no vault, guards against a
+    // passkey/non-passkey toggle leaving a stale vault behind.
+    try {
+      await deleteVault();
+    } catch {
+      // Best-effort.
     }
 
     // Always reset all state — even if disconnect threw
@@ -1100,7 +1117,36 @@ export function useBreezSdk(
           // mode must always re-derive via PRF on launch.
           clearMnemonic();
         }
-        const savedMnemonic = !isPasskeyMode() ? getSavedMnemonic() : null;
+
+        // Web non-passkey: vault first, then legacy-plaintext migration.
+        if (isWeb && !isPasskeyMode()) {
+          try {
+            if (await hasVault()) {
+              setStartupState('vault-locked');
+              setIsLoading(false);
+              if (isInitialLoadRef.current) {
+                isInitialLoadRef.current = false;
+                void hideSplash();
+              }
+              return;
+            }
+          } catch (e) {
+            logger.warn(LogCategory.AUTH, 'hasVault probe failed', { error: formatError(e) });
+          }
+          if (hasLegacyMnemonic()) {
+            setStartupState('needs-migration');
+            setIsLoading(false);
+            if (isInitialLoadRef.current) {
+              isInitialLoadRef.current = false;
+              void hideSplash();
+            }
+            return;
+          }
+        }
+
+        // Native fallback for a legacy plaintext mnemonic the device-only
+        // migration helper missed; leaves the user not stranded.
+        const savedMnemonic = !isWeb && !isPasskeyMode() ? getSavedMnemonic() : null;
         if (savedMnemonic) {
           try {
             setIsLoading(true);

--- a/src/index.css
+++ b/src/index.css
@@ -539,6 +539,19 @@ h6 {
   }
 }
 
+/* Autofill overrides for dark theme. Without these the browser's
+   default white background and black text leak through, breaking the
+   dark UI. The 5000s transition on background-color is a known trick
+   to keep the autofill yellow / blue from animating back in on focus. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 1000px rgba(212, 165, 116, 0.08) inset !important;
+  -webkit-text-fill-color: var(--spark-text-primary) !important;
+  caret-color: var(--spark-text-primary);
+  transition: background-color 5000s ease-in-out 0s;
+}
+
 /* Custom select styling */
 select {
   appearance: none;
@@ -666,6 +679,19 @@ video::-webkit-media-controls-panel {
 /* ============================================
    ANIMATIONS
    ============================================ */
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  15% { transform: translateX(-6px); }
+  30% { transform: translateX(5px); }
+  45% { transform: translateX(-4px); }
+  60% { transform: translateX(3px); }
+  75% { transform: translateX(-2px); }
+}
+
+.animate-shake {
+  animation: shake 0.4s ease-out;
+}
 
 @keyframes float {
 

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -1,9 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { WarningIcon, SpinnerIcon, EyeIcon, FingerprintIcon, PasskeyIcon } from '../components/Icons';
+import { Capacitor } from '@capacitor/core';
+import { WarningIcon, SpinnerIcon, EyeIcon, FingerprintIcon, PasskeyIcon, LockIcon } from '../components/Icons';
 import SlideInPage from '../components/layout/SlideInPage';
 import { isPasskeyMode, getWallet } from '@/services/passkeyService';
 import { deviceOnlyStorage, secureStorage, getBiometryLabel } from '@/services/secureStorage';
+import { hasVault, unlockVault, VaultError } from '@/services/vault';
+import PasswordForm from '@/components/PasswordForm';
 import { logger, LogCategory } from '@/services/logger';
+
+const isWeb = !Capacitor.isNativePlatform();
 
 interface BackupPageProps {
   onBack: () => void;
@@ -15,8 +20,11 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
   const [isRevealed, setIsRevealed] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // null while probing IndexedDB; web-non-passkey only.
+  const [vaultExists, setVaultExists] = useState<boolean | null>(null);
 
   const isPasskey = isPasskeyMode();
+  const isWebVault = isWeb && !isPasskey;
 
   useEffect(() => {
     if (isPasskey) return;
@@ -37,12 +45,20 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
         }
       }
       if (cancelled) return;
+      // Vault present: defer mnemonic load until password unlock.
+      // Otherwise fall through to the legacy plaintext (migration window).
+      if (isWebVault) {
+        const exists = await hasVault();
+        if (cancelled) return;
+        setVaultExists(exists);
+        if (exists) return;
+      }
       setMnemonic(localStorage.getItem('walletMnemonic'));
     })();
     return () => {
       cancelled = true;
     };
-  }, [isPasskey]);
+  }, [isPasskey, isWebVault]);
 
   // Tracks whether passkey-based reveal failed once, so we can offer a
   // secureStorage fallback button in the error UI. We don't try
@@ -119,6 +135,27 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
     }
   };
 
+  const handleRevealVault = async (password: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const phrase = await unlockVault(password);
+      setMnemonic(phrase);
+      setIsRevealed(true);
+    } catch (e) {
+      if (e instanceof VaultError && e.code === 'wrong_password') {
+        setError('Wrong password');
+      } else {
+        logger.error(LogCategory.AUTH, 'Failed to unlock vault for backup', {
+          error: e instanceof Error ? e.message : String(e),
+        });
+        setError('Failed to decrypt recovery phrase');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const handleCopy = async () => {
     if (!mnemonic) return;
     try {
@@ -137,6 +174,10 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
     if (isPasskey) {
       setMnemonic(null);
       setPasskeyAttemptFailed(false);
+      setError(null);
+    } else if (isWebVault) {
+      // Drop the decrypted mnemonic; reveal re-prompts for the password.
+      setMnemonic(null);
       setError(null);
     }
   };
@@ -190,8 +231,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </button>
           )}
 
-          {/* Reveal button — mnemonic mode */}
-          {!isPasskey && !isRevealed && mnemonic && (
+          {/* Reveal: native or web-pre-migration (mnemonic already in memory). */}
+          {!isPasskey && !isWebVault && !isRevealed && mnemonic && (
             <button
               onClick={() => setIsRevealed(true)}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors"
@@ -204,10 +245,28 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </button>
           )}
 
-          {/* Mnemonic-mode error: passkey-mode errors are now folded
-              into the fallback card below, so this only renders for
-              non-passkey edge cases. */}
-          {error && !isPasskey && (
+          {/* Password-gated reveal: web non-passkey vault. */}
+          {!isPasskey && isWebVault && vaultExists && !isRevealed && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-6 space-y-4">
+              <div className="flex flex-col items-center gap-3">
+                <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
+                  <LockIcon size="xl" className="text-spark-primary" />
+                </div>
+                <span className="font-display font-semibold text-spark-text-primary">Enter password to reveal</span>
+                <span className="text-sm text-spark-text-muted">Your recovery phrase is encrypted</span>
+              </div>
+              <PasswordForm
+                mode="unlock"
+                onSubmit={handleRevealVault}
+                isLoading={isLoading}
+                error={error}
+              />
+            </div>
+          )}
+
+          {/* Generic error banner. Vault path uses PasswordForm's inline error;
+              passkey path uses the fallback card below. */}
+          {error && !isPasskey && !isWebVault && (
             <div className="bg-spark-error/10 border border-spark-error/30 rounded-xl p-4 text-center">
               <p className="text-spark-error text-sm">{error}</p>
             </div>
@@ -308,8 +367,9 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </div>
           )}
 
-          {/* No backup found (mnemonic mode only) */}
-          {!isPasskey && !mnemonic && (
+          {/* No backup found. Vault path waits for the probe to resolve. */}
+          {!isPasskey && !mnemonic && !isRevealed
+            && (!isWebVault || vaultExists === false) && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-8 text-center">
               <div className="w-16 h-16 rounded-2xl bg-spark-error/20 flex items-center justify-center mx-auto mb-4">
                 <WarningIcon size="xl" className="text-spark-error" />

--- a/src/pages/SetPasswordPage.tsx
+++ b/src/pages/SetPasswordPage.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import PageLayout from '../components/layout/PageLayout';
+import PasswordForm from '../components/PasswordForm';
+import { AlertCard } from '../components/AlertCard';
+import { PrimaryButton } from '../components/ui';
+import { ShieldCheckIcon, LockIcon } from '../components/Icons';
+
+interface SetPasswordPageProps {
+  onPasswordSet: (password: string) => void;
+  onBack?: () => void;
+  isLoading?: boolean;
+  error?: string | null;
+  /** 'create' = new wallet setup, 'migrate' = legacy localStorage migration. */
+  mode?: 'create' | 'migrate';
+}
+
+const FORM_ID = 'set-password-form';
+
+const SetPasswordPage: React.FC<SetPasswordPageProps> = ({
+  onPasswordSet,
+  onBack,
+  isLoading = false,
+  error = null,
+  mode = 'create',
+}) => {
+  const isMigrate = mode === 'migrate';
+  const Icon = isMigrate ? ShieldCheckIcon : LockIcon;
+  const title = isMigrate ? 'Secure Glow' : 'Set Password';
+  const heading = isMigrate ? 'Secure Glow' : 'Create a password';
+  const subtitle = isMigrate
+    ? 'Glow now encrypts your recovery phrase with a password. Set a password to continue.'
+    : "You'll need this password each time you open Glow.";
+
+  const footer = (
+    <div className="max-w-xl mx-auto">
+      <PrimaryButton type="submit" form={FORM_ID} disabled={isLoading} className="w-full">
+        {isLoading ? 'Encrypting...' : 'Set Password'}
+      </PrimaryButton>
+    </div>
+  );
+
+  return (
+    <PageLayout onBack={onBack} footer={footer} title={title} showHeader={!isMigrate}>
+      <div className={`max-w-xl mx-auto w-full flex flex-col space-y-4 ${isMigrate ? 'justify-center min-h-full' : 'flex-1 mt-6'}`}>
+        <div className="flex justify-center">
+          <div className="size-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
+            <Icon className="text-spark-primary" size="xl" />
+          </div>
+        </div>
+
+        <div className="text-center">
+          <h2 className="text-xl font-display font-bold text-spark-text-primary mb-2">{heading}</h2>
+          <p className="text-spark-text-secondary">{subtitle}</p>
+        </div>
+
+        <AlertCard variant="warning" title="Important">
+          <p className="text-spark-text-secondary text-sm">
+            If you forget this password, you can only recover your funds using your recovery phrase. There is no password reset.
+          </p>
+        </AlertCard>
+
+        <PasswordForm
+          formId={FORM_ID}
+          hideSubmit
+          mode="setup"
+          onSubmit={onPasswordSet}
+          isLoading={isLoading}
+          error={error}
+        />
+
+        <p className="text-xs text-spark-text-muted text-center">
+          Use your password manager to generate a strong password
+        </p>
+      </div>
+    </PageLayout>
+  );
+};
+
+export default SetPasswordPage;

--- a/src/pages/VaultUnlockPage.tsx
+++ b/src/pages/VaultUnlockPage.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import PasswordForm from '../components/PasswordForm';
+import { unlockVault, VaultError } from '../services/vault';
+
+interface VaultUnlockPageProps {
+  onUnlocked: (mnemonic: string) => void;
+}
+
+const VaultUnlockPage: React.FC<VaultUnlockPageProps> = ({ onUnlocked }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleUnlock = async (password: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const mnemonic = await unlockVault(password);
+      onUnlocked(mnemonic);
+    } catch (e) {
+      if (e instanceof VaultError && e.code === 'wrong_password') {
+        setError('Wrong password. Try again.');
+      } else {
+        setError('Failed to unlock Glow. Please try again.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-dvh h-dvh w-full flex flex-col bg-spark-surface relative">
+      <div className="flex-1 flex items-center justify-center p-6">
+        <div className="max-w-sm w-full space-y-8">
+          {/* Logo */}
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src="/assets/Glow_Logo.svg"
+              alt="Glow"
+              className="w-36 h-36"
+            />
+            <h1 className="font-display text-2xl font-bold text-spark-text-primary">
+              Welcome back
+            </h1>
+          </div>
+
+          <PasswordForm
+            mode="unlock"
+            onSubmit={handleUnlock}
+            isLoading={isLoading}
+            error={error}
+          />
+
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VaultUnlockPage;

--- a/src/services/vault.test.ts
+++ b/src/services/vault.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { createVault, unlockVault, hasVault, deleteVault, _resetForTesting, VaultError } from './vault';
+
+beforeEach(async () => {
+  // Wipe records, then drop the cached connection + the database
+  // itself so each test boots from scratch.
+  await deleteVault();
+  _resetForTesting();
+  const databases = await indexedDB.databases();
+  for (const db of databases) {
+    if (db.name) indexedDB.deleteDatabase(db.name);
+  }
+});
+
+describe('vault', () => {
+  const TEST_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+  const TEST_PASSWORD = 'testpassword123';
+
+  describe('createVault + unlockVault roundtrip', () => {
+    it('encrypts and decrypts mnemonic correctly', async () => {
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      const result = await unlockVault(TEST_PASSWORD);
+      expect(result).toBe(TEST_MNEMONIC);
+    });
+
+    it('works with 24-word mnemonic', async () => {
+      const mnemonic24 = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art';
+      await createVault(mnemonic24, TEST_PASSWORD);
+      const result = await unlockVault(TEST_PASSWORD);
+      expect(result).toBe(mnemonic24);
+    });
+
+    it('works with long passwords', async () => {
+      const longPassword = 'a'.repeat(256);
+      await createVault(TEST_MNEMONIC, longPassword);
+      const result = await unlockVault(longPassword);
+      expect(result).toBe(TEST_MNEMONIC);
+    });
+  });
+
+  describe('unlockVault error handling', () => {
+    it('throws wrong_password for incorrect password', async () => {
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      await expect(unlockVault('wrongpassword')).rejects.toThrow(VaultError);
+      try {
+        await unlockVault('wrongpassword');
+      } catch (e) {
+        expect(e).toBeInstanceOf(VaultError);
+        expect((e as VaultError).code).toBe('wrong_password');
+      }
+    });
+
+    it('throws no_vault when no vault exists', async () => {
+      await expect(unlockVault(TEST_PASSWORD)).rejects.toThrow(VaultError);
+      try {
+        await unlockVault(TEST_PASSWORD);
+      } catch (e) {
+        expect(e).toBeInstanceOf(VaultError);
+        expect((e as VaultError).code).toBe('no_vault');
+      }
+    });
+
+    it('throws wrong_password for empty password', async () => {
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      await expect(unlockVault('')).rejects.toThrow(VaultError);
+      try {
+        await unlockVault('');
+      } catch (e) {
+        expect(e).toBeInstanceOf(VaultError);
+        expect((e as VaultError).code).toBe('wrong_password');
+      }
+    });
+  });
+
+  describe('createVault validation', () => {
+    it('throws for empty password', async () => {
+      await expect(createVault(TEST_MNEMONIC, '')).rejects.toThrow(VaultError);
+      try {
+        await createVault(TEST_MNEMONIC, '');
+      } catch (e) {
+        expect(e).toBeInstanceOf(VaultError);
+        expect((e as VaultError).code).toBe('crypto_error');
+      }
+    });
+
+    it('throws if vault already exists', async () => {
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      await expect(createVault(TEST_MNEMONIC, 'anotherpassword')).rejects.toThrow(VaultError);
+      try {
+        await createVault(TEST_MNEMONIC, 'anotherpassword');
+      } catch (e) {
+        expect(e).toBeInstanceOf(VaultError);
+        expect((e as VaultError).code).toBe('crypto_error');
+        expect((e as VaultError).message).toContain('already exists');
+      }
+    });
+  });
+
+  describe('hasVault', () => {
+    it('returns false when no vault exists', async () => {
+      expect(await hasVault()).toBe(false);
+    });
+
+    it('returns true after vault is created', async () => {
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      expect(await hasVault()).toBe(true);
+    });
+
+    it('returns false after vault is deleted', async () => {
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      await deleteVault();
+      expect(await hasVault()).toBe(false);
+    });
+  });
+
+  describe('deleteVault', () => {
+    it('removes the vault', async () => {
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      await deleteVault();
+      expect(await hasVault()).toBe(false);
+    });
+
+    it('does not throw when no vault exists', async () => {
+      await expect(deleteVault()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('unique salt and IV per vault', () => {
+    it('produces different ciphertexts for same mnemonic and password', async () => {
+      // Create, unlock, delete, re-create — ciphertext should differ due to random salt+IV
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      const result1 = await unlockVault(TEST_PASSWORD);
+      await deleteVault();
+
+      await createVault(TEST_MNEMONIC, TEST_PASSWORD);
+      const result2 = await unlockVault(TEST_PASSWORD);
+
+      // Both should decrypt to the same mnemonic
+      expect(result1).toBe(TEST_MNEMONIC);
+      expect(result2).toBe(TEST_MNEMONIC);
+    });
+  });
+});

--- a/src/services/vault.ts
+++ b/src/services/vault.ts
@@ -1,0 +1,251 @@
+/**
+ * Password-encrypted seed vault.
+ *
+ * PBKDF2 (600k iters, SHA-256) derives an AES-GCM-256 key from the
+ * user's password; the mnemonic is encrypted under that key and the
+ * ciphertext is persisted in IndexedDB. Wrong password is detected
+ * via the AES-GCM authentication tag.
+ */
+
+const DB_NAME = 'glow-vault';
+const DB_VERSION = 1;
+const STORE_NAME = 'vault';
+const RECORD_ID = 'primary';
+
+const PBKDF2_ITERATIONS = 600_000;
+const PBKDF2_HASH = 'SHA-256';
+const SALT_BYTES = 16;
+const IV_BYTES = 12;
+
+export type VaultErrorCode = 'wrong_password' | 'no_vault' | 'storage_unavailable' | 'crypto_error';
+
+export class VaultError extends Error {
+  constructor(public code: VaultErrorCode, message: string) {
+    super(message);
+    this.name = 'VaultError';
+  }
+}
+
+interface VaultRecord {
+  id: typeof RECORD_ID;
+  version: 1;
+  tier: 'password';
+  ciphertext: ArrayBuffer;
+  iv: Uint8Array;
+  pbkdf2Salt: Uint8Array;
+}
+
+/**
+ * Encryption material handed off between flow steps. CryptoKey is
+ * non-extractable, so passing this around in component state is
+ * preferable to passing the plaintext password.
+ */
+export interface VaultKeyMaterial {
+  key: CryptoKey;
+  salt: Uint8Array;
+}
+
+// --- Storage availability ---
+
+/** True if IndexedDB and the Web Crypto subtle API are available. */
+export function isVaultStorageAvailable(): boolean {
+  return typeof indexedDB !== 'undefined' && typeof crypto?.subtle !== 'undefined';
+}
+
+function requireStorage(): void {
+  if (!isVaultStorageAvailable()) {
+    throw new VaultError('storage_unavailable', 'IndexedDB or Web Crypto is not available');
+  }
+}
+
+// --- IndexedDB ---
+
+let db: IDBDatabase | null = null;
+
+function openDatabase(): Promise<IDBDatabase> {
+  if (db) return Promise.resolve(db);
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => {
+      db = req.result;
+      db.onclose = () => { db = null; };
+      resolve(db);
+    };
+    req.onupgradeneeded = (e) => {
+      const database = (e.target as IDBOpenDBRequest).result;
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        database.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+  });
+}
+
+async function readRecord(): Promise<VaultRecord | null> {
+  const database = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const tx = database.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(RECORD_ID);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result ?? null);
+  });
+}
+
+/**
+ * Run a write op inside a single transaction, resolving on
+ * `tx.oncomplete` so the caller doesn't see "success" until the data
+ * is durable.
+ */
+async function withWriteTx(op: (store: IDBObjectStore) => void): Promise<void> {
+  const database = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const tx = database.transaction(STORE_NAME, 'readwrite');
+    op(tx.objectStore(STORE_NAME));
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error ?? new Error('Transaction aborted'));
+  });
+}
+
+// --- Crypto ---
+
+async function deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+  const passwordBytes = new TextEncoder().encode(password);
+  try {
+    const baseKey = await crypto.subtle.importKey('raw', passwordBytes, 'PBKDF2', false, ['deriveKey']);
+    return await crypto.subtle.deriveKey(
+      {
+        name: 'PBKDF2',
+        salt: salt as Uint8Array<ArrayBuffer>,
+        iterations: PBKDF2_ITERATIONS,
+        hash: PBKDF2_HASH,
+      },
+      baseKey,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt'],
+    );
+  } finally {
+    passwordBytes.fill(0);
+  }
+}
+
+// --- Public API ---
+
+/** True if a vault exists in IndexedDB. Never throws. */
+export async function hasVault(): Promise<boolean> {
+  if (!isVaultStorageAvailable()) return false;
+  try {
+    return (await readRecord()) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derive a non-extractable AES-GCM key from a password. Lets callers
+ * drop the plaintext password as soon as this resolves.
+ */
+export async function deriveVaultKey(password: string): Promise<VaultKeyMaterial> {
+  requireStorage();
+  if (!password) throw new VaultError('crypto_error', 'Password is required');
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const key = await deriveKey(password, salt);
+  return { key, salt };
+}
+
+/**
+ * Encrypt a mnemonic with already-derived material and persist.
+ * Use this when the password and mnemonic are captured on different
+ * screens, so the plaintext password never has to live in cross-screen state.
+ */
+export async function createVaultFromMaterial(
+  mnemonic: string,
+  material: VaultKeyMaterial,
+): Promise<void> {
+  requireStorage();
+  if (await readRecord()) {
+    throw new VaultError('crypto_error', 'Vault already exists. Delete the existing vault first.');
+  }
+  try {
+    const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+    const mnemonicBytes = new TextEncoder().encode(mnemonic);
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: iv as Uint8Array<ArrayBuffer> },
+      material.key,
+      mnemonicBytes,
+    );
+    // Best-effort scrub. JS strings stay reachable, the encoded bytes don't.
+    mnemonicBytes.fill(0);
+
+    const record: VaultRecord = {
+      id: RECORD_ID,
+      version: 1,
+      tier: 'password',
+      ciphertext,
+      iv,
+      pbkdf2Salt: material.salt,
+    };
+    await withWriteTx((store) => store.put(record));
+  } catch (e) {
+    throw new VaultError(
+      'crypto_error',
+      `Failed to create vault: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+/** Derive material from a password and persist a fresh vault in one call. */
+export async function createVault(mnemonic: string, password: string): Promise<void> {
+  await createVaultFromMaterial(mnemonic, await deriveVaultKey(password));
+}
+
+/** Decrypt the persisted vault. Wrong password surfaces as `wrong_password`. */
+export async function unlockVault(password: string): Promise<string> {
+  requireStorage();
+  if (!password) throw new VaultError('wrong_password', 'Wrong password');
+
+  const record = await readRecord();
+  if (!record) throw new VaultError('no_vault', 'No vault found');
+
+  try {
+    const key = await deriveKey(password, record.pbkdf2Salt);
+    const decrypted = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: record.iv as Uint8Array<ArrayBuffer> },
+      key,
+      record.ciphertext,
+    );
+    const decryptedBytes = new Uint8Array(decrypted);
+    const mnemonic = new TextDecoder().decode(decryptedBytes);
+    decryptedBytes.fill(0);
+    return mnemonic;
+  } catch (e) {
+    // AES-GCM tag failure on wrong password produces OperationError.
+    if (e instanceof Error && e.name === 'OperationError') {
+      throw new VaultError('wrong_password', 'Wrong password');
+    }
+    throw new VaultError(
+      'crypto_error',
+      `Failed to unlock vault: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+/** Wipe the vault. Never throws. */
+export async function deleteVault(): Promise<void> {
+  if (!isVaultStorageAvailable()) return;
+  try {
+    await withWriteTx((store) => store.clear());
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+/**
+ * Test-only: drop the cached connection so the next call reopens
+ * fresh. Pairs with `indexedDB.deleteDatabase` between test cases.
+ */
+export function _resetForTesting(): void {
+  db?.close();
+  db = null;
+}

--- a/src/utils/password.test.ts
+++ b/src/utils/password.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  PASSWORD_MAX_LENGTH,
+  isPasswordPwned,
+  passwordStrength,
+  sanitizePasswordInput,
+  validatePasswordSetup,
+  validatePasswordUnlock,
+} from './password';
+
+describe('sanitizePasswordInput', () => {
+  it('strips ASCII control characters (newline, tab, NUL, DEL)', () => {
+    expect(sanitizePasswordInput('foo\nbar\tbaz qux')).toBe('foobarbaz qux');
+  });
+
+  it('strips carriage returns from pasted CRLF lines', () => {
+    expect(sanitizePasswordInput('hunter2\r\n')).toBe('hunter2');
+  });
+
+  it('preserves spaces so the user can see them and the validator can reject', () => {
+    expect(sanitizePasswordInput('  hunter 22  ')).toBe('  hunter 22  ');
+  });
+
+  it('preserves unicode and symbols', () => {
+    expect(sanitizePasswordInput('p@ssw0rd!~$%^&*()_+£€π🦀')).toBe('p@ssw0rd!~$%^&*()_+£€π🦀');
+  });
+
+  it('caps at PASSWORD_MAX_LENGTH', () => {
+    const long = 'a'.repeat(PASSWORD_MAX_LENGTH + 100);
+    expect(sanitizePasswordInput(long)).toBe('a'.repeat(PASSWORD_MAX_LENGTH));
+  });
+
+  it('returns empty for an empty input', () => {
+    expect(sanitizePasswordInput('')).toBe('');
+  });
+});
+
+describe('validatePasswordSetup', () => {
+  it('accepts a 12-char password matching its confirm', () => {
+    expect(validatePasswordSetup('hunter22hunt!', 'hunter22hunt!')).toBeNull();
+  });
+
+  it('accepts unicode characters', () => {
+    const password = 'p@ssw0rd£€π🦀';
+    expect(validatePasswordSetup(password, password)).toBeNull();
+  });
+
+  it('rejects empty', () => {
+    expect(validatePasswordSetup('', '')).toBe('Password is required');
+  });
+
+  it('rejects passwords containing spaces', () => {
+    expect(validatePasswordSetup('hello world!', 'hello world!')).toBe('Password cannot contain spaces');
+    expect(validatePasswordSetup(' hunter22hunt', ' hunter22hunt')).toBe('Password cannot contain spaces');
+    expect(validatePasswordSetup('hunter22hunt ', 'hunter22hunt ')).toBe('Password cannot contain spaces');
+  });
+
+  it('rejects below the minimum length', () => {
+    expect(validatePasswordSetup('hunter22', 'hunter22')).toBe('Password must be at least 12 characters');
+  });
+
+  it('rejects above the maximum length', () => {
+    const long = 'a'.repeat(PASSWORD_MAX_LENGTH + 1);
+    expect(validatePasswordSetup(long, long)).toBe(`Password must be at most ${PASSWORD_MAX_LENGTH} characters`);
+  });
+
+  it('rejects mismatched confirm', () => {
+    expect(validatePasswordSetup('hunter22hunt!', 'hunter22hunt?')).toBe('Passwords do not match');
+  });
+});
+
+describe('validatePasswordUnlock', () => {
+  it('accepts any non-empty password (decrypt verifies)', () => {
+    expect(validatePasswordUnlock('a')).toBeNull();
+  });
+
+  it('rejects empty', () => {
+    expect(validatePasswordUnlock('')).toBe('Password is required');
+  });
+});
+
+describe('passwordStrength', () => {
+  it('returns weak for anything the setup validator rejects', () => {
+    expect(passwordStrength('')).toBe('weak');
+    expect(passwordStrength('short')).toBe('weak');
+    expect(passwordStrength('hello world Aa1!')).toBe('weak');
+  });
+
+  it('rates a 12-char lowercase password as medium', () => {
+    // 12 chars * log2(26) ~= 56 bits -> medium
+    expect(passwordStrength('aaaabbbbcccc')).toBe('medium');
+  });
+
+  it('rates a 12-char all-classes password as strong', () => {
+    // 12 chars * log2(94) ~= 78 bits -> strong
+    expect(passwordStrength('Aaaa1!Bccccd')).toBe('strong');
+  });
+
+  it('rates a 16-char mixed password as strong', () => {
+    expect(passwordStrength('Hunter2!Hunter22')).toBe('strong');
+  });
+});
+
+describe('isPasswordPwned', () => {
+  // SHA-1 of "password" = 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8.
+  // Prefix "5BAA6", suffix "1E4C9B93F3F0682250B6CF8331B7EE68FD8".
+  const KNOWN_SUFFIX = '1E4C9B93F3F0682250B6CF8331B7EE68FD8';
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when the suffix appears in the API response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(`AAAAA1234567890ABCDEF1234567890ABCDEF:9\n${KNOWN_SUFFIX}:42\n`),
+    );
+    expect(await isPasswordPwned('password')).toBe(true);
+  });
+
+  it('returns false when the suffix is absent', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('AAAAA1234567890ABCDEF1234567890ABCDEF:9\n'),
+    );
+    expect(await isPasswordPwned('password')).toBe(false);
+  });
+
+  it('returns false on a non-2xx response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('', { status: 503 }));
+    expect(await isPasswordPwned('password')).toBe(false);
+  });
+
+  it('returns false when fetch rejects', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('network down'));
+    expect(await isPasswordPwned('password')).toBe(false);
+  });
+});

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,114 @@
+/**
+ * Password rules for the encrypted seed vault. One source of truth so
+ * setup, unlock, and input sanitization all agree.
+ */
+
+export const PASSWORD_MIN_LENGTH = 12;
+export const PASSWORD_MAX_LENGTH = 32;
+
+export function sanitizePasswordInput(raw: string): string {
+  let out = '';
+  for (let i = 0; i < raw.length && out.length < PASSWORD_MAX_LENGTH; i++) {
+    const code = raw.charCodeAt(i);
+    if (code < 0x20 || code === 0x7F) continue;
+    out += raw[i];
+  }
+  return out;
+}
+
+/** Setup-time rules. Stricter than unlock so new vaults start clean. */
+export function validatePasswordSetup(password: string, confirm: string): string | null {
+  if (password.length === 0) return 'Password is required';
+  if (/\s/.test(password)) return 'Password cannot contain spaces';
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    return `Password must be at least ${PASSWORD_MIN_LENGTH} characters`;
+  }
+  if (password.length > PASSWORD_MAX_LENGTH) {
+    return `Password must be at most ${PASSWORD_MAX_LENGTH} characters`;
+  }
+  if (password !== confirm) return 'Passwords do not match';
+  return null;
+}
+
+/**
+ * Unlock-time rules. Minimal: non-empty only. We never reject an
+ * existing password here, the AES-GCM tag check is the source of
+ * truth for "is this the right password?".
+ */
+export function validatePasswordUnlock(password: string): string | null {
+  if (password.length === 0) return 'Password is required';
+  return null;
+}
+
+// ---------- Strength rating ----------
+
+export type PasswordStrength = 'weak' | 'medium' | 'strong';
+
+const SYMBOL_POOL_SIZE = 32; // common ASCII punctuation
+
+/** Union of character classes the password actually uses. */
+function poolSize(password: string): number {
+  let size = 0;
+  if (/[a-z]/.test(password)) size += 26;
+  if (/[A-Z]/.test(password)) size += 26;
+  if (/[0-9]/.test(password)) size += 10;
+  if (/ /.test(password)) size += 1;
+  if (/[^A-Za-z0-9 ]/.test(password)) size += SYMBOL_POOL_SIZE;
+  return size;
+}
+
+/** Shannon entropy of a brute-force search over `poolSize(password)`. */
+function entropyBits(password: string): number {
+  const pool = poolSize(password);
+  return pool === 0 ? 0 : password.length * Math.log2(pool);
+}
+
+/**
+ * Strength bucket. Anything the setup validator would reject is
+ * automatically weak: we don't reward malformed inputs with a
+ * higher score even if they're long.
+ */
+export function passwordStrength(password: string): PasswordStrength {
+  if (validatePasswordSetup(password, password) !== null) return 'weak';
+  const bits = entropyBits(password);
+  if (bits >= 70) return 'strong'; // ~370 yr at 1e11 g/s
+  if (bits >= 50) return 'medium'; // ~3 hr at 1e11 g/s
+  return 'weak';
+}
+
+// ---------- Have I Been Pwned ----------
+
+const HIBP_RANGE_URL = 'https://api.pwnedpasswords.com/range/';
+
+async function sha1HexUpper(text: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0').toUpperCase())
+    .join('');
+}
+
+/**
+ * Returns true only when HIBP positively confirms the password is in
+ * a breach corpus. Any failure (network, non-200, parse, missing
+ * crypto.subtle) returns false so a transient outage can't block
+ * onboarding. Uses k-anonymity: only the first 5 chars of the
+ * SHA-1 prefix leave the device.
+ */
+export async function isPasswordPwned(password: string): Promise<boolean> {
+  if (typeof crypto?.subtle === 'undefined') return false;
+  try {
+    const hash = await sha1HexUpper(password);
+    const prefix = hash.slice(0, 5);
+    const suffix = hash.slice(5);
+    const res = await fetch(`${HIBP_RANGE_URL}${prefix}`);
+    if (!res.ok) return false;
+    const text = await res.text();
+    for (const line of text.split('\n')) {
+      const candidate = line.split(':')[0]?.trim();
+      if (candidate === suffix) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #111 

This PR implements password-encrypted seed following the [Glow-Web: Password-Encrypted Seed — Fallback Auth Spec](https://claude.ai/public/artifacts/e672b0a7-3f8d-47ea-a37d-addb7ffd6d89).

## Summary

- **Password-encrypted vault**: Adds a PBKDF2 (600k iterations) + AES-GCM-256 vault service that encrypts the mnemonic at rest in `IndexedDB`, replacing plain `localStorage` storage.
  - See `src/services/vault.ts`.
- **Full auth flow**: New `SetPasswordPage`, `UnlockPage`, and migration flow for existing users. Passkey remains the default when PRF is available; recovery phrase flow is accessible via toggle or 5-tap logo gateway.
- **UI polish**: Shake animation on password errors, autofill dark-theme overrides, `FormError` fade transitions and `PasswordForm` external submit support.

## Test plan

- [x] **New user flow**: passkey button shown by default (PRF available), "Use Recovery Phrase Instead" toggles to mnemonic flow
- [x] **New user mnemonic flow**: Get Started → set password → recovery phrase → wallet
- [x] **Restore flow**: Restore from Backup → enter valid mnemonic → set password → wallet
- [x] **Unlock flow**: returning user sees `UnlockPage`, enters password to decrypt vault
- [x] **Migration flow**: existing `localStorage` user sees "Secure Glow" page, sets password, vault created
- [ ] No PRF device (e.g. Firefox): always shows mnemonic flow, no passkey option
- [x] **Regression Test**: 5-tap logo easter egg toggles between passkey and mnemonic views
- [ ] **Regression Test**: In the same session, create or restore via passkey, then log out and switch to password-encrypted mode (and vice versa); verify no unexpected behavior occurs