### PR TITLE
copy: replace user-facing "wallet" with contextual alternatives

### DIFF
--- a/src/features/send/workflows/LnurlAuthWorkflow.tsx
+++ b/src/features/send/workflows/LnurlAuthWorkflow.tsx
@@ -72,7 +72,7 @@ const LnurlAuthWorkflow: React.FC<LnurlAuthWorkflowProps> = ({ parsed, onBack, o
           <div>
             <p className="text-spark-text-primary font-medium">{getActionText()}</p>
             <p className="text-spark-text-muted text-sm">
-              Your wallet will sign a message to prove your identity without sharing any personal information.
+              Glow will sign a message to prove your identity without sharing any personal information.
             </p>
           </div>
         </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,7 +36,7 @@ async function init() {
     document.getElementById('root')!.innerHTML = `
       <div style="color: #ef4444; padding: 20px; text-align: center; background: #0a0a0f; min-height: 100vh; display: flex; flex-direction: column; justify-content: center;">
         <h2>Failed to load application</h2>
-        <p>There was an error initializing the wallet. Please refresh and try again.</p>
+        <p>There was an error starting Glow. Please refresh and try again.</p>
       </div>
     `;
   }

--- a/src/pages/GeneratePage.tsx
+++ b/src/pages/GeneratePage.tsx
@@ -90,7 +90,7 @@ const GeneratePage: React.FC<GeneratePageProps> = ({
         </div>
 
         <p className="text-spark-text-secondary text-center mb-6">
-          Write down these words in order. This is your only backup to recover your wallet.
+          Write down these words in order. This is your only backup to recover your funds.
         </p>
 
         {/* Mnemonic grid */}


### PR DESCRIPTION
## Summary

- Replace "wallet" with "Glow" in user-facing error messages and descriptions
- Affects: LNURL auth workflow, app initialization error, and seed generation page

## Test plan

- [x] LNURL auth screen says "Glow will sign a message..." instead of "Your wallet will sign..."
- [x] App crash screen says "...error starting Glow" instead of "...error initializing the wallet"
- [x] Generate page says "...to recover your funds" instead of "...to recover your wallet"