### PR TITLE
feat: passkey unlock screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,9 @@ import UnlockPage from './pages/UnlockPage';
 import SettingsPage from './pages/SettingsPage';
 import FiatCurrenciesPage from './pages/FiatCurrenciesPage';
 import { useIOSViewportFix } from './hooks/useIOSViewportFix';
-import { isPasskeyMode } from './services/passkeyService';
 import type { Seed, Wallet } from '@breeztech/breez-sdk-spark';
 
-type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'passkey';
+type Screen = 'home' | 'unlock' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'passkey';
 
 const AppContent: React.FC = () => {
   const [currentScreen, setCurrentScreen] = useState<Screen>('home');
@@ -34,9 +33,16 @@ const AppContent: React.FC = () => {
 
   const sdk = useBreezSdk(showToast);
 
-  // Auto-navigate to wallet when SDK reconnects from saved mnemonic
+  // Auto-navigate to unlock screen for returning passkey users
   useEffect(() => {
-    if (sdk.isConnected && currentScreen === 'home') {
+    if (sdk.needsPasskeyUnlock && currentScreen === 'home') {
+      setCurrentScreen('unlock');
+    }
+  }, [sdk.needsPasskeyUnlock, currentScreen]);
+
+  // Auto-navigate to wallet when SDK connects
+  useEffect(() => {
+    if (sdk.isConnected && (currentScreen === 'home' || currentScreen === 'unlock')) {
       setCurrentScreen('wallet');
     }
   }, [sdk.isConnected, currentScreen]);
@@ -82,10 +88,10 @@ const AppContent: React.FC = () => {
     }
 
     switch (currentScreen) {
+      case 'unlock':
+        return <UnlockPage onUnlock={handlePasskeyUnlock} onLogout={handleLogout} />;
+
       case 'home':
-        if (isPasskeyMode()) {
-          return <UnlockPage onUnlock={handlePasskeyUnlock} onLogout={handleLogout} />;
-        }
         return (
           <HomePage
             onRestoreWallet={() => setCurrentScreen('restore')}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,10 +15,12 @@ import GeneratePage from './pages/GeneratePage';
 import GetRefundPage from './pages/GetRefundPage';
 import BackupPage from './pages/BackupPage';
 import PasskeyPage from './pages/PasskeyPage';
+import UnlockPage from './pages/UnlockPage';
 import SettingsPage from './pages/SettingsPage';
 import FiatCurrenciesPage from './pages/FiatCurrenciesPage';
 import { useIOSViewportFix } from './hooks/useIOSViewportFix';
-import type { Seed } from '@breeztech/breez-sdk-spark';
+import { isPasskeyMode } from './services/passkeyService';
+import type { Seed, Wallet } from '@breeztech/breez-sdk-spark';
 
 type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'passkey';
 
@@ -60,6 +62,10 @@ const AppContent: React.FC = () => {
     setCurrentScreen('wallet');
   }, []);
 
+  const handlePasskeyUnlock = async (wallet: Wallet) => {
+    await sdk.connectWallet(wallet.seed, false, wallet.label);
+  };
+
   const handleLogout = async () => {
     setCurrentScreen('home');
     await sdk.handleLogout();
@@ -77,6 +83,9 @@ const AppContent: React.FC = () => {
 
     switch (currentScreen) {
       case 'home':
+        if (isPasskeyMode()) {
+          return <UnlockPage onUnlock={handlePasskeyUnlock} onLogout={handleLogout} />;
+        }
         return (
           <HomePage
             onRestoreWallet={() => setCurrentScreen('restore')}

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -89,7 +89,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
     },
     {
       icon: <LogoutIcon />,
-      label: 'Logout',
+      label: 'Log out',
       onClick: () => { setShowLogoutConfirm(true); }
     }
   ];
@@ -244,7 +244,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
                       onClick={handleConfirmLogout}
                       className="flex-1 px-4 py-3 bg-spark-error text-white rounded-xl font-medium hover:bg-spark-error/90 transition-colors"
                     >
-                      Logout
+                      Log out
                     </button>
                   </div>
                 </Transition.Child>

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -66,6 +66,7 @@ export interface BreezSdkState {
   hasRejectedDeposits: boolean;
   celebrationAmount: number | null;
   prfAvailable: boolean;
+  needsPasskeyUnlock: boolean;
 }
 
 export interface BreezSdkActions {
@@ -100,6 +101,7 @@ export function useBreezSdk(
   const [hasRejectedDeposits, setHasRejectedDeposits] = useState(false);
   const [celebrationAmount, setCelebrationAmount] = useState<number | null>(null);
   const [prfAvailable, setPrfAvailable] = useState(false);
+  const [needsPasskeyUnlock, setNeedsPasskeyUnlock] = useState(false);
 
   // Refs
   const isInitialLoadRef = useRef(true);
@@ -259,6 +261,7 @@ export function useBreezSdk(
       setWalletInfo(info);
       setTransactions(txns.payments);
 
+      setNeedsPasskeyUnlock(false);
       setIsConnected(true);
 
       try {
@@ -372,6 +375,7 @@ export function useBreezSdk(
         }
       } else if (isPasskeyMode()) {
         // Don't auto-prompt — let the UnlockPage handle user-initiated auth
+        setNeedsPasskeyUnlock(true);
         setIsLoading(false);
       } else {
         setIsLoading(false);
@@ -436,6 +440,7 @@ export function useBreezSdk(
     hasRejectedDeposits,
     celebrationAmount,
     prfAvailable,
+    needsPasskeyUnlock,
     // Actions
     connectWallet,
     refreshWalletData,

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -23,7 +23,6 @@ import {
   isPasskeyMode,
   setPasskeyMode,
   clearPasskeyMode,
-  getWallet,
 } from '../services/passkeyService';
 
 
@@ -372,27 +371,8 @@ export function useBreezSdk(
           setIsLoading(false);
         }
       } else if (isPasskeyMode()) {
-        setIsLoading(true);
-        let wallet;
-        try {
-          wallet = await getWallet();
-        } catch (e) {
-          logger.error(LogCategory.AUTH, 'Passkey authentication failed', { error: formatError(e) });
-          if (e instanceof DOMException && e.name === 'NotAllowedError') {
-            clearPasskeyMode();
-          }
-          setError('Failed to authenticate with passkey. Please try again.');
-          setIsLoading(false);
-        }
-        if (wallet) {
-          try {
-            await connectWallet(wallet.seed, false, wallet.label);
-          } catch (e) {
-            logger.error(LogCategory.SDK, 'Failed to connect after passkey auth', { error: formatError(e) });
-            setError('Failed to connect wallet. Please try again.');
-            setIsLoading(false);
-          }
-        }
+        // Don't auto-prompt — let the UnlockPage handle user-initiated auth
+        setIsLoading(false);
       } else {
         setIsLoading(false);
       }

--- a/src/pages/UnlockPage.tsx
+++ b/src/pages/UnlockPage.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import type { Wallet } from '@breeztech/breez-sdk-spark';
+import { getWallet } from '../services/passkeyService';
+
+
+interface UnlockPageProps {
+  onUnlock: (wallet: Wallet) => void;
+  onLogout: () => void;
+}
+
+const UnlockPage: React.FC<UnlockPageProps> = ({ onUnlock, onLogout }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleUnlock = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const wallet = await getWallet();
+      onUnlock(wallet);
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'NotAllowedError') {
+        setError('No passkey found or authentication was cancelled.');
+      } else {
+        setError('Failed to authenticate. Please try again.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-dvh h-dvh w-full flex flex-col bg-spark-surface relative">
+      <div className="flex-1 flex items-center justify-center p-6">
+        <div className="max-w-sm w-full space-y-8">
+          {/* Logo */}
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src="/assets/Glow_Logo.png"
+              alt="Glow"
+              className="w-36 h-36"
+            />
+            <h1 className="font-display text-2xl font-bold text-spark-text-primary">
+              Welcome back
+            </h1>
+          </div>
+
+          {/* Passkey button */}
+          <div className="space-y-4">
+            <button
+              onClick={handleUnlock}
+              disabled={isLoading}
+              className="button w-full py-4 text-base tracking-wider flex items-center justify-center gap-2"
+            >
+              {isLoading ? 'Unlocking...' : 'Unlock'}
+            </button>
+
+            <p className={`text-sm text-center min-h-[2.5rem] flex items-center justify-center ${error ? 'text-spark-error' : 'text-transparent'}`}>
+              {error ?? '\u00A0'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="pb-8 flex justify-center">
+        <button
+          onClick={onLogout}
+          className={`text-xs py-2 transition-colors ${error ? 'text-spark-text-muted hover:text-spark-text-secondary' : 'text-transparent pointer-events-none'}`}
+          tabIndex={error ? 0 : -1}
+          aria-hidden={!error}
+        >
+          Log out
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default UnlockPage;


### PR DESCRIPTION
**Proposal** built on top of #145.

Shows a "Welcome back" unlock screen for returning passkey users instead of auto-triggering a WebAuthn prompt on page load. Passkey auth is now always user-initiated.

Cookie deletion is already handled by #145 (`passkeyLabel` is cleared). However, cache clearing and passkey deletion are not silently detectable. WebAuthn has no API to check if a credential still exists without prompting. This screen sidesteps that by letting the user initiate auth. On failure, a "Log out" link appears.

Inspired by the upcoming session unlock flow in the password-encryption branch.

**Known limitation:** If the user has multiple passkeys registered for the same RP (relying party), the browser's credential picker shows all of them. Picking a different passkey than the original derives a different seed, connecting to a different label. This is a pre-existing limitation, not introduced by this PR. Fixing this would require storing `credentialId` at registration and passing it in `allowCredentials`, which is a broader architectural change to the passkey system.