### PR TITLE
Amount input validation and shared input handling across send, buy, and receive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { WalletProvider } from './contexts/WalletContext';
+import { WalletProvider, WalletInfoProvider } from './contexts/WalletContext';
 import LoadingSpinner from './components/LoadingSpinner';
 import PaymentReceivedCelebration from './components/PaymentReceivedCelebration';
 import InstallPrompt from './components/InstallPrompt';
@@ -214,21 +214,23 @@ const AppContent: React.FC = () => {
 
   return (
     <WalletProvider client={sdk.sdk} isConnected={sdk.isConnected} subscribeToSdkEvents={sdk.subscribeToSdkEvents}>
-      <FiatDataProvider>
-        <StableBalanceProvider>
-          <StableBalanceFormatterBridge formatterRef={formatPaymentAmountRef} />
-          <ContactsProvider>
-            {renderCurrentScreen()}
-          </ContactsProvider>
-          {sdk.celebrationPayment !== null && (
-            <PaymentReceivedCelebration
-              payment={sdk.celebrationPayment}
-              onClose={sdk.dismissCelebration}
-            />
-          )}
-          <InstallPrompt />
-        </StableBalanceProvider>
-      </FiatDataProvider>
+      <WalletInfoProvider walletInfo={sdk.walletInfo}>
+        <FiatDataProvider>
+          <StableBalanceProvider>
+            <StableBalanceFormatterBridge formatterRef={formatPaymentAmountRef} />
+            <ContactsProvider>
+              {renderCurrentScreen()}
+            </ContactsProvider>
+            {sdk.celebrationPayment !== null && (
+              <PaymentReceivedCelebration
+                payment={sdk.celebrationPayment}
+                onClose={sdk.dismissCelebration}
+              />
+            )}
+            <InstallPrompt />
+          </StableBalanceProvider>
+        </FiatDataProvider>
+      </WalletInfoProvider>
     </WalletProvider>
   );
 };

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useMemo } from 'react';
-import type { BreezSdk } from '@breeztech/breez-sdk-spark';
+import type { BreezSdk, GetInfoResponse } from '@breeztech/breez-sdk-spark';
 import type { SdkEventHandler, SdkEventUnsubscribe } from '../hooks/useBreezSdk';
 
 type SubscribeToSdkEvents = (handler: SdkEventHandler) => SdkEventUnsubscribe;
@@ -18,6 +18,10 @@ const WalletContext = createContext<WalletContextValue>({
   subscribeToSdkEvents: noopSubscribe,
 });
 
+// Live wallet info (balance, token balances) lives in its own context so that
+// SDK consumers (`useWallet`, `useSdkEvents`) don't re-render on every sync.
+const WalletInfoContext = createContext<GetInfoResponse | null>(null);
+
 export const WalletProvider: React.FC<{
   children: React.ReactNode;
   client: BreezSdk | null;
@@ -29,6 +33,19 @@ export const WalletProvider: React.FC<{
     [client, isConnected, subscribeToSdkEvents]
   );
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
+};
+
+/**
+ * Provides the latest `walletInfo` (balance, token balances) to descendants.
+ * The value is owned by `useBreezSdk`, which auto-refreshes it on `synced`,
+ * `paymentSucceeded`, and `claimedDeposits` events. Consumers should read via
+ * `useWalletInfo()` and re-render on each refresh.
+ */
+export const WalletInfoProvider: React.FC<{
+  children: React.ReactNode;
+  walletInfo: GetInfoResponse | null;
+}> = ({ children, walletInfo }) => {
+  return <WalletInfoContext.Provider value={walletInfo}>{children}</WalletInfoContext.Provider>;
 };
 
 /**
@@ -59,4 +76,14 @@ export const useWalletConnection = () => {
  */
 export const useSdkEvents = (): SubscribeToSdkEvents => {
   return useContext(WalletContext).subscribeToSdkEvents;
+};
+
+/**
+ * Returns the latest wallet info (balance, token balances) from the global
+ * SDK state. Auto-updates on SDK events — callers should not snapshot the
+ * value into local state for validation. Returns null until the wallet has
+ * loaded.
+ */
+export const useWalletInfo = (): GetInfoResponse | null => {
+  return useContext(WalletInfoContext);
 };

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -140,7 +140,7 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
                     className="w-full p-4 pr-16 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     data-testid="cashapp-amount-input"
                   />
-                  {buy.hasTokenConfig && buy.tokenConfig && (
+                  {buy.isStableBalanceActive && buy.tokenConfig && (
                     <CurrencySwitcher
                       isTokenMode={buy.isTokenMode}
                       tokenSymbol={buy.tokenConfig.symbol}

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -54,7 +54,8 @@ export interface UseBuyBitcoinReturn {
   quickAmounts: number[];
   // Token mode
   isTokenMode: boolean;
-  hasTokenConfig: boolean;
+  /** True when stable balance is currently active — gates the CurrencySwitcher. */
+  isStableBalanceActive: boolean;
   tokenConfig: TokenDisplayConfig | null;
   // Actions
   selectProvider: (provider: BuyBitcoinProvider) => Promise<void>;
@@ -88,7 +89,6 @@ export function useBuyBitcoin({
     setIsTokenMode,
     toggleDenomination,
     config: tokenConfig,
-    hasTokenConfig,
     amountSats,
     btcFiatRate,
   } = input;
@@ -139,14 +139,24 @@ export function useBuyBitcoin({
     if (!isOpen) {
       setStep('select');
       setRedirectingProvider(null);
-      setIsTokenMode(stableBalance.isActive && hasTokenConfig);
+      setIsTokenMode(stableBalance.isActive);
       resetAmount();
       setCashAppUrl(null);
       setGeneratedAmountSats(null);
       setIsGenerating(false);
       setError(null);
     }
-  }, [isOpen, stableBalance.isActive, hasTokenConfig, setIsTokenMode, resetAmount]);
+  }, [isOpen, stableBalance.isActive, setIsTokenMode, resetAmount]);
+
+  // Force the input back to sats mode when stable balance is deactivated
+  // while the dialog is open (e.g. user toggled it off in another view).
+  useEffect(() => {
+    if (!stableBalance.isActive && isTokenMode) {
+      setIsTokenMode(false);
+      resetAmount();
+      setError(null);
+    }
+  }, [stableBalance.isActive, isTokenMode, setIsTokenMode, resetAmount]);
 
   const selectProvider = useCallback(
     async (provider: BuyBitcoinProvider) => {
@@ -276,7 +286,7 @@ export function useBuyBitcoin({
     isMobile,
     quickAmounts,
     isTokenMode,
-    hasTokenConfig,
+    isStableBalanceActive: stableBalance.isActive,
     tokenConfig,
     selectProvider,
     setAmount: setAmountWithErrorClear,

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '../../../contexts/WalletContext';
-import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useInvoicePaid } from '../../../hooks/useInvoicePaid';
 import { useAmountInput } from '../../../hooks/useAmountInput';
@@ -75,7 +74,6 @@ export function useBuyBitcoin({
   onInvoicePaid,
 }: UseBuyBitcoinOptions): UseBuyBitcoinReturn {
   const sdk = useWallet();
-  const stableBalance = useStableBalance();
   const platform = usePlatform();
   const isMobile = platform.isIOS || platform.isAndroid;
 
@@ -88,6 +86,7 @@ export function useBuyBitcoin({
     isTokenMode,
     setIsTokenMode,
     toggleDenomination,
+    isStableBalanceActive,
     config: tokenConfig,
     amountSats,
     btcFiatRate,
@@ -134,29 +133,20 @@ export function useBuyBitcoin({
     [isOpen, network]
   );
 
-  // Reset local state whenever the dialog closes.
+  // Reset local state whenever the dialog closes. Note: useAmountInput
+  // already handles auto-reset when stable balance is deactivated mid-flow.
   useEffect(() => {
     if (!isOpen) {
       setStep('select');
       setRedirectingProvider(null);
-      setIsTokenMode(stableBalance.isActive);
+      setIsTokenMode(isStableBalanceActive);
       resetAmount();
       setCashAppUrl(null);
       setGeneratedAmountSats(null);
       setIsGenerating(false);
       setError(null);
     }
-  }, [isOpen, stableBalance.isActive, setIsTokenMode, resetAmount]);
-
-  // Force the input back to sats mode when stable balance is deactivated
-  // while the dialog is open (e.g. user toggled it off in another view).
-  useEffect(() => {
-    if (!stableBalance.isActive && isTokenMode) {
-      setIsTokenMode(false);
-      resetAmount();
-      setError(null);
-    }
-  }, [stableBalance.isActive, isTokenMode, setIsTokenMode, resetAmount]);
+  }, [isOpen, isStableBalanceActive, setIsTokenMode, resetAmount]);
 
   const selectProvider = useCallback(
     async (provider: BuyBitcoinProvider) => {
@@ -286,7 +276,7 @@ export function useBuyBitcoin({
     isMobile,
     quickAmounts,
     isTokenMode,
-    isStableBalanceActive: stableBalance.isActive,
+    isStableBalanceActive,
     tokenConfig,
     selectProvider,
     setAmount: setAmountWithErrorClear,

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -4,13 +4,10 @@ import { useWallet } from '../../../contexts/WalletContext';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useInvoicePaid } from '../../../hooks/useInvoicePaid';
+import { useAmountInput } from '../../../hooks/useAmountInput';
 import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
-import {
-  fiatToSats,
-  sanitizeTokenInput,
-  type TokenDisplayConfig,
-} from '../../../utils/tokenFormatting';
+import { type TokenDisplayConfig } from '../../../utils/tokenFormatting';
 import {
   getBuyProviderSettings,
   filterProvidersByNetwork,
@@ -76,13 +73,22 @@ export function useBuyBitcoin({
   const platform = usePlatform();
   const isMobile = platform.isIOS || platform.isAndroid;
 
-  const hasTokenConfig = !!stableBalance.displayConfig;
-  const tokenConfig = stableBalance.displayConfig;
+  const input = useAmountInput();
+  const {
+    amountInput,
+    setAmount,
+    setAmountInput,
+    resetAmount,
+    isTokenMode,
+    setIsTokenMode,
+    toggleDenomination,
+    config: tokenConfig,
+    hasTokenConfig,
+    amountSats,
+  } = input;
 
   const [step, setStep] = useState<BuyStep>('select');
   const [redirectingProvider, setRedirectingProvider] = useState<BuyBitcoinProvider | null>(null);
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
-  const [amountInput, setAmountInput] = useState('');
   const [cashAppUrl, setCashAppUrl] = useState<string | null>(null);
   const [generatedAmountSats, setGeneratedAmountSats] = useState<number | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -101,13 +107,13 @@ export function useBuyBitcoin({
       setStep('select');
       setRedirectingProvider(null);
       setIsTokenMode(stableBalance.isActive && hasTokenConfig);
-      setAmountInput('');
+      resetAmount();
       setCashAppUrl(null);
       setGeneratedAmountSats(null);
       setIsGenerating(false);
       setError(null);
     }
-  }, [isOpen, stableBalance.isActive, hasTokenConfig]);
+  }, [isOpen, stableBalance.isActive, hasTokenConfig, setIsTokenMode, resetAmount]);
 
   const selectProvider = useCallback(
     async (provider: BuyBitcoinProvider) => {
@@ -127,44 +133,26 @@ export function useBuyBitcoin({
     [onSelectRedirectProvider]
   );
 
-  const setAmount = useCallback(
+  const setAmountWithErrorClear = useCallback(
     (value: string) => {
-      if (isTokenMode && tokenConfig) {
-        const sanitized = sanitizeTokenInput(value, tokenConfig.fractionSize);
-        if (sanitized !== null) {
-          setAmountInput(sanitized);
-          setError((prev) => (prev ? null : prev));
-        }
-      } else {
-        setAmountInput(value.replace(/[^0-9]/g, ''));
-        setError((prev) => (prev ? null : prev));
-      }
+      setAmount(value);
+      setError((prev) => (prev ? null : prev));
     },
-    [isTokenMode, tokenConfig]
+    [setAmount],
   );
 
-  const setQuickAmount = useCallback((value: number) => {
-    setAmountInput(String(value));
-    setError(null);
-  }, []);
+  const setQuickAmount = useCallback(
+    (value: number) => {
+      setAmountInput(String(value));
+      setError(null);
+    },
+    [setAmountInput],
+  );
 
-  const toggleDenomination = useCallback(() => {
-    setIsTokenMode((prev) => !prev);
-    setAmountInput('');
+  const toggleDenominationWithErrorClear = useCallback(() => {
+    toggleDenomination();
     setError(null);
-  }, []);
-
-  // Convert the input string to sats based on the current mode.
-  const amountSats = useMemo(() => {
-    if (amountInput === '') return 0;
-    if (isTokenMode && tokenConfig && stableBalance.btcFiatRate > 0) {
-      const fiat = parseFloat(amountInput);
-      if (!fiat || fiat <= 0) return 0;
-      return fiatToSats(fiat, stableBalance.btcFiatRate);
-    }
-    const sats = parseInt(amountInput, 10);
-    return Number.isFinite(sats) ? sats : 0;
-  }, [amountInput, isTokenMode, tokenConfig, stableBalance.btcFiatRate]);
+  }, [toggleDenomination]);
 
   const generate = useCallback(async () => {
     if (!amountSats || amountSats < MIN_CASH_APP_SATS) {
@@ -213,9 +201,9 @@ export function useBuyBitcoin({
 
   const goBackToSelect = useCallback(() => {
     setStep('select');
-    setAmountInput('');
+    resetAmount();
     setError(null);
-  }, []);
+  }, [resetAmount]);
 
   const goBackToAmount = useCallback(() => {
     setStep('amount');
@@ -242,9 +230,9 @@ export function useBuyBitcoin({
     hasTokenConfig,
     tokenConfig,
     selectProvider,
-    setAmount,
+    setAmount: setAmountWithErrorClear,
     setQuickAmount,
-    toggleDenomination,
+    toggleDenomination: toggleDenominationWithErrorClear,
     generate,
     goBackToSelect,
     goBackToAmount,

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -19,6 +19,10 @@ export type BuyStep = 'select' | 'amount' | 'qr';
 const CASH_APP_QUICK_AMOUNTS_SATS = [10000, 50000, 100000];
 const CASH_APP_QUICK_AMOUNTS_TOKEN = [5, 10, 25];
 const MIN_CASH_APP_SATS = 1;
+// Cash App caps verified-user Bitcoin buys at roughly $100k/week (~$10k/day).
+// Using the weekly ceiling as a generous client-side guardrail — anything above
+// this is sure to be rejected by Cash App, so we fail fast with a clear error.
+const CASH_APP_MAX_USD = 100_000;
 
 export interface UseBuyBitcoinOptions {
   /** Whether the dialog is open — used to reset state when closed. */
@@ -101,6 +105,20 @@ export function useBuyBitcoin({
     return projectedSats > Number.MAX_SAFE_INTEGER;
   }, [amountInput, amountSats, isTokenMode, btcFiatRate]);
 
+  // Cash App's own purchase ceiling — converted to sats at the current rate so
+  // we can compare against `amountSats` regardless of which input mode the
+  // user is in. Skipped while the rate hasn't loaded.
+  const cashAppMaxSats = useMemo(() => {
+    if (!btcFiatRate || btcFiatRate <= 0) return null;
+    return Math.floor((CASH_APP_MAX_USD * 100_000_000) / btcFiatRate);
+  }, [btcFiatRate]);
+
+  const exceedsCashAppLimit = useMemo(() => {
+    if (cashAppMaxSats === null) return false;
+    if (amountSats <= 0) return false;
+    return amountSats > cashAppMaxSats;
+  }, [amountSats, cashAppMaxSats]);
+
   const [step, setStep] = useState<BuyStep>('select');
   const [redirectingProvider, setRedirectingProvider] = useState<BuyBitcoinProvider | null>(null);
   const [cashAppUrl, setCashAppUrl] = useState<string | null>(null);
@@ -173,6 +191,10 @@ export function useBuyBitcoin({
       setError(`Amount must be at least ₿${MIN_CASH_APP_SATS.toLocaleString()}`);
       return;
     }
+    if (cashAppMaxSats !== null && amountSats > cashAppMaxSats) {
+      setError('Amount is too large');
+      return;
+    }
     setError(null);
     setIsGenerating(true);
 
@@ -201,7 +223,7 @@ export function useBuyBitcoin({
     } finally {
       setIsGenerating(false);
     }
-  }, [amountSats, isMobile, sdk, onMobileRedirectComplete]);
+  }, [amountSats, cashAppMaxSats, isMobile, sdk, onMobileRedirectComplete]);
 
   // Cash App URLs are `https://cash.app/launch/lightning/<bolt11>`. Extract the
   // invoice only while we're showing the QR so the bus subscription pauses
@@ -224,9 +246,13 @@ export function useBuyBitcoin({
     setCashAppUrl(null);
   }, []);
 
-  const validAmount = amountInput !== '' && amountSats >= MIN_CASH_APP_SATS && !amountTooLarge;
+  const validAmount = amountInput !== ''
+    && amountSats >= MIN_CASH_APP_SATS
+    && !amountTooLarge
+    && !exceedsCashAppLimit;
 
-  const displayedError = error ?? (amountTooLarge ? 'Amount is too large' : null);
+  const displayedError = error
+    ?? ((amountTooLarge || exceedsCashAppLimit) ? 'Amount is too large' : null);
 
   const quickAmounts = isTokenMode ? CASH_APP_QUICK_AMOUNTS_TOKEN : CASH_APP_QUICK_AMOUNTS_SATS;
 

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -8,6 +8,7 @@ import { useAmountInput } from '../../../hooks/useAmountInput';
 import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
 import { type TokenDisplayConfig } from '../../../utils/tokenFormatting';
+import { toSats, toSdkAmountNumber, type Sats } from '../../../types/sats';
 import {
   getBuyProviderSettings,
   filterProvidersByNetwork,
@@ -18,7 +19,7 @@ export type BuyStep = 'select' | 'amount' | 'qr';
 
 const CASH_APP_QUICK_AMOUNTS_SATS = [10000, 50000, 100000];
 const CASH_APP_QUICK_AMOUNTS_TOKEN = [5, 10, 25];
-const MIN_CASH_APP_SATS = 1;
+const MIN_CASH_APP_SATS: Sats = 1n as Sats;
 // Cash App caps verified-user Bitcoin buys at roughly $100k/week (~$10k/day).
 // Using the weekly ceiling as a generous client-side guardrail — anything above
 // this is sure to be rejected by Cash App, so we fail fast with a clear error.
@@ -45,7 +46,7 @@ export interface UseBuyBitcoinReturn {
   /** Display string bound to the input. Holds fiat in token mode, sats otherwise. */
   amountInput: string;
   cashAppUrl: string | null;
-  generatedAmountSats: number | null;
+  generatedAmountSats: Sats | null;
   isGenerating: boolean;
   error: string | null;
   validAmount: boolean;
@@ -92,11 +93,11 @@ export function useBuyBitcoin({
     btcFiatRate,
   } = input;
 
-  // Detect "too large" inputs: parseAmountToSats returns 0 once the result
-  // exceeds Number.MAX_SAFE_INTEGER (would silently overflow the SDK's u64).
-  // Without this hint, the user just sees Continue stay disabled.
+  // Detect "too large" inputs: parseAmountToSats returns null once the result
+  // exceeds the absolute Bitcoin max. Without this hint, the user just sees
+  // Continue stay disabled.
   const amountTooLarge = useMemo(() => {
-    if (amountInput === '' || amountSats > 0) return false;
+    if (amountInput === '' || amountSats !== null) return false;
     const numeric = Number(amountInput);
     if (!Number.isFinite(numeric) || numeric <= 0) return false;
     const projectedSats = isTokenMode && btcFiatRate > 0
@@ -108,21 +109,21 @@ export function useBuyBitcoin({
   // Cash App's own purchase ceiling — converted to sats at the current rate so
   // we can compare against `amountSats` regardless of which input mode the
   // user is in. Skipped while the rate hasn't loaded.
-  const cashAppMaxSats = useMemo(() => {
+  const cashAppMaxSats = useMemo<Sats | null>(() => {
     if (!btcFiatRate || btcFiatRate <= 0) return null;
-    return Math.floor((CASH_APP_MAX_USD * 100_000_000) / btcFiatRate);
+    return toSats(BigInt(Math.floor((CASH_APP_MAX_USD * 100_000_000) / btcFiatRate)));
   }, [btcFiatRate]);
 
   const exceedsCashAppLimit = useMemo(() => {
     if (cashAppMaxSats === null) return false;
-    if (amountSats <= 0) return false;
+    if (amountSats === null) return false;
     return amountSats > cashAppMaxSats;
   }, [amountSats, cashAppMaxSats]);
 
   const [step, setStep] = useState<BuyStep>('select');
   const [redirectingProvider, setRedirectingProvider] = useState<BuyBitcoinProvider | null>(null);
   const [cashAppUrl, setCashAppUrl] = useState<string | null>(null);
-  const [generatedAmountSats, setGeneratedAmountSats] = useState<number | null>(null);
+  const [generatedAmountSats, setGeneratedAmountSats] = useState<Sats | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -187,12 +188,17 @@ export function useBuyBitcoin({
   }, [toggleDenomination]);
 
   const generate = useCallback(async () => {
-    if (!amountSats || amountSats < MIN_CASH_APP_SATS) {
-      setError(`Amount must be at least ₿${MIN_CASH_APP_SATS.toLocaleString()}`);
+    if (amountSats === null || amountSats < MIN_CASH_APP_SATS) {
+      setError(`Amount must be at least ₿${MIN_CASH_APP_SATS.toString()}`);
       return;
     }
     if (cashAppMaxSats !== null && amountSats > cashAppMaxSats) {
-      setError('Amount is too large');
+      setError('Invalid amount');
+      return;
+    }
+    const amountSatsForSdk = toSdkAmountNumber(amountSats);
+    if (amountSatsForSdk === null) {
+      setError('Invalid amount');
       return;
     }
     setError(null);
@@ -203,7 +209,7 @@ export function useBuyBitcoin({
     const mobileTab = isMobile ? window.open('', '_blank') : null;
 
     try {
-      const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats });
+      const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats: amountSatsForSdk });
       setGeneratedAmountSats(amountSats);
       if (isMobile) {
         if (mobileTab) {
@@ -247,12 +253,13 @@ export function useBuyBitcoin({
   }, []);
 
   const validAmount = amountInput !== ''
+    && amountSats !== null
     && amountSats >= MIN_CASH_APP_SATS
     && !amountTooLarge
     && !exceedsCashAppLimit;
 
   const displayedError = error
-    ?? ((amountTooLarge || exceedsCashAppLimit) ? 'Amount is too large' : null);
+    ?? ((amountTooLarge || exceedsCashAppLimit) ? 'Invalid amount' : null);
 
   const quickAmounts = isTokenMode ? CASH_APP_QUICK_AMOUNTS_TOKEN : CASH_APP_QUICK_AMOUNTS_SATS;
 

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -85,7 +85,21 @@ export function useBuyBitcoin({
     config: tokenConfig,
     hasTokenConfig,
     amountSats,
+    btcFiatRate,
   } = input;
+
+  // Detect "too large" inputs: parseAmountToSats returns 0 once the result
+  // exceeds Number.MAX_SAFE_INTEGER (would silently overflow the SDK's u64).
+  // Without this hint, the user just sees Continue stay disabled.
+  const amountTooLarge = useMemo(() => {
+    if (amountInput === '' || amountSats > 0) return false;
+    const numeric = Number(amountInput);
+    if (!Number.isFinite(numeric) || numeric <= 0) return false;
+    const projectedSats = isTokenMode && btcFiatRate > 0
+      ? (numeric / btcFiatRate) * 100_000_000
+      : numeric;
+    return projectedSats > Number.MAX_SAFE_INTEGER;
+  }, [amountInput, amountSats, isTokenMode, btcFiatRate]);
 
   const [step, setStep] = useState<BuyStep>('select');
   const [redirectingProvider, setRedirectingProvider] = useState<BuyBitcoinProvider | null>(null);
@@ -210,7 +224,9 @@ export function useBuyBitcoin({
     setCashAppUrl(null);
   }, []);
 
-  const validAmount = amountInput !== '' && amountSats >= MIN_CASH_APP_SATS;
+  const validAmount = amountInput !== '' && amountSats >= MIN_CASH_APP_SATS && !amountTooLarge;
+
+  const displayedError = error ?? (amountTooLarge ? 'Amount is too large' : null);
 
   const quickAmounts = isTokenMode ? CASH_APP_QUICK_AMOUNTS_TOKEN : CASH_APP_QUICK_AMOUNTS_SATS;
 
@@ -222,7 +238,7 @@ export function useBuyBitcoin({
     cashAppUrl,
     generatedAmountSats,
     isGenerating,
-    error,
+    error: displayedError,
     validAmount,
     isMobile,
     quickAmounts,

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -48,6 +48,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     amountInput: displayAmount,
     setAmount,
     setAmountInput,
+    resetAmount,
     isTokenMode,
     toggleDenomination,
     isStableBalanceActive,
@@ -62,6 +63,12 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   useEffect(() => {
     setAmountSats(parsedSats);
   }, [parsedSats, setAmountSats]);
+
+  // Clear the input when the dialog closes so it doesn't persist a stale
+  // value on the next open.
+  useEffect(() => {
+    if (!isOpen) resetAmount();
+  }, [isOpen, resetAmount]);
 
   const handleToggleDenomination = () => {
     toggleDenomination();

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import {
   FormError,
@@ -8,15 +8,13 @@ import {
   DialogHeader,
 } from '../../components/ui';
 import { LightningBoltIcon } from '../../components/Icons';
-import { useStableBalance } from '../../contexts/StableBalanceContext';
 import {
   TOKEN_QUICK_AMOUNTS,
   SATS_QUICK_AMOUNTS,
   formatQuickAmount,
-  sanitizeTokenInput,
-  parseAmountToSats,
 } from '../../utils/tokenFormatting';
 import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
+import { useAmountInput } from '../../hooks/useAmountInput';
 import type { Sats } from '../../types/sats';
 
 interface AmountPanelProps {
@@ -45,59 +43,39 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   onCreateInvoice,
   onClose,
 }) => {
-  const stableBalance = useStableBalance();
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive);
-  const config = stableBalance.displayConfig;
+  const input = useAmountInput();
+  const {
+    amountInput: displayAmount,
+    setAmount,
+    setAmountInput,
+    isTokenMode,
+    toggleDenomination,
+    isStableBalanceActive,
+    tokenSymbol,
+    config,
+    btcFiatRate,
+    amountSats: parsedSats,
+  } = input;
 
-  // The display string for the input field. In token mode this holds fiat;
-  // in sats mode it holds sats. The parsed sats value is pushed to the parent
-  // separately so there's no string-passing round trip.
-  const [displayAmount, setDisplayAmount] = useState('');
+  // Push the hook's parsed sats up to the parent. Centralizes the contract:
+  // parent always sees a validated Sats (or null) — never a raw string.
+  useEffect(() => {
+    setAmountSats(parsedSats);
+  }, [parsedSats, setAmountSats]);
 
   const handleToggleDenomination = () => {
-    setIsTokenMode(prev => !prev);
-    setAmountSats(null);
-    setDisplayAmount('');
-  };
-
-  // Force the input back to sats mode when stable balance is deactivated.
-  // Without this, the CurrencySwitcher disappears but isTokenMode stays true,
-  // leaving the input showing a fiat value that's no longer toggleable.
-  useEffect(() => {
-    if (!stableBalance.isActive && isTokenMode) {
-      setIsTokenMode(false);
-      setAmountSats(null);
-      setDisplayAmount('');
-    }
-  }, [stableBalance.isActive, isTokenMode, setAmountSats]);
-
-  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
-
-  // Push parsed Sats to the parent. parseAmountToSats handles the safe-integer
-  // guard, so the parent always gets either a validated Sats or null.
-  const pushSats = (display: string) => {
-    setAmountSats(parseAmountToSats(display, isTokenMode, stableBalance.btcFiatRate));
+    toggleDenomination();
   };
 
   const handleAmountChange = (value: string) => {
-    if (isTokenMode && config) {
-      const sanitized = sanitizeTokenInput(value, config.fractionSize);
-      if (sanitized !== null) {
-        setDisplayAmount(sanitized);
-        pushSats(sanitized);
-      }
-    } else {
-      const sats = value.replace(/[^0-9]/g, '');
-      setDisplayAmount(sats);
-      pushSats(sats);
-    }
+    setAmount(value);
   };
 
   const handleQuickAmount = (quickAmount: number) => {
-    const sanitized = String(quickAmount);
-    setDisplayAmount(sanitized);
-    pushSats(sanitized);
+    setAmountInput(String(quickAmount));
   };
+
+  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
 
   const validAmount = amountSats !== null && amountSats > 0n;
 
@@ -105,14 +83,14 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   // can't safely be converted to sats — covers both unsafe-integer overflow
   // (fiat or sats) and unsafe results from fiat→sats conversion.
   const amountTooLarge = useMemo(() => {
-    if (displayAmount === '' || amountSats !== null) return false;
+    if (displayAmount === '' || parsedSats !== null) return false;
     const numeric = Number(displayAmount);
     if (!Number.isFinite(numeric) || numeric <= 0) return false;
-    const projectedSats = isTokenMode && stableBalance.btcFiatRate > 0
-      ? (numeric / stableBalance.btcFiatRate) * 100_000_000
+    const projectedSats = isTokenMode && btcFiatRate > 0
+      ? (numeric / btcFiatRate) * 100_000_000
       : numeric;
     return projectedSats > Number.MAX_SAFE_INTEGER;
-  }, [displayAmount, amountSats, isTokenMode, stableBalance.btcFiatRate]);
+  }, [displayAmount, parsedSats, isTokenMode, btcFiatRate]);
 
   return (
     <BottomSheetContainer isOpen={isOpen} onClose={onClose} showBackdrop>
@@ -141,10 +119,10 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
                 className="w-full bg-spark-dark border border-spark-border rounded-xl px-4 py-3 pr-16 text-spark-text-primary text-lg font-mono placeholder-spark-text-muted focus-within:border-spark-primary focus:outline-none transition-all resize-none"
                 data-testid="invoice-amount-input"
               />
-              {stableBalance.isActive && config && (
+              {isStableBalanceActive && tokenSymbol && (
                 <CurrencySwitcher
                   isTokenMode={isTokenMode}
-                  tokenSymbol={config.symbol}
+                  tokenSymbol={tokenSymbol}
                   onSwitch={handleToggleDenomination}
                   disabled={isLoading}
                 />

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import {
   FormError,
@@ -14,14 +14,16 @@ import {
   SATS_QUICK_AMOUNTS,
   formatQuickAmount,
   sanitizeTokenInput,
-  fiatToSats,
+  parseAmountToSats,
 } from '../../utils/tokenFormatting';
 import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
+import type { Sats } from '../../types/sats';
 
 interface AmountPanelProps {
   isOpen: boolean;
-  amount: string;
-  setAmount: (v: string) => void;
+  /** Validated amount in sats; null when the input is empty or invalid. */
+  amountSats: Sats | null;
+  setAmountSats: (sats: Sats | null) => void;
   description: string;
   setDescription: (v: string) => void;
   limits: { min: number; max: number };
@@ -33,8 +35,8 @@ interface AmountPanelProps {
 
 const AmountPanel: React.FC<AmountPanelProps> = ({
   isOpen,
-  amount,
-  setAmount,
+  amountSats,
+  setAmountSats,
   description,
   setDescription,
   limits: _limits,
@@ -48,47 +50,59 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
   const config = stableBalance.displayConfig;
 
-  // In token mode we show the fiat value locally; the parent's `amount` always holds sats.
+  // The display string for the input field. In token mode this holds fiat;
+  // in sats mode it holds sats. The parsed sats value is pushed to the parent
+  // separately so there's no string-passing round trip.
   const [displayAmount, setDisplayAmount] = useState('');
 
   const handleToggleDenomination = () => {
     setIsTokenMode(prev => !prev);
-    setAmount('');
+    setAmountSats(null);
     setDisplayAmount('');
   };
 
   const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
+
+  // Push parsed Sats to the parent. parseAmountToSats handles the safe-integer
+  // guard, so the parent always gets either a validated Sats or null.
+  const pushSats = (display: string) => {
+    setAmountSats(parseAmountToSats(display, isTokenMode, stableBalance.btcFiatRate));
+  };
 
   const handleAmountChange = (value: string) => {
     if (isTokenMode && config) {
       const sanitized = sanitizeTokenInput(value, config.fractionSize);
       if (sanitized !== null) {
         setDisplayAmount(sanitized);
-        const fiat = parseFloat(sanitized);
-        if (fiat > 0 && stableBalance.btcFiatRate > 0) {
-          setAmount(String(fiatToSats(fiat, stableBalance.btcFiatRate)));
-        } else {
-          setAmount('');
-        }
+        pushSats(sanitized);
       }
     } else {
       const sats = value.replace(/[^0-9]/g, '');
-      setAmount(sats);
       setDisplayAmount(sats);
+      pushSats(sats);
     }
   };
 
   const handleQuickAmount = (quickAmount: number) => {
-    if (isTokenMode && stableBalance.btcFiatRate > 0) {
-      setDisplayAmount(String(quickAmount));
-      setAmount(String(fiatToSats(quickAmount, stableBalance.btcFiatRate)));
-    } else {
-      setDisplayAmount(String(quickAmount));
-      setAmount(String(quickAmount));
-    }
+    const sanitized = String(quickAmount);
+    setDisplayAmount(sanitized);
+    pushSats(sanitized);
   };
 
-  const validAmount = amount !== '' && parseInt(amount) > 0;
+  const validAmount = amountSats !== null && amountSats > 0n;
+
+  // "Invalid amount" surfaces when the input is non-empty and positive but
+  // can't safely be converted to sats — covers both unsafe-integer overflow
+  // (fiat or sats) and unsafe results from fiat→sats conversion.
+  const amountTooLarge = useMemo(() => {
+    if (displayAmount === '' || amountSats !== null) return false;
+    const numeric = Number(displayAmount);
+    if (!Number.isFinite(numeric) || numeric <= 0) return false;
+    const projectedSats = isTokenMode && stableBalance.btcFiatRate > 0
+      ? (numeric / stableBalance.btcFiatRate) * 100_000_000
+      : numeric;
+    return projectedSats > Number.MAX_SAFE_INTEGER;
+  }, [displayAmount, amountSats, isTokenMode, stableBalance.btcFiatRate]);
 
   return (
     <BottomSheetContainer isOpen={isOpen} onClose={onClose} showBackdrop>
@@ -163,7 +177,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
             />
           </div>
 
-          <FormError error={error} data-testid="invoice-error-message" />
+          <FormError error={amountTooLarge ? 'Invalid amount' : error} data-testid="invoice-error-message" />
 
           {/* Generate Button */}
           <PrimaryButton

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import {
   FormError,
@@ -46,8 +46,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
   onClose,
 }) => {
   const stableBalance = useStableBalance();
-  const hasTokenConfig = !!stableBalance.displayConfig;
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
+  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive);
   const config = stableBalance.displayConfig;
 
   // The display string for the input field. In token mode this holds fiat;
@@ -60,6 +59,17 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     setAmountSats(null);
     setDisplayAmount('');
   };
+
+  // Force the input back to sats mode when stable balance is deactivated.
+  // Without this, the CurrencySwitcher disappears but isTokenMode stays true,
+  // leaving the input showing a fiat value that's no longer toggleable.
+  useEffect(() => {
+    if (!stableBalance.isActive && isTokenMode) {
+      setIsTokenMode(false);
+      setAmountSats(null);
+      setDisplayAmount('');
+    }
+  }, [stableBalance.isActive, isTokenMode, setAmountSats]);
 
   const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
 
@@ -131,7 +141,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
                 className="w-full bg-spark-dark border border-spark-border rounded-xl px-4 py-3 pr-16 text-spark-text-primary text-lg font-mono placeholder-spark-text-muted focus-within:border-spark-primary focus:outline-none transition-all resize-none"
                 data-testid="invoice-amount-input"
               />
-              {hasTokenConfig && config && (
+              {stableBalance.isActive && config && (
                 <CurrencySwitcher
                   isTokenMode={isTokenMode}
                   tokenSymbol={config.symbol}

--- a/src/features/receive/ReceivePaymentDialog.tsx
+++ b/src/features/receive/ReceivePaymentDialog.tsx
@@ -238,8 +238,8 @@ const ReceivePaymentDialog: React.FC<ReceivePaymentDialogProps> = ({ isOpen, onC
 
       <AmountPanel
         isOpen={isOpen && receive.activeTab === 'lightning' && receive.showAmountPanel}
-        amount={receive.amount}
-        setAmount={receive.setAmount}
+        amountSats={receive.amountSats}
+        setAmountSats={receive.setAmountSats}
         description={receive.description}
         setDescription={receive.setDescription}
         limits={{ min: 1, max: 1000000 }}

--- a/src/features/receive/hooks/useReceivePayment.ts
+++ b/src/features/receive/hooks/useReceivePayment.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { useWallet } from '../../../contexts/WalletContext';
 import { logger, LogCategory } from '@/services/logger';
 import { formatError } from '@/utils/formatError';
+import { toSdkAmountNumber, type Sats } from '../../../types/sats';
 import type { PaymentMethod, ReceiveStep } from '../../../types/domain';
 
 export interface UseReceivePaymentReturn {
@@ -9,7 +10,8 @@ export interface UseReceivePaymentReturn {
   activeTab: PaymentMethod;
   currentStep: ReceiveStep;
   description: string;
-  amount: string;
+  /** Validated amount in sats (or null until set / when invalid). */
+  amountSats: Sats | null;
   error: string | null;
   isLoading: boolean;
   paymentData: string;
@@ -21,7 +23,7 @@ export interface UseReceivePaymentReturn {
   showAmountPanel: boolean;
   // Actions
   setDescription: (desc: string) => void;
-  setAmount: (amt: string) => void;
+  setAmountSats: (sats: Sats | null) => void;
   setShowAmountPanel: (show: boolean) => void;
   handleTabChange: (tab: PaymentMethod, loadLightningAddress: () => void) => void;
   generateBitcoinAddress: () => Promise<void>;
@@ -35,7 +37,7 @@ export function useReceivePayment(): UseReceivePaymentReturn {
   const [activeTab, setActiveTab] = useState<PaymentMethod>('lightning');
   const [currentStep, setCurrentStep] = useState<ReceiveStep>('loading_limits');
   const [description, setDescription] = useState<string>('');
-  const [amount, setAmount] = useState<string>('');
+  const [amountSats, setAmountSats] = useState<Sats | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [paymentData, setPaymentData] = useState<string>('');
@@ -50,7 +52,7 @@ export function useReceivePayment(): UseReceivePaymentReturn {
   const reset = useCallback(() => {
     setCurrentStep('input');
     setDescription('');
-    setAmount('');
+    setAmountSats(null);
     setError(null);
     setIsLoading(false);
     setPaymentData('');
@@ -95,7 +97,9 @@ export function useReceivePayment(): UseReceivePaymentReturn {
   }, [wallet, bitcoinAddress, bitcoinLoading]);
 
   const generateBolt11Invoice = useCallback(async () => {
-    logger.info(LogCategory.PAYMENT, 'Starting invoice generation', { amount });
+    logger.info(LogCategory.PAYMENT, 'Starting invoice generation', {
+      amountSats: amountSats !== null ? String(amountSats) : null,
+    });
     setError(null);
     setIsLoading(true);
     setCurrentStep('loading');
@@ -106,17 +110,22 @@ export function useReceivePayment(): UseReceivePaymentReturn {
     }
 
     try {
-      const amountSats = parseInt(amount);
-      if (isNaN(amountSats)) {
+      if (amountSats === null) {
+        throw new Error('Invalid amount');
+      }
+      const amountSatsForSdk = toSdkAmountNumber(amountSats);
+      if (amountSatsForSdk === null) {
         throw new Error('Invalid amount');
       }
 
-      logger.debug(LogCategory.PAYMENT, 'Calling wallet.receivePayment for bolt11 invoice', { amountSats });
+      logger.debug(LogCategory.PAYMENT, 'Calling wallet.receivePayment for bolt11 invoice', {
+        amountSats: amountSatsForSdk,
+      });
       const receiveResponse = await wallet.receivePayment({
         paymentMethod: {
           type: 'bolt11Invoice',
           description,
-          amountSats,
+          amountSats: amountSatsForSdk,
         },
       });
       logger.info(LogCategory.PAYMENT, 'Invoice generated successfully', {
@@ -135,7 +144,7 @@ export function useReceivePayment(): UseReceivePaymentReturn {
       setIsLoading(false);
       logger.debug(LogCategory.PAYMENT, 'Receive invoice generation process finished');
     }
-  }, [wallet, amount, description, showAmountPanel]);
+  }, [wallet, amountSats, description, showAmountPanel]);
 
   const handleTabChange = useCallback((tab: PaymentMethod, loadLightningAddress: () => void) => {
     setActiveTab(tab);
@@ -157,7 +166,7 @@ export function useReceivePayment(): UseReceivePaymentReturn {
     activeTab,
     currentStep,
     description,
-    amount,
+    amountSats,
     error,
     isLoading,
     paymentData,
@@ -168,7 +177,7 @@ export function useReceivePayment(): UseReceivePaymentReturn {
     bitcoinLoading,
     showAmountPanel,
     setDescription,
-    setAmount,
+    setAmountSats,
     setShowAmountPanel,
     handleTabChange,
     generateBitcoinAddress,

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -144,6 +144,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                 paymentInput={send.paymentInput?.rawInput || ''}
                 amount={send.amount}
                 balanceSats={send.balanceSats}
+                tokenBalance={send.tokenBalance}
                 isLoading={send.isLoading}
                 error={send.error}
                 onBack={() => send.setCurrentStep('input')}
@@ -158,6 +159,8 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     method={send.prepareResponse.paymentMethod}
                     amountSats={send.prepareResponse.amount}
                     conversionEstimate={send.prepareResponse.conversionEstimate}
+                    balanceSats={send.balanceSats}
+                    tokenBalance={send.tokenBalance}
                     onBack={() => send.setCurrentStep('input')}
                     onSend={send.handleSend}
                   />
@@ -168,6 +171,8 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     amountSats={send.prepareResponse.amount}
                     feesIncluded={send.feesIncluded}
                     conversionEstimate={send.prepareResponse.conversionEstimate}
+                    balanceSats={send.balanceSats}
+                    tokenBalance={send.tokenBalance}
                     onBack={() => send.setCurrentStep('amount')}
                     onSend={send.handleSend}
                   />
@@ -178,6 +183,8 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     amountSats={send.prepareResponse.amount}
                     feesIncluded={send.feesIncluded}
                     conversionEstimate={send.prepareResponse.conversionEstimate}
+                    balanceSats={send.balanceSats}
+                    tokenBalance={send.tokenBalance}
                     onBack={() => send.setCurrentStep('input')}
                     onSend={send.handleSend}
                   />
@@ -187,6 +194,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     parsed={lnurlPayDetails}
                     recipientLabel={recipientLabel}
                     balanceSats={send.balanceSats}
+                    tokenBalance={send.tokenBalance}
                     onBack={() => send.setCurrentStep('input')}
                     onRun={send.handleRun}
                     onPrepare={async (prepareRequest: PrepareLnurlPayRequest) => {

--- a/src/features/send/hooks/useBalanceValidation.ts
+++ b/src/features/send/hooks/useBalanceValidation.ts
@@ -1,0 +1,114 @@
+import { useMemo } from 'react';
+import { useStableBalance } from '../../../contexts/StableBalanceContext';
+import { fiatToSats, type TokenDisplayConfig } from '../../../utils/tokenFormatting';
+import type { ConversionEstimate } from '@breeztech/breez-sdk-spark';
+
+interface BalanceValidation {
+  isTokenMode: boolean;
+  setIsTokenMode?: (value: boolean) => void;
+  parseInputToSats: (input: string) => number | null;
+  exceedsBalance: (displayAmount: number) => boolean;
+  validateAmount: (input: string, feesIncluded?: boolean) => string | null;
+  checkInsufficientFunds: (opts: {
+    isTokenMode: boolean;
+    totalSats: number;
+    conversionEstimate?: ConversionEstimate | null;
+  }) => boolean;
+  config: TokenDisplayConfig | null;
+}
+
+const hasValidRate = (rate?: number): rate is number =>
+  rate !== undefined && rate > 0;
+
+const hasPositiveTokenBalance = (balance?: bigint): balance is bigint =>
+  balance !== undefined && balance > 0n;
+
+export function useBalanceValidation(
+  isTokenMode: boolean,
+  setIsTokenMode?: (value: boolean) => void,
+  balanceSats?: number,
+  tokenBalance?: bigint,
+): BalanceValidation {
+  const { displayConfig: config, btcFiatRate, isActive } = useStableBalance();
+
+  const tokenBalanceSats = useMemo<number | null>(() => {
+    if (!config || !hasPositiveTokenBalance(tokenBalance) || !hasValidRate(btcFiatRate)) return null;
+    const fiat = Number(tokenBalance) / 10 ** config.decimals;
+    return fiatToSats(fiat, btcFiatRate);
+  }, [config, tokenBalance, btcFiatRate]);
+
+  const parseInputToSats = (input: string): number | null => {
+    if (isTokenMode) {
+      if (!hasValidRate(btcFiatRate)) return null;
+      const fiat = Number(input);
+      if (!Number.isFinite(fiat) || fiat <= 0) return null;
+      return fiatToSats(fiat, btcFiatRate);
+    }
+    const sats = Number(input);
+    if (!Number.isInteger(sats) || sats <= 0) return null;
+    return sats;
+  };
+
+  const maxAvailableSats = (): number | undefined => {
+    if (balanceSats === undefined) return undefined;
+    const tokenFallback = isActive && tokenBalanceSats !== null ? tokenBalanceSats : 0;
+    return Math.max(balanceSats, tokenFallback);
+  };
+
+  const exceedsBalance = (displayAmount: number): boolean => {
+    if (isTokenMode && config) {
+      if (hasPositiveTokenBalance(tokenBalance)) {
+        const baseUnits = BigInt(Math.round(displayAmount * 10 ** config.decimals));
+        if (baseUnits <= tokenBalance) return false;
+      }
+      // Token balance can't cover it (or is zero). Check if BTC change can.
+      if (!hasValidRate(btcFiatRate)) return tokenBalance !== undefined;
+      const satsNeeded = fiatToSats(displayAmount, btcFiatRate);
+      const available = maxAvailableSats();
+      return available === undefined || satsNeeded > available;
+    }
+
+    const available = maxAvailableSats();
+    if (available === undefined) return false;
+    return displayAmount > available;
+  };
+
+  const validateAmount = (input: string, feesIncluded?: boolean): string | null => {
+    const parsed = parseInputToSats(input);
+    if (parsed === null) return 'Please enter a valid amount';
+
+    const displayAmount = isTokenMode ? Number(input) : parsed;
+    const isSendAll = !isTokenMode && feesIncluded;
+    if (isSendAll) return null;
+
+    if (exceedsBalance(displayAmount)) {
+      return 'Amount exceeds available balance';
+    }
+    return null;
+  };
+
+  const checkInsufficientFunds: BalanceValidation['checkInsufficientFunds'] = ({
+    isTokenMode: confirmTokenMode,
+    totalSats,
+    conversionEstimate,
+  }) => {
+    if (confirmTokenMode && conversionEstimate && tokenBalance !== undefined) {
+      const required = conversionEstimate.amountIn + conversionEstimate.fee;
+      return required > tokenBalance;
+    }
+
+    const available = maxAvailableSats();
+    if (available === undefined) return false;
+    return totalSats > available;
+  };
+
+  return {
+    isTokenMode,
+    setIsTokenMode,
+    parseInputToSats,
+    exceedsBalance,
+    validateAmount,
+    checkInsufficientFunds,
+    config,
+  };
+}

--- a/src/features/send/hooks/useBalanceValidation.ts
+++ b/src/features/send/hooks/useBalanceValidation.ts
@@ -1,17 +1,23 @@
 import { useMemo } from 'react';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { fiatToSats, parseAmountToSats, type TokenDisplayConfig } from '../../../utils/tokenFormatting';
+import type { Sats } from '../../../types/sats';
 import type { ConversionEstimate } from '@breeztech/breez-sdk-spark';
 
 interface BalanceValidation {
   isTokenMode: boolean;
   setIsTokenMode?: (value: boolean) => void;
-  parseInputToSats: (input: string) => number | null;
+  parseInputToSats: (input: string) => Sats | null;
+  /**
+   * Whether a user-typed display amount (fiat in token mode, sats in sats
+   * mode) exceeds the available balance. Takes a plain `number` because the
+   * value is the raw display value, not a validated Sats.
+   */
   exceedsBalance: (displayAmount: number) => boolean;
   validateAmount: (input: string, feesIncluded?: boolean) => string | null;
   checkInsufficientFunds: (opts: {
     isTokenMode: boolean;
-    totalSats: number;
+    totalSats: Sats;
     conversionEstimate?: ConversionEstimate | null;
   }) => boolean;
   config: TokenDisplayConfig | null;
@@ -37,7 +43,7 @@ export function useBalanceValidation(
     return fiatToSats(fiat, btcFiatRate);
   }, [config, tokenBalance, btcFiatRate]);
 
-  const parseInputToSats = (input: string): number | null =>
+  const parseInputToSats = (input: string): Sats | null =>
     parseAmountToSats(input, isTokenMode, btcFiatRate);
 
   const maxAvailableSats = (): number | undefined => {
@@ -68,7 +74,9 @@ export function useBalanceValidation(
     const parsed = parseInputToSats(input);
     if (parsed === null) return 'Please enter a valid amount';
 
-    const displayAmount = isTokenMode ? Number(input) : parsed;
+    // displayAmount represents the user-typed value (fiat in token mode,
+    // sats in sats mode). exceedsBalance handles both shapes.
+    const displayAmount = isTokenMode ? Number(input) : Number(parsed);
     const isSendAll = !isTokenMode && feesIncluded;
     if (isSendAll) return null;
 
@@ -90,7 +98,9 @@ export function useBalanceValidation(
 
     const available = maxAvailableSats();
     if (available === undefined) return false;
-    return totalSats > available;
+    // available is `number` (sourced from balanceSats) — convert totalSats
+    // for the comparison. Both are bounded by toSats() so neither overflows.
+    return Number(totalSats) > available;
   };
 
   return {

--- a/src/features/send/hooks/useBalanceValidation.ts
+++ b/src/features/send/hooks/useBalanceValidation.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
-import { fiatToSats, type TokenDisplayConfig } from '../../../utils/tokenFormatting';
+import { fiatToSats, parseAmountToSats, type TokenDisplayConfig } from '../../../utils/tokenFormatting';
 import type { ConversionEstimate } from '@breeztech/breez-sdk-spark';
 
 interface BalanceValidation {
@@ -37,17 +37,8 @@ export function useBalanceValidation(
     return fiatToSats(fiat, btcFiatRate);
   }, [config, tokenBalance, btcFiatRate]);
 
-  const parseInputToSats = (input: string): number | null => {
-    if (isTokenMode) {
-      if (!hasValidRate(btcFiatRate)) return null;
-      const fiat = Number(input);
-      if (!Number.isFinite(fiat) || fiat <= 0) return null;
-      return fiatToSats(fiat, btcFiatRate);
-    }
-    const sats = Number(input);
-    if (!Number.isInteger(sats) || sats <= 0) return null;
-    return sats;
-  };
+  const parseInputToSats = (input: string): number | null =>
+    parseAmountToSats(input, isTokenMode, btcFiatRate);
 
   const maxAvailableSats = (): number | undefined => {
     if (balanceSats === undefined) return undefined;

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -2,6 +2,8 @@ import { useState, useCallback } from 'react';
 import type { PrepareSendPaymentResponse, FeePolicy, SendPaymentOptions, SdkEvent, ConversionOptions } from '@breeztech/breez-sdk-spark';
 import type { SendInput } from '@/types/domain';
 import { useWallet } from '../../../contexts/WalletContext';
+import { useStableBalance } from '../../../contexts/StableBalanceContext';
+import { getTokenBalance } from '../../../utils/tokenFormatting';
 import { logger, LogCategory } from '@/services/logger';
 import { formatError } from '@/utils/formatError';
 
@@ -18,6 +20,7 @@ export interface UseSendPaymentReturn {
   prepareResponse: PrepareSendPaymentResponse | null;
   paymentResult: 'success' | 'failure' | null;
   balanceSats: number | undefined;
+  tokenBalance: bigint | undefined;
   feesIncluded: boolean;
   processingPhase: ProcessingPhase;
   // Actions
@@ -32,6 +35,7 @@ export interface UseSendPaymentReturn {
 
 export function useSendPayment(): UseSendPaymentReturn {
   const wallet = useWallet();
+  const stableBalance = useStableBalance();
 
   const [currentStep, setCurrentStep] = useState<SendStep>('input');
   const [paymentInput, setPaymentInput] = useState<SendInput | null>(null);
@@ -41,14 +45,23 @@ export function useSendPayment(): UseSendPaymentReturn {
   const [prepareResponse, setPrepareResponse] = useState<PrepareSendPaymentResponse | null>(null);
   const [paymentResult, setPaymentResult] = useState<'success' | 'failure' | null>(null);
   const [balanceSats, setBalanceSats] = useState<number | undefined>(undefined);
+  const [tokenBalance, setTokenBalance] = useState<bigint | undefined>(undefined);
   const [feesIncluded, setFeesIncluded] = useState(false);
   const [processingPhase, setProcessingPhase] = useState<ProcessingPhase>('sending');
 
   const fetchBalance = useCallback(() => {
     wallet.getInfo({}).then(info => {
-      if (info) setBalanceSats(info.balanceSats);
+      if (info) {
+        setBalanceSats(info.balanceSats);
+        if (stableBalance.isActive && stableBalance.tokenIdentifier && info.tokenBalances) {
+          const tb = getTokenBalance(info.tokenBalances, stableBalance.tokenIdentifier);
+          setTokenBalance(tb ? tb.balance : 0n);
+        } else {
+          setTokenBalance(undefined);
+        }
+      }
     }).catch(() => { /* balance fetch is best-effort */ });
-  }, [wallet]);
+  }, [wallet, stableBalance.isActive, stableBalance.tokenIdentifier]);
 
   const prepareSend = useCallback(async (
     paymentRequest: string,
@@ -253,6 +266,7 @@ export function useSendPayment(): UseSendPaymentReturn {
     setError(null);
     setIsLoading(false);
     setBalanceSats(undefined);
+    setTokenBalance(undefined);
     setFeesIncluded(false);
     setPaymentInput(null);
     setPaymentResult(null);
@@ -268,6 +282,7 @@ export function useSendPayment(): UseSendPaymentReturn {
     prepareResponse,
     paymentResult,
     balanceSats,
+    tokenBalance,
     feesIncluded,
     processingPhase,
     clearError: useCallback(() => setError(null), []),

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -1,7 +1,7 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import type { PrepareSendPaymentResponse, FeePolicy, SendPaymentOptions, SdkEvent, ConversionOptions } from '@breeztech/breez-sdk-spark';
 import type { SendInput } from '@/types/domain';
-import { useWallet } from '../../../contexts/WalletContext';
+import { useWallet, useWalletInfo } from '../../../contexts/WalletContext';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { getTokenBalance } from '../../../utils/tokenFormatting';
 import { logger, LogCategory } from '@/services/logger';
@@ -35,6 +35,7 @@ export interface UseSendPaymentReturn {
 
 export function useSendPayment(): UseSendPaymentReturn {
   const wallet = useWallet();
+  const walletInfo = useWalletInfo();
   const stableBalance = useStableBalance();
 
   const [currentStep, setCurrentStep] = useState<SendStep>('input');
@@ -44,24 +45,20 @@ export function useSendPayment(): UseSendPaymentReturn {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [prepareResponse, setPrepareResponse] = useState<PrepareSendPaymentResponse | null>(null);
   const [paymentResult, setPaymentResult] = useState<'success' | 'failure' | null>(null);
-  const [balanceSats, setBalanceSats] = useState<number | undefined>(undefined);
-  const [tokenBalance, setTokenBalance] = useState<bigint | undefined>(undefined);
   const [feesIncluded, setFeesIncluded] = useState(false);
   const [processingPhase, setProcessingPhase] = useState<ProcessingPhase>('sending');
 
-  const fetchBalance = useCallback(() => {
-    wallet.getInfo({}).then(info => {
-      if (info) {
-        setBalanceSats(info.balanceSats);
-        if (stableBalance.isActive && stableBalance.tokenIdentifier && info.tokenBalances) {
-          const tb = getTokenBalance(info.tokenBalances, stableBalance.tokenIdentifier);
-          setTokenBalance(tb ? tb.balance : 0n);
-        } else {
-          setTokenBalance(undefined);
-        }
-      }
-    }).catch(() => { /* balance fetch is best-effort */ });
-  }, [wallet, stableBalance.isActive, stableBalance.tokenIdentifier]);
+  // Balance is read live from the wallet info context, which is auto-refreshed
+  // by useBreezSdk on `synced`/`paymentSucceeded`/`claimedDeposits` events. We
+  // don't snapshot it locally — that was the bug that caused validation to use
+  // a stale balance after auto-conversion completed mid-flow.
+  const balanceSats = walletInfo?.balanceSats;
+  const tokenBalance = useMemo<bigint | undefined>(() => {
+    if (!walletInfo?.tokenBalances) return undefined;
+    if (!stableBalance.isActive || !stableBalance.tokenIdentifier) return undefined;
+    const tb = getTokenBalance(walletInfo.tokenBalances, stableBalance.tokenIdentifier);
+    return tb ? tb.balance : 0n;
+  }, [walletInfo, stableBalance.isActive, stableBalance.tokenIdentifier]);
 
   const prepareSend = useCallback(async (
     paymentRequest: string,
@@ -115,13 +112,10 @@ export function useSendPayment(): UseSendPaymentReturn {
         setAmount(String(sats));
         await prepareSend(currentInput, sats);
       } else if (parseResult.type === 'bolt11Invoice') {
-        fetchBalance();
         setCurrentStep('amount');
       } else if (parseResult.type === 'bitcoinAddress' || parseResult.type === 'sparkAddress') {
-        fetchBalance();
         setCurrentStep('amount');
       } else if (parseResult.type === 'lnurlPay' || parseResult.type === 'lightningAddress') {
-        fetchBalance();
         setCurrentStep('workflow');
       } else if (parseResult.type === 'lnurlAuth') {
         setCurrentStep('workflow');
@@ -135,7 +129,7 @@ export function useSendPayment(): UseSendPaymentReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [wallet, paymentInput?.rawInput, prepareSend, fetchBalance]);
+  }, [wallet, paymentInput?.rawInput, prepareSend]);
 
   const onAmountNext = useCallback(async (
     amountNum: number,
@@ -265,8 +259,6 @@ export function useSendPayment(): UseSendPaymentReturn {
     setPrepareResponse(null);
     setError(null);
     setIsLoading(false);
-    setBalanceSats(undefined);
-    setTokenBalance(undefined);
     setFeesIncluded(false);
     setPaymentInput(null);
     setPaymentResult(null);

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -27,7 +27,7 @@ export interface UseSendPaymentReturn {
   clearError: () => void;
   reset: () => void;
   processInput: (input?: string | null) => Promise<void>;
-  onAmountNext: (amountNum: number, includeFees?: boolean, tokenIdentifier?: string, conversionOptions?: ConversionOptions) => Promise<void>;
+  onAmountNext: (amount: bigint, includeFees?: boolean, tokenIdentifier?: string, conversionOptions?: ConversionOptions) => Promise<void>;
   handleSend: (options?: SendPaymentOptions) => Promise<void>;
   handleRun: (runner: () => Promise<void>, hasConversion?: boolean) => Promise<void>;
   setCurrentStep: (step: SendStep) => void;
@@ -62,12 +62,12 @@ export function useSendPayment(): UseSendPaymentReturn {
 
   const prepareSend = useCallback(async (
     paymentRequest: string,
-    amountSats: number,
+    amount: bigint,
     feePolicy?: FeePolicy,
     tokenIdentifier?: string,
     conversionOptions?: ConversionOptions,
   ) => {
-    if (amountSats <= 0) {
+    if (amount <= 0n) {
       setError('Please enter a valid amount');
       return;
     }
@@ -76,7 +76,7 @@ export function useSendPayment(): UseSendPaymentReturn {
     try {
       const response = await wallet.prepareSendPayment({
         paymentRequest,
-        amount: BigInt(amountSats),
+        amount,
         feePolicy,
         tokenIdentifier,
         conversionOptions,
@@ -110,7 +110,7 @@ export function useSendPayment(): UseSendPaymentReturn {
       if (parseResult.type === 'bolt11Invoice' && parseResult.amountMsat && parseResult.amountMsat > 0) {
         const sats = Math.floor(parseResult.amountMsat / 1000);
         setAmount(String(sats));
-        await prepareSend(currentInput, sats);
+        await prepareSend(currentInput, BigInt(sats));
       } else if (parseResult.type === 'bolt11Invoice') {
         setCurrentStep('amount');
       } else if (parseResult.type === 'bitcoinAddress' || parseResult.type === 'sparkAddress') {
@@ -132,19 +132,19 @@ export function useSendPayment(): UseSendPaymentReturn {
   }, [wallet, paymentInput?.rawInput, prepareSend]);
 
   const onAmountNext = useCallback(async (
-    amountNum: number,
+    amount: bigint,
     includeFees?: boolean,
     tokenIdentifier?: string,
     conversionOptions?: ConversionOptions,
   ) => {
-    if (!amountNum || amountNum <= 0) {
+    if (amount <= 0n) {
       setError('Please enter a valid amount');
       return;
     }
     setFeesIncluded(!!includeFees);
     await prepareSend(
       paymentInput?.rawInput || '',
-      amountNum,
+      amount,
       includeFees ? 'feesIncluded' : undefined,
       tokenIdentifier,
       conversionOptions,

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -3,21 +3,20 @@ import type { ConversionOptions } from '@breeztech/breez-sdk-spark';
 import { FormError, PrimaryButton, SecondaryButton } from '../../../components/ui';
 import { SpinnerIcon } from '../../../components/Icons';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
-import { useWallet } from '../../../contexts/WalletContext';
 import {
-  fiatToSats,
-  getTokenBalance,
   TOKEN_QUICK_AMOUNTS,
   SATS_QUICK_AMOUNTS,
   formatQuickAmount,
   sanitizeTokenInput,
 } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
+import { useBalanceValidation } from '../hooks/useBalanceValidation';
 
 export interface AmountStepProps {
   paymentInput: string;
   amount: string;
   balanceSats?: number;
+  tokenBalance?: bigint;
   isLoading: boolean;
   error: string | null;
   onBack: () => void;
@@ -28,45 +27,35 @@ const AmountStep: React.FC<AmountStepProps> = ({
   paymentInput,
   amount,
   balanceSats,
+  tokenBalance,
   isLoading,
   error,
   onBack,
   onNext,
 }) => {
-  const wallet = useWallet();
   const stableBalance = useStableBalance();
   const hasTokenConfig = !!stableBalance.displayConfig;
   const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
-  const config = stableBalance.displayConfig;
+  const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance);
 
   const [localAmount, setLocalAmount] = useState<string>(amount || '');
   const [feesIncluded, setFeesIncluded] = useState(false);
-  const [tokenBalanceRaw, setTokenBalanceRaw] = useState<bigint | null>(null);
-
-  // Fetch token balance for send-all in token mode
-  useEffect(() => {
-    if (!stableBalance.isActive || !stableBalance.tokenIdentifier) return;
-    wallet.getInfo({}).then(info => {
-      if (!info || !stableBalance.tokenIdentifier) return;
-      const tb = getTokenBalance(info.tokenBalances, stableBalance.tokenIdentifier);
-      setTokenBalanceRaw(tb?.balance ?? null);
-    }).catch(() => {});
-  }, [wallet, stableBalance.isActive, stableBalance.tokenIdentifier]);
+  const [localError, setLocalError] = useState<string | null>(null);
 
   useEffect(() => {
     setLocalAmount(amount || '');
   }, [amount]);
 
   const handleToggleDenomination = () => {
-    setIsTokenMode(prev => !prev);
+    balance.setIsTokenMode?.(!isTokenMode);
     setLocalAmount('');
     setFeesIncluded(false);
   };
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    if (isTokenMode && config) {
-      const sanitized = sanitizeTokenInput(value, config.fractionSize);
+    if (isTokenMode && balance.config) {
+      const sanitized = sanitizeTokenInput(value, balance.config.fractionSize);
       if (sanitized !== null) {
         setLocalAmount(sanitized);
         setFeesIncluded(false);
@@ -83,51 +72,51 @@ const AmountStep: React.FC<AmountStepProps> = ({
 
   const handleNext = () => {
     if (!validAmount) return;
-    if (isTokenMode && isSendAllToken && tokenBalanceRaw && stableBalance.tokenIdentifier) {
-      // Send-all in token mode: pass token balance as amount with conversion options
+    setLocalError(null);
+
+    // Token send-all bypasses validation — amount goes directly as tokenBalance to the SDK
+    if (isTokenMode && isSendAllToken && tokenBalance && stableBalance.tokenIdentifier) {
       onNext(
-        Number(tokenBalanceRaw),
+        Number(tokenBalance),
         true,
         stableBalance.tokenIdentifier,
         { conversionType: { type: 'toBitcoin', fromTokenIdentifier: stableBalance.tokenIdentifier } },
       );
-    } else if (isTokenMode && config && stableBalance.btcFiatRate > 0) {
-      const fiatAmount = parseFloat(localAmount);
-      if (!fiatAmount || fiatAmount <= 0) return;
-      const sats = fiatToSats(fiatAmount, stableBalance.btcFiatRate);
-      onNext(sats, feesIncluded);
-    } else {
-      const sats = parseInt(localAmount);
-      if (!sats || sats <= 0) return;
-      onNext(sats, feesIncluded);
+      return;
     }
+
+    const validationError = balance.validateAmount(localAmount, feesIncluded);
+    if (validationError) {
+      setLocalError(validationError);
+      return;
+    }
+
+    // Safe to parse — validateAmount already confirmed the input is valid
+    onNext(balance.parseInputToSats(localAmount)!, feesIncluded);
   };
 
   const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
-
   const amountNum = isTokenMode ? parseFloat(localAmount) || 0 : parseInt(localAmount) || 0;
 
   // Token send-all: format token balance as display string using BigInt math
   // (matches formatTokenAmount used by the balance header)
   const tokenBalanceDisplay = useMemo(() => {
-    if (!tokenBalanceRaw || !config) return null;
-    const { decimals, fractionSize } = config;
+    if (!tokenBalance || !balance.config) return null;
+    const { decimals, fractionSize } = balance.config;
     const divisor = BigInt(10 ** decimals);
-    const wholePart = tokenBalanceRaw / divisor;
-    const fractionalPart = tokenBalanceRaw % divisor;
+    const wholePart = tokenBalance / divisor;
+    const fractionalPart = tokenBalance % divisor;
     const fractionalStr = fractionalPart.toString().padStart(decimals, '0').slice(0, fractionSize);
     return `${wholePart}.${fractionalStr}`;
-  }, [tokenBalanceRaw, config]);
+  }, [tokenBalance, balance.config]);
 
   // Send All: when stable balance is active, always use token path (switch to token mode if needed)
   // When stable balance is not active, use sats path
-  const hasTokenBalance = tokenBalanceRaw !== null && tokenBalanceRaw > 0n;
+  const hasTokenBalance = tokenBalance !== undefined && tokenBalance > 0n;
   const showSendAll = hasTokenBalance || (!stableBalance.isActive && balanceSats !== undefined && balanceSats > 0);
   const isSendAllToken = isTokenMode && hasTokenBalance && localAmount === tokenBalanceDisplay && feesIncluded;
   const isSendAllSats = !isTokenMode && !stableBalance.isActive && balanceSats !== undefined && amountNum === balanceSats && feesIncluded;
   const isSendAll = isSendAllSats || isSendAllToken;
-
-  const amountLabel = 'Amount';
 
   return (
     <div className="space-y-5">
@@ -144,7 +133,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
       {/* Amount input */}
       <div>
         <label className="block text-sm font-medium text-spark-text-primary mb-2">
-          {amountLabel}
+          Amount
         </label>
         <div className="relative">
           <input
@@ -152,16 +141,16 @@ const AmountStep: React.FC<AmountStepProps> = ({
             inputMode={isTokenMode ? 'decimal' : 'numeric'}
             value={localAmount}
             onChange={handleAmountChange}
-            placeholder={isTokenMode && config ? `Enter amount in ${config.symbol}` : 'Enter amount in satoshis'}
+            placeholder={isTokenMode && balance.config ? `Enter amount in ${balance.config.symbol}` : 'Enter amount in satoshis'}
             className="w-full p-4 pr-16 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             disabled={isLoading}
             min={isTokenMode ? undefined : 1}
             data-testid="amount-input"
           />
-          {hasTokenConfig && config && (
+          {hasTokenConfig && balance.config && (
             <CurrencySwitcher
               isTokenMode={isTokenMode}
-              tokenSymbol={config.symbol}
+              tokenSymbol={balance.config.symbol}
               onSwitch={handleToggleDenomination}
               disabled={isLoading}
             />
@@ -170,19 +159,26 @@ const AmountStep: React.FC<AmountStepProps> = ({
 
         {/* Quick amount buttons */}
         <div className="flex gap-2 mt-3">
-          {quickAmounts.map((quickAmount) => (
-            <button
-              key={quickAmount}
-              onClick={() => { setLocalAmount(String(quickAmount)); setFeesIncluded(false); }}
-              className={`flex-1 py-2 rounded-lg text-sm font-mono font-medium transition-all ${
-                amountNum === quickAmount && !isSendAll
-                  ? 'bg-spark-primary text-white'
-                  : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
-              }`}
-            >
-              {formatQuickAmount(quickAmount, config, isTokenMode)}
-            </button>
-          ))}
+          {quickAmounts.map((quickAmount) => {
+            const disabled = balance.exceedsBalance(quickAmount);
+            const isSelected = amountNum === quickAmount && !isSendAll;
+            return (
+              <button
+                key={quickAmount}
+                onClick={() => { setLocalAmount(String(quickAmount)); setFeesIncluded(false); setLocalError(null); }}
+                disabled={disabled}
+                className={`flex-1 py-2 rounded-lg text-sm font-mono font-medium transition-all ${
+                  isSelected
+                    ? 'bg-spark-electric text-white'
+                    : disabled
+                      ? 'opacity-40 cursor-not-allowed border border-spark-border text-spark-text-secondary'
+                      : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
+                }`}
+              >
+                {formatQuickAmount(quickAmount, balance.config, isTokenMode)}
+              </button>
+            );
+          })}
           {showSendAll && (
             <button
               onClick={() => {
@@ -194,6 +190,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
                   setLocalAmount(String(balanceSats));
                 }
                 setFeesIncluded(true);
+                setLocalError(null);
               }}
               className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
                 isSendAll
@@ -207,7 +204,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
         </div>
       </div>
 
-      <FormError error={error} />
+      <FormError error={localError || error} />
 
       {/* Action buttons */}
       <div className="flex gap-3">

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -20,7 +20,7 @@ export interface AmountStepProps {
   isLoading: boolean;
   error: string | null;
   onBack: () => void;
-  onNext: (amountSats: number, feesIncluded?: boolean, tokenIdentifier?: string, conversionOptions?: ConversionOptions) => void;
+  onNext: (amount: bigint, feesIncluded?: boolean, tokenIdentifier?: string, conversionOptions?: ConversionOptions) => void;
 }
 
 const AmountStep: React.FC<AmountStepProps> = ({
@@ -77,7 +77,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
     // Token send-all bypasses validation — amount goes directly as tokenBalance to the SDK
     if (isTokenMode && isSendAllToken && tokenBalance && stableBalance.tokenIdentifier) {
       onNext(
-        Number(tokenBalance),
+        tokenBalance,
         true,
         stableBalance.tokenIdentifier,
         { conversionType: { type: 'toBitcoin', fromTokenIdentifier: stableBalance.tokenIdentifier } },

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -2,14 +2,13 @@ import React, { useEffect, useState, useMemo } from 'react';
 import type { ConversionOptions } from '@breeztech/breez-sdk-spark';
 import { FormError, PrimaryButton, SecondaryButton } from '../../../components/ui';
 import { SpinnerIcon } from '../../../components/Icons';
-import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import {
   TOKEN_QUICK_AMOUNTS,
   SATS_QUICK_AMOUNTS,
   formatQuickAmount,
-  sanitizeTokenInput,
 } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
+import { useAmountInput } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 
 export interface AmountStepProps {
@@ -33,65 +32,78 @@ const AmountStep: React.FC<AmountStepProps> = ({
   onBack,
   onNext,
 }) => {
-  const stableBalance = useStableBalance();
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive);
+  const input = useAmountInput({ initialAmount: amount, balanceSats, tokenBalance });
+  const {
+    amountInput: localAmount,
+    setAmount,
+    setAmountInput: setLocalAmount,
+    isTokenMode,
+    setIsTokenMode,
+    toggleDenomination,
+    isStableBalanceActive,
+    tokenIdentifier,
+    tokenSymbol,
+    config,
+    parseToSats,
+    tokenBalanceDisplay,
+    formatSatsAsTokenDisplay,
+    tokenSendAllBelowThreshold,
+  } = input;
+
   const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance);
 
-  const [localAmount, setLocalAmount] = useState<string>(amount || '');
   const [feesIncluded, setFeesIncluded] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 
+  // Sync the parent-provided amount into the input when it changes (e.g. when
+  // the dialog re-opens with a prior value).
   useEffect(() => {
     setLocalAmount(amount || '');
-  }, [amount]);
-
-  // Force the input back to sats mode when stable balance is deactivated
-  // (e.g. user toggled it off while the dialog was open). Without this, the
-  // CurrencySwitcher disappears but isTokenMode stays true, leaving the input
-  // showing a fiat value that's no longer toggleable.
-  useEffect(() => {
-    if (!stableBalance.isActive && isTokenMode) {
-      setIsTokenMode(false);
-      setLocalAmount('');
-      setFeesIncluded(false);
-    }
-  }, [stableBalance.isActive, isTokenMode, setIsTokenMode]);
+  }, [amount, setLocalAmount]);
 
   const handleToggleDenomination = () => {
-    balance.setIsTokenMode?.(!isTokenMode);
-    setLocalAmount('');
+    toggleDenomination();
     setFeesIncluded(false);
   };
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    if (isTokenMode && balance.config) {
-      const sanitized = sanitizeTokenInput(value, balance.config.fractionSize);
-      if (sanitized !== null) {
-        setLocalAmount(sanitized);
-        setFeesIncluded(false);
-      }
-    } else {
-      setLocalAmount(value);
-      setFeesIncluded(false);
-    }
+    setAmount(e.target.value);
+    setFeesIncluded(false);
   };
 
   const validAmount = isTokenMode
     ? localAmount !== '' && parseFloat(localAmount) > 0
     : localAmount !== '' && parseInt(localAmount) > 0;
 
+  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
+  const amountNum = isTokenMode ? parseFloat(localAmount) || 0 : parseInt(localAmount) || 0;
+
+  // Send All target value in BTC-as-fiat (when in token mode without a token
+  // balance). null when not applicable or rounds below displayable.
+  const sendAllBtcInTokenDisplay = balanceSats !== undefined ? formatSatsAsTokenDisplay(balanceSats) : null;
+  const hasTokenBalance = tokenBalance !== undefined && tokenBalance > 0n;
+  const showSendAll = hasTokenBalance || (balanceSats !== undefined && balanceSats > 0);
+
+  const isSendAllToken = isTokenMode && hasTokenBalance && localAmount === tokenBalanceDisplay && feesIncluded;
+  const isSendAllBtcInTokenMode = isTokenMode
+    && !hasTokenBalance
+    && sendAllBtcInTokenDisplay !== null
+    && localAmount === sendAllBtcInTokenDisplay
+    && feesIncluded;
+  const isSendAllSats = !isTokenMode && balanceSats !== undefined && amountNum === balanceSats && feesIncluded;
+  const isSendAll = isSendAllSats || isSendAllToken || isSendAllBtcInTokenMode;
+
   const handleNext = () => {
     if (!validAmount) return;
     setLocalError(null);
 
     // Token send-all bypasses validation — amount goes directly as tokenBalance to the SDK
-    if (isTokenMode && isSendAllToken && tokenBalance && stableBalance.tokenIdentifier) {
+    if (isTokenMode && isSendAllToken && tokenBalance && tokenIdentifier) {
       onNext(
         tokenBalance,
         true,
-        stableBalance.tokenIdentifier,
-        { conversionType: { type: 'toBitcoin', fromTokenIdentifier: stableBalance.tokenIdentifier } },
+        tokenIdentifier,
+        { conversionType: { type: 'toBitcoin', fromTokenIdentifier: tokenIdentifier } },
       );
       return;
     }
@@ -110,68 +122,8 @@ const AmountStep: React.FC<AmountStepProps> = ({
     }
 
     // Safe to parse — validateAmount already confirmed the input is valid
-    onNext(balance.parseInputToSats(localAmount)!, feesIncluded);
+    onNext(parseToSats(localAmount)!, feesIncluded);
   };
-
-  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
-  const amountNum = isTokenMode ? parseFloat(localAmount) || 0 : parseInt(localAmount) || 0;
-
-  // Token send-all: format token balance as display string using BigInt math
-  // (matches formatTokenAmount used by the balance header)
-  const tokenBalanceDisplay = useMemo(() => {
-    if (!tokenBalance || !balance.config) return null;
-    const { decimals, fractionSize } = balance.config;
-    const divisor = BigInt(10 ** decimals);
-    const wholePart = tokenBalance / divisor;
-    const fractionalPart = tokenBalance % divisor;
-    const fractionalStr = fractionalPart.toString().padStart(decimals, '0').slice(0, fractionSize);
-    return `${wholePart}.${fractionalStr}`;
-  }, [tokenBalance, balance.config]);
-
-  // Send All paths:
-  //   - has token balance: switch to token mode, display token balance
-  //   - in token mode without token balance, but BTC > 0: display BTC sats
-  //     converted to fiat (so we don't drop a raw sats integer into a
-  //     fiat-denominated input)
-  //   - sats mode with BTC: display sats
-  const hasTokenBalance = tokenBalance !== undefined && tokenBalance > 0n;
-
-  // BTC balance expressed in the token (fiat) display unit. Computed only when
-  // the user is currently in token mode — used as the Send All target when
-  // there's no token balance to draw from.
-  const sendAllBtcInTokenDisplay = useMemo(() => {
-    if (!isTokenMode || !balance.config) return null;
-    if (balanceSats === undefined || balanceSats <= 0) return null;
-    if (stableBalance.btcFiatRate <= 0) return null;
-    const fiat = (balanceSats / 100_000_000) * stableBalance.btcFiatRate;
-    return fiat.toFixed(balance.config.fractionSize);
-  }, [isTokenMode, balance.config, balanceSats, stableBalance.btcFiatRate]);
-
-  const showSendAll = hasTokenBalance || (balanceSats !== undefined && balanceSats > 0);
-
-  // Send All in token mode is meaningless when both balance sources round
-  // below the displayable threshold (e.g. <$0.01 for USDB). Disable the
-  // button in that case so users don't get a useless "0.00" filled-in value.
-  const tokenSendAllBelowThreshold = useMemo(() => {
-    if (!isTokenMode || !balance.config) return false;
-    const threshold = BigInt(10 ** (balance.config.decimals - balance.config.fractionSize));
-    if (tokenBalance !== undefined && tokenBalance >= threshold) return false;
-    if (balanceSats !== undefined && balanceSats > 0 && stableBalance.btcFiatRate > 0) {
-      const fiat = (balanceSats / 100_000_000) * stableBalance.btcFiatRate;
-      const baseUnits = BigInt(Math.round(fiat * 10 ** balance.config.decimals));
-      if (baseUnits >= threshold) return false;
-    }
-    return true;
-  }, [isTokenMode, balance.config, tokenBalance, balanceSats, stableBalance.btcFiatRate]);
-
-  const isSendAllToken = isTokenMode && hasTokenBalance && localAmount === tokenBalanceDisplay && feesIncluded;
-  const isSendAllBtcInTokenMode = isTokenMode
-    && !hasTokenBalance
-    && sendAllBtcInTokenDisplay !== null
-    && localAmount === sendAllBtcInTokenDisplay
-    && feesIncluded;
-  const isSendAllSats = !isTokenMode && balanceSats !== undefined && amountNum === balanceSats && feesIncluded;
-  const isSendAll = isSendAllSats || isSendAllToken || isSendAllBtcInTokenMode;
 
   // Inline balance error — surface "Amount exceeds available balance" as the
   // user types instead of waiting for them to click Continue. Skipped for
@@ -206,16 +158,16 @@ const AmountStep: React.FC<AmountStepProps> = ({
             inputMode={isTokenMode ? 'decimal' : 'numeric'}
             value={localAmount}
             onChange={handleAmountChange}
-            placeholder={isTokenMode && balance.config ? `Enter amount in ${balance.config.symbol}` : 'Enter amount in satoshis'}
+            placeholder={isTokenMode && tokenSymbol ? `Enter amount in ${tokenSymbol}` : 'Enter amount in satoshis'}
             className="w-full p-4 pr-16 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             disabled={isLoading}
             min={isTokenMode ? undefined : 1}
             data-testid="amount-input"
           />
-          {stableBalance.isActive && balance.config && (
+          {isStableBalanceActive && tokenSymbol && (
             <CurrencySwitcher
               isTokenMode={isTokenMode}
-              tokenSymbol={balance.config.symbol}
+              tokenSymbol={tokenSymbol}
               onSwitch={handleToggleDenomination}
               disabled={isLoading}
             />
@@ -240,7 +192,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
                       : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
                 }`}
               >
-                {formatQuickAmount(quickAmount, balance.config, isTokenMode)}
+                {formatQuickAmount(quickAmount, config, isTokenMode)}
               </button>
             );
           })}

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -34,8 +34,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
   onNext,
 }) => {
   const stableBalance = useStableBalance();
-  const hasTokenConfig = !!stableBalance.displayConfig;
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
+  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive);
   const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance);
 
   const [localAmount, setLocalAmount] = useState<string>(amount || '');
@@ -45,6 +44,18 @@ const AmountStep: React.FC<AmountStepProps> = ({
   useEffect(() => {
     setLocalAmount(amount || '');
   }, [amount]);
+
+  // Force the input back to sats mode when stable balance is deactivated
+  // (e.g. user toggled it off while the dialog was open). Without this, the
+  // CurrencySwitcher disappears but isTokenMode stays true, leaving the input
+  // showing a fiat value that's no longer toggleable.
+  useEffect(() => {
+    if (!stableBalance.isActive && isTokenMode) {
+      setIsTokenMode(false);
+      setLocalAmount('');
+      setFeesIncluded(false);
+    }
+  }, [stableBalance.isActive, isTokenMode, setIsTokenMode]);
 
   const handleToggleDenomination = () => {
     balance.setIsTokenMode?.(!isTokenMode);
@@ -201,7 +212,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
             min={isTokenMode ? undefined : 1}
             data-testid="amount-input"
           />
-          {hasTokenConfig && balance.config && (
+          {stableBalance.isActive && balance.config && (
             <CurrencySwitcher
               isTokenMode={isTokenMode}
               tokenSymbol={balance.config.symbol}

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -85,6 +85,13 @@ const AmountStep: React.FC<AmountStepProps> = ({
       return;
     }
 
+    // BTC send-all displayed in token mode — pass the raw sats balance to
+    // avoid losing precision through fiat→sats round-tripping.
+    if (isSendAllBtcInTokenMode && balanceSats !== undefined) {
+      onNext(BigInt(balanceSats), true);
+      return;
+    }
+
     const validationError = balance.validateAmount(localAmount, feesIncluded);
     if (validationError) {
       setLocalError(validationError);
@@ -110,13 +117,50 @@ const AmountStep: React.FC<AmountStepProps> = ({
     return `${wholePart}.${fractionalStr}`;
   }, [tokenBalance, balance.config]);
 
-  // Send All: when stable balance is active, always use token path (switch to token mode if needed)
-  // When stable balance is not active, use sats path
+  // Send All paths:
+  //   - has token balance: switch to token mode, display token balance
+  //   - in token mode without token balance, but BTC > 0: display BTC sats
+  //     converted to fiat (so we don't drop a raw sats integer into a
+  //     fiat-denominated input)
+  //   - sats mode with BTC: display sats
   const hasTokenBalance = tokenBalance !== undefined && tokenBalance > 0n;
-  const showSendAll = hasTokenBalance || (!stableBalance.isActive && balanceSats !== undefined && balanceSats > 0);
+
+  // BTC balance expressed in the token (fiat) display unit. Computed only when
+  // the user is currently in token mode — used as the Send All target when
+  // there's no token balance to draw from.
+  const sendAllBtcInTokenDisplay = useMemo(() => {
+    if (!isTokenMode || !balance.config) return null;
+    if (balanceSats === undefined || balanceSats <= 0) return null;
+    if (stableBalance.btcFiatRate <= 0) return null;
+    const fiat = (balanceSats / 100_000_000) * stableBalance.btcFiatRate;
+    return fiat.toFixed(balance.config.fractionSize);
+  }, [isTokenMode, balance.config, balanceSats, stableBalance.btcFiatRate]);
+
+  const showSendAll = hasTokenBalance || (balanceSats !== undefined && balanceSats > 0);
+
+  // Send All in token mode is meaningless when both balance sources round
+  // below the displayable threshold (e.g. <$0.01 for USDB). Disable the
+  // button in that case so users don't get a useless "0.00" filled-in value.
+  const tokenSendAllBelowThreshold = useMemo(() => {
+    if (!isTokenMode || !balance.config) return false;
+    const threshold = BigInt(10 ** (balance.config.decimals - balance.config.fractionSize));
+    if (tokenBalance !== undefined && tokenBalance >= threshold) return false;
+    if (balanceSats !== undefined && balanceSats > 0 && stableBalance.btcFiatRate > 0) {
+      const fiat = (balanceSats / 100_000_000) * stableBalance.btcFiatRate;
+      const baseUnits = BigInt(Math.round(fiat * 10 ** balance.config.decimals));
+      if (baseUnits >= threshold) return false;
+    }
+    return true;
+  }, [isTokenMode, balance.config, tokenBalance, balanceSats, stableBalance.btcFiatRate]);
+
   const isSendAllToken = isTokenMode && hasTokenBalance && localAmount === tokenBalanceDisplay && feesIncluded;
-  const isSendAllSats = !isTokenMode && !stableBalance.isActive && balanceSats !== undefined && amountNum === balanceSats && feesIncluded;
-  const isSendAll = isSendAllSats || isSendAllToken;
+  const isSendAllBtcInTokenMode = isTokenMode
+    && !hasTokenBalance
+    && sendAllBtcInTokenDisplay !== null
+    && localAmount === sendAllBtcInTokenDisplay
+    && feesIncluded;
+  const isSendAllSats = !isTokenMode && balanceSats !== undefined && amountNum === balanceSats && feesIncluded;
+  const isSendAll = isSendAllSats || isSendAllToken || isSendAllBtcInTokenMode;
 
   // Inline balance error — surface "Amount exceeds available balance" as the
   // user types instead of waiting for them to click Continue. Skipped for
@@ -193,19 +237,28 @@ const AmountStep: React.FC<AmountStepProps> = ({
             <button
               onClick={() => {
                 if (hasTokenBalance && tokenBalanceDisplay) {
-                  // When stable balance is active, always use token path
+                  // Token send-all: switch to token mode + show token balance
                   if (!isTokenMode) setIsTokenMode(true);
                   setLocalAmount(tokenBalanceDisplay);
-                } else {
+                } else if (sendAllBtcInTokenDisplay !== null) {
+                  // No token balance but in token mode — fill with BTC sats
+                  // converted to fiat so the input stays in the user's chosen
+                  // unit instead of jumping back to sats.
+                  setLocalAmount(sendAllBtcInTokenDisplay);
+                } else if (balanceSats !== undefined) {
+                  // Sats mode (with or without stable balance)
                   setLocalAmount(String(balanceSats));
                 }
                 setFeesIncluded(true);
                 setLocalError(null);
               }}
+              disabled={tokenSendAllBelowThreshold}
               className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
-                isSendAll
-                  ? 'bg-spark-primary text-white'
-                  : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
+                tokenSendAllBelowThreshold
+                  ? 'opacity-40 cursor-not-allowed border border-spark-border text-spark-text-secondary'
+                  : isSendAll
+                    ? 'bg-spark-primary text-white'
+                    : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
               }`}
             >
               Send All

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -118,6 +118,16 @@ const AmountStep: React.FC<AmountStepProps> = ({
   const isSendAllSats = !isTokenMode && !stableBalance.isActive && balanceSats !== undefined && amountNum === balanceSats && feesIncluded;
   const isSendAll = isSendAllSats || isSendAllToken;
 
+  // Inline balance error — surface "Amount exceeds available balance" as the
+  // user types instead of waiting for them to click Continue. Skipped for
+  // empty/zero input (don't nag while still typing) and for send-all
+  // (which intentionally fills the full balance with feesIncluded on).
+  const inlineBalanceError = useMemo(() => {
+    if (amountNum <= 0) return null;
+    if (isSendAll) return null;
+    return balance.exceedsBalance(amountNum) ? 'Amount exceeds available balance' : null;
+  }, [amountNum, isSendAll, balance]);
+
   return (
     <div className="space-y-5">
       {/* Destination */}
@@ -204,7 +214,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
         </div>
       </div>
 
-      <FormError error={localError || error} />
+      <FormError error={inlineBalanceError || localError || error} />
 
       {/* Action buttons */}
       <div className="flex gap-3">
@@ -213,7 +223,7 @@ const AmountStep: React.FC<AmountStepProps> = ({
         </SecondaryButton>
         <PrimaryButton
           onClick={handleNext}
-          disabled={isLoading || !validAmount}
+          disabled={isLoading || !validAmount || !!inlineBalanceError}
           className="flex-1"
         >
           {isLoading ? (

--- a/src/features/send/steps/ConfirmStep.tsx
+++ b/src/features/send/steps/ConfirmStep.tsx
@@ -3,8 +3,9 @@ import { PrimaryButton, SecondaryButton, FormError } from '../../../components/u
 import { FeeBreakdownCard, SimpleFeeBreakdown } from '../../../components/FeeBreakdownCard';
 import { SpinnerIcon } from '../../../components/Icons';
 import { formatWithThinSpaces } from '../../../utils/formatNumber';
-import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { formatTokenAmount } from '../../../utils/tokenFormatting';
+import { useStableBalance } from '../../../contexts/StableBalanceContext';
+import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import type { ConversionEstimate } from '@breeztech/breez-sdk-spark';
 
 export interface ConfirmStepProps {
@@ -12,26 +13,32 @@ export interface ConfirmStepProps {
   feesSat: number | null;
   feesIncluded?: boolean;
   conversionEstimate?: ConversionEstimate | null;
+  balanceSats?: number;
+  tokenBalance?: bigint;
   error: string | null;
   isLoading: boolean;
   onBack?: () => void;
   onConfirm: () => void;
 }
 
-const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncluded, conversionEstimate, error, isLoading, onBack, onConfirm }) => {
+const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncluded, conversionEstimate, balanceSats, tokenBalance, error, isLoading, onBack, onConfirm }) => {
   const stableBalance = useStableBalance();
   const isTokenMode = stableBalance.isActive && !!stableBalance.displayConfig && !!conversionEstimate;
+  const balance = useBalanceValidation(isTokenMode, undefined, balanceSats, tokenBalance);
 
   const amount = Number(amountSats || 0n);
   const fee = Number(feesSat || 0);
   const total = feesIncluded ? amount : amount + fee;
 
+  const insufficientBalance = balance.checkInsufficientFunds({ isTokenMode, totalSats: total, conversionEstimate });
+  const balanceError = insufficientBalance ? 'Insufficient funds' : null;
+
   // Token-formatted values from conversion estimate
-  const tokenAmount = isTokenMode
-    ? formatTokenAmount(BigInt(conversionEstimate!.amountIn), stableBalance.displayConfig!)
+  const tokenAmount = isTokenMode && balance.config
+    ? formatTokenAmount(BigInt(conversionEstimate!.amountIn), balance.config)
     : null;
-  const tokenFee = isTokenMode
-    ? formatTokenAmount(BigInt(conversionEstimate!.fee), stableBalance.displayConfig!, { fullPrecision: true })
+  const tokenFee = isTokenMode && balance.config
+    ? formatTokenAmount(BigInt(conversionEstimate!.fee), balance.config, { fullPrecision: true })
     : null;
 
   return (
@@ -60,7 +67,7 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
         />
       )}
 
-      <FormError error={error} />
+      <FormError error={balanceError || error} />
 
       {/* Action buttons */}
       <div className="flex gap-3">
@@ -71,7 +78,7 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
         )}
         <PrimaryButton
           onClick={onConfirm}
-          disabled={isLoading}
+          disabled={isLoading || insufficientBalance}
           className={onBack ? 'flex-1' : 'w-full'}
         >
           {isLoading ? (

--- a/src/features/send/steps/ConfirmStep.tsx
+++ b/src/features/send/steps/ConfirmStep.tsx
@@ -6,6 +6,7 @@ import { formatWithThinSpaces } from '../../../utils/formatNumber';
 import { formatTokenAmount } from '../../../utils/tokenFormatting';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
+import { toSats } from '../../../types/sats';
 import type { ConversionEstimate } from '@breeztech/breez-sdk-spark';
 
 export interface ConfirmStepProps {
@@ -30,7 +31,13 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
   const fee = Number(feesSat || 0);
   const total = feesIncluded ? amount : amount + fee;
 
-  const insufficientBalance = balance.checkInsufficientFunds({ isTokenMode, totalSats: total, conversionEstimate });
+  // Convert the total to a validated Sats for the balance check. `total` is
+  // sourced from a prepare response so in practice this never exceeds the
+  // cap; if it somehow did, treat as insufficient funds.
+  const totalSats = toSats(total);
+  const insufficientBalance = totalSats === null
+    ? true
+    : balance.checkInsufficientFunds({ isTokenMode, totalSats, conversionEstimate });
   const balanceError = insufficientBalance ? 'Insufficient funds' : null;
 
   // Token-formatted values from conversion estimate

--- a/src/features/send/workflows/BitcoinWorkflow.tsx
+++ b/src/features/send/workflows/BitcoinWorkflow.tsx
@@ -10,11 +10,13 @@ interface BitcoinWorkflowProps {
   amountSats: bigint;
   feesIncluded?: boolean;
   conversionEstimate?: ConversionEstimate | null;
+  balanceSats?: number;
+  tokenBalance?: bigint;
   onBack: () => void;
   onSend: (options: { type: 'bitcoinAddress'; confirmationSpeed: 'fast' | 'medium' | 'slow' }) => Promise<void>;
 }
 
-const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, feesIncluded, conversionEstimate, onBack, onSend }) => {
+const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, feesIncluded, conversionEstimate, balanceSats, tokenBalance, onBack, onSend }) => {
   const [step, setStep] = useState<PaymentStep>('fee');
   // Fee selection happens here; processing/result are handled by parent
   const [selectedFeeRate, setSelectedFeeRate] = useState<'fast' | 'medium' | 'slow' | null>(null);
@@ -98,7 +100,7 @@ const BitcoinWorkflow: React.FC<BitcoinWorkflowProps> = ({ method, amountSats, f
 
       {/* Confirm */}
       {step === 'confirm' && (
-        <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} error={null} isLoading={false} onConfirm={handleSend} />
+        <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />
       )}
     </>
   );

--- a/src/features/send/workflows/Bolt11Workflow.tsx
+++ b/src/features/send/workflows/Bolt11Workflow.tsx
@@ -6,11 +6,13 @@ interface Bolt11WorkflowProps {
   method: Extract<SendPaymentMethod, { type: 'bolt11Invoice' }>;
   amountSats: bigint;
   conversionEstimate?: ConversionEstimate | null;
+  balanceSats?: number;
+  tokenBalance?: bigint;
   onBack: () => void;
   onSend: (options: { type: 'bolt11Invoice'; preferSpark: boolean }) => Promise<void>;
 }
 
-const Bolt11Workflow: React.FC<Bolt11WorkflowProps> = ({ method, amountSats, conversionEstimate, onSend }) => {
+const Bolt11Workflow: React.FC<Bolt11WorkflowProps> = ({ method, amountSats, conversionEstimate, balanceSats, tokenBalance, onBack, onSend }) => {
   const handleSend = () => {
     const preferSpark = method.sparkTransferFeeSats != null;
     return onSend({ type: 'bolt11Invoice', preferSpark });
@@ -24,7 +26,7 @@ const Bolt11Workflow: React.FC<Bolt11WorkflowProps> = ({ method, amountSats, con
     feesSat = method.lightningFeeSats;
   }
 
-  return <ConfirmStep amountSats={amountSats} feesSat={feesSat} conversionEstimate={conversionEstimate} error={null} isLoading={false} onConfirm={handleSend} />;
+  return <ConfirmStep amountSats={amountSats} feesSat={feesSat} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />;
 };
 
 export default Bolt11Workflow;

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -5,15 +5,14 @@ import { FormError, PrimaryButton, SecondaryButton } from '../../../components/u
 import ConfirmStep from '../steps/ConfirmStep';
 import { logger, LogCategory } from '@/services/logger';
 import { SpinnerIcon } from '@/components/Icons';
-import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import {
   TOKEN_QUICK_AMOUNTS,
-  sanitizeTokenInput,
   formatQuickAmount,
   formatTokenAmount,
   tokenAmountDisplaysAsZero,
 } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
+import { useAmountInput } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 
 interface LnurlWorkflowProps {
@@ -28,12 +27,27 @@ interface LnurlWorkflowProps {
 }
 
 const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, balanceSats, tokenBalance, onBack, onRun, onPrepare, onPay }) => {
-  const stableBalance = useStableBalance();
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive);
+  const input = useAmountInput({ balanceSats, tokenBalance });
+  const {
+    amountInput: amount,
+    setAmount,
+    setAmountInput,
+    isTokenMode,
+    setIsTokenMode,
+    toggleDenomination,
+    isStableBalanceActive,
+    tokenIdentifier,
+    tokenSymbol,
+    config,
+    btcFiatRate,
+    tokenBalanceDisplay,
+    formatSatsAsTokenDisplay,
+    tokenSendAllBelowThreshold,
+  } = input;
+
   const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance);
 
   const [step, setStep] = useState<PaymentStep>('amount');
-  const [amount, setAmount] = useState<string>('');
   const [feesIncluded, setFeesIncluded] = useState(false);
   const [comment, setComment] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
@@ -56,31 +70,17 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     return null;
   }, [balanceSats, maxSats]);
 
-  // Token send-all: format token balance as display string using BigInt math
-  // (matches formatTokenAmount used by the balance header)
-  const tokenBalanceDisplay = useMemo(() => {
-    if (!tokenBalance || !stableBalance.displayConfig) return null;
-    const { decimals, fractionSize } = stableBalance.displayConfig;
-    const divisor = BigInt(10 ** decimals);
-    const wholePart = tokenBalance / divisor;
-    const fractionalPart = tokenBalance % divisor;
-    const fractionalStr = fractionalPart.toString().padStart(decimals, '0').slice(0, fractionSize);
-    return `${wholePart}.${fractionalStr}`;
-  }, [tokenBalance, stableBalance.displayConfig]);
-
   const hasTokenBalance = tokenBalance !== undefined && tokenBalance > 0n;
 
-  // BTC balance expressed in the token (fiat) display unit. Capped at maxSats
-  // (LNURL upper bound) so Send All never overshoots the LNURL service's range.
+  // BTC balance expressed in the token (fiat) display unit, capped at maxSats
+  // (LNURL upper bound) and gated by minSats. Uses the hook helper for
+  // conversion + sub-threshold handling.
   const sendAllBtcInTokenDisplay = useMemo(() => {
-    if (!isTokenMode || !stableBalance.displayConfig) return null;
     if (balanceSats === undefined || balanceSats <= 0) return null;
-    if (stableBalance.btcFiatRate <= 0) return null;
     const cappedSats = Math.min(balanceSats, maxSats);
     if (cappedSats < minSats) return null;
-    const fiat = (cappedSats / 100_000_000) * stableBalance.btcFiatRate;
-    return fiat.toFixed(stableBalance.displayConfig.fractionSize);
-  }, [isTokenMode, balanceSats, maxSats, minSats, stableBalance.btcFiatRate, stableBalance.displayConfig]);
+    return formatSatsAsTokenDisplay(cappedSats);
+  }, [balanceSats, maxSats, minSats, formatSatsAsTokenDisplay]);
 
   const isSendAllToken = isTokenMode && hasTokenBalance && amount === tokenBalanceDisplay && feesIncluded;
   const isSendAllBtcInTokenMode = isTokenMode
@@ -89,39 +89,24 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     && amount === sendAllBtcInTokenDisplay
     && feesIncluded;
 
-  // Send All in token mode is meaningless when both balance sources round
-  // below the displayable threshold (e.g. <$0.01 for USDB).
-  const tokenSendAllBelowThreshold = useMemo(() => {
-    if (!isTokenMode || !stableBalance.displayConfig) return false;
-    const threshold = BigInt(10 ** (stableBalance.displayConfig.decimals - stableBalance.displayConfig.fractionSize));
-    if (tokenBalance !== undefined && tokenBalance >= threshold) return false;
-    if (balanceSats !== undefined && balanceSats > 0 && stableBalance.btcFiatRate > 0) {
-      const fiat = (balanceSats / 100_000_000) * stableBalance.btcFiatRate;
-      const baseUnits = BigInt(Math.round(fiat * 10 ** stableBalance.displayConfig.decimals));
-      if (baseUnits >= threshold) return false;
-    }
-    return true;
-  }, [isTokenMode, stableBalance.displayConfig, tokenBalance, balanceSats, stableBalance.btcFiatRate]);
-
-  // LNURL min/max range expressed in the token (fiat) display unit. Lets the
-  // user see the supported range without mentally converting from sats.
-  // Both bounds get a ~ prefix because the values are exchange-rate-derived.
+  // LNURL min/max range expressed in the token (fiat) display unit. Both
+  // bounds get a ~ prefix because the values are exchange-rate-derived.
   // Sub-threshold values (e.g. 1 sat at typical BTC prices rounds below
-  // $0.01) snap up to the smallest displayable amount ($0.01) instead of
-  // rendering as "0.00" or "< $0.01".
+  // $0.01) snap up to the smallest displayable amount ($0.01) so the range
+  // stays informative rather than rendering as "0.00" or "< $0.01".
   const tokenRangeDisplay = useMemo(() => {
-    if (!isTokenMode || !stableBalance.displayConfig || stableBalance.btcFiatRate <= 0) return null;
-    const config = stableBalance.displayConfig;
+    if (!isTokenMode || !config || btcFiatRate <= 0) return null;
     const minDisplayable = BigInt(10 ** (config.decimals - config.fractionSize));
-    const formatSats = (sats: number) => {
-      const fiat = (sats / 100_000_000) * stableBalance.btcFiatRate;
+    const formatBound = (sats: number) => {
+      const fiat = (sats / 100_000_000) * btcFiatRate;
       const baseUnits = BigInt(Math.round(fiat * 10 ** config.decimals));
       return tokenAmountDisplaysAsZero(baseUnits, config)
         ? formatTokenAmount(minDisplayable, config)
         : formatTokenAmount(baseUnits, config);
     };
-    return `~${formatSats(minSats)} – ~${formatSats(maxSats)}`;
-  }, [isTokenMode, stableBalance.displayConfig, stableBalance.btcFiatRate, minSats, maxSats]);
+    return `~${formatBound(minSats)} – ~${formatBound(maxSats)}`;
+  }, [isTokenMode, config, btcFiatRate, minSats, maxSats]);
+
   const description = useMemo(() => {
     const metadataArr = JSON.parse(parsed.metadataStr);
     for (let i = 0; i < metadataArr.length; i++) {
@@ -133,24 +118,13 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   }, [parsed]);
 
   const handleToggleDenomination = () => {
-    balance.setIsTokenMode?.(!isTokenMode);
-    setAmount('');
+    toggleDenomination();
     setFeesIncluded(false);
   };
 
   useEffect(() => {
     setError(null);
   }, [step]);
-
-  // Force the input back to sats mode when stable balance is deactivated.
-  // See AmountStep for details — same behavior here.
-  useEffect(() => {
-    if (!stableBalance.isActive && isTokenMode) {
-      setIsTokenMode(false);
-      setAmount('');
-      setFeesIncluded(false);
-    }
-  }, [stableBalance.isActive, isTokenMode, setIsTokenMode]);
 
   const onAmountNext = async () => {
     if (commentAllowed && commentMaxLen && comment.length > commentMaxLen) {
@@ -159,7 +133,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     }
 
     // Token send-all bypasses validation — amount goes directly as tokenBalance to the SDK
-    if (isSendAllToken && stableBalance.tokenIdentifier && tokenBalance) {
+    if (isSendAllToken && tokenIdentifier && tokenBalance) {
       setIsLoading(true);
       setError(null);
       try {
@@ -168,9 +142,9 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
           comment: comment ? comment : undefined,
           payRequest: parsed,
           feePolicy: feesIncluded ? 'feesIncluded' : undefined,
-          tokenIdentifier: stableBalance.tokenIdentifier,
+          tokenIdentifier,
           conversionOptions: {
-            conversionType: { type: 'toBitcoin', fromTokenIdentifier: stableBalance.tokenIdentifier },
+            conversionType: { type: 'toBitcoin', fromTokenIdentifier: tokenIdentifier },
           },
         });
         setPrepareResponse(resp);
@@ -283,7 +257,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     ? amount !== '' && parseFloat(amount) > 0
     : amount !== '' && parseInt(amount) > 0;
   const amountNum = isTokenMode ? parseFloat(amount) || 0 : parseInt(amount) || 0;
-  const isSendAllSats = !stableBalance.isActive && sendAllAmount !== null && amountNum === sendAllAmount && feesIncluded;
+  const isSendAllSats = !isStableBalanceActive && sendAllAmount !== null && amountNum === sendAllAmount && feesIncluded;
   const isSendAll = isSendAllSats || isSendAllToken || isSendAllBtcInTokenMode;
 
   // Inline balance error — surface "Amount exceeds available balance" as the
@@ -324,19 +298,11 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
             inputMode={isTokenMode ? 'decimal' : 'numeric'}
             value={amount}
             onChange={(e) => {
-              if (isTokenMode && balance.config) {
-                const sanitized = sanitizeTokenInput(e.target.value, balance.config.fractionSize);
-                if (sanitized !== null) {
-                  setAmount(sanitized);
-                  setFeesIncluded(false);
-                }
-              } else {
-                setAmount(e.target.value);
-                setFeesIncluded(false);
-              }
+              setAmount(e.target.value);
+              setFeesIncluded(false);
             }}
-            placeholder={isTokenMode && balance.config
-              ? `Enter amount in ${balance.config.symbol}`
+            placeholder={isTokenMode && tokenSymbol
+              ? `Enter amount in ${tokenSymbol}`
               : `Between ${minSats.toLocaleString('en-US').replace(/,/g, ' ')} and ${maxSats.toLocaleString('en-US').replace(/,/g, ' ')} sats`
             }
             className="w-full p-4 pr-16 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
@@ -344,10 +310,10 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
             min={isTokenMode ? undefined : minSats}
             max={isTokenMode ? undefined : maxSats}
           />
-          {stableBalance.isActive && balance.config && (
+          {isStableBalanceActive && tokenSymbol && (
             <CurrencySwitcher
               isTokenMode={isTokenMode}
-              tokenSymbol={balance.config.symbol}
+              tokenSymbol={tokenSymbol}
               onSwitch={handleToggleDenomination}
               disabled={isLoading}
             />
@@ -362,7 +328,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
             return (
               <button
                 key={quickAmount}
-                onClick={() => { setAmount(String(quickAmount)); setFeesIncluded(false); }}
+                onClick={() => { setAmountInput(String(quickAmount)); setFeesIncluded(false); }}
                 disabled={disabled}
                 className={`flex-1 py-2 text-sm font-medium rounded-lg transition-all ${
                   isSelected
@@ -372,7 +338,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
                       : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
                 }`}
               >
-                {formatQuickAmount(quickAmount, balance.config, isTokenMode)}
+                {formatQuickAmount(quickAmount, config, isTokenMode)}
               </button>
             );
           })}
@@ -383,14 +349,14 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
               onClick={() => {
                 if (hasTokenBalance && tokenBalanceDisplay) {
                   if (!isTokenMode) setIsTokenMode(true);
-                  setAmount(tokenBalanceDisplay);
+                  setAmountInput(tokenBalanceDisplay);
                 } else if (sendAllBtcInTokenDisplay !== null) {
                   // In token mode without token balance — fill with BTC sats
                   // converted to fiat (capped at maxSats). Avoids dropping a
                   // raw sats integer into a fiat-denominated input.
-                  setAmount(sendAllBtcInTokenDisplay);
+                  setAmountInput(sendAllBtcInTokenDisplay);
                 } else if (sendAllAmount !== null) {
-                  setAmount(String(sendAllAmount));
+                  setAmountInput(String(sendAllAmount));
                 }
                 setFeesIncluded(true);
               }}

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -193,6 +193,14 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   const isSendAllSats = !stableBalance.isActive && sendAllAmount !== null && amountNum === sendAllAmount && feesIncluded;
   const isSendAll = isSendAllSats || isSendAllToken;
 
+  // Inline balance error — surface "Amount exceeds available balance" as the
+  // user types instead of waiting for Continue. Computed inline (not via
+  // useMemo) because we're past the early-return for the confirm step and
+  // can't add a Hook here without violating rules-of-hooks.
+  const inlineBalanceError = amountNum > 0 && !isSendAll && balance.exceedsBalance(amountNum)
+    ? 'Amount exceeds available balance'
+    : null;
+
   // amount + optional comment form
   return (
     <div className="space-y-5">
@@ -313,14 +321,14 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
         </div>
       )}
 
-      <FormError error={error} />
+      <FormError error={inlineBalanceError || error} />
 
       {/* Action buttons */}
       <div className="flex gap-3">
         <SecondaryButton onClick={onBack} disabled={isLoading} className="flex-1">
           Back
         </SecondaryButton>
-        <PrimaryButton onClick={onAmountNext} disabled={isLoading || !validAmount} className="flex-1">
+        <PrimaryButton onClick={onAmountNext} disabled={isLoading || !validAmount || !!inlineBalanceError} className="flex-1">
           {isLoading ? (
             <span className="flex items-center justify-center gap-2">
               <SpinnerIcon />

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -6,36 +6,26 @@ import ConfirmStep from '../steps/ConfirmStep';
 import { logger, LogCategory } from '@/services/logger';
 import { SpinnerIcon } from '@/components/Icons';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
-import { useWallet } from '../../../contexts/WalletContext';
-import { fiatToSats, getTokenBalance, TOKEN_QUICK_AMOUNTS, sanitizeTokenInput, formatQuickAmount } from '../../../utils/tokenFormatting';
+import { TOKEN_QUICK_AMOUNTS, sanitizeTokenInput, formatQuickAmount } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
+import { useBalanceValidation } from '../hooks/useBalanceValidation';
 
 interface LnurlWorkflowProps {
   parsed: LnurlPayRequestDetails;
   recipientLabel?: string;
   balanceSats?: number;
+  tokenBalance?: bigint;
   onBack: () => void;
   onRun: (runner: () => Promise<void>, hasConversion?: boolean) => Promise<void>;
   onPrepare: (args: PrepareLnurlPayRequest) => Promise<PrepareLnurlPayResponse>;
   onPay: (prepareResponse: PrepareLnurlPayResponse) => Promise<void>;
 }
 
-const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, balanceSats, onBack, onRun, onPrepare, onPay }) => {
-  const wallet = useWallet();
+const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, balanceSats, tokenBalance, onBack, onRun, onPrepare, onPay }) => {
   const stableBalance = useStableBalance();
   const hasTokenConfig = !!stableBalance.displayConfig;
   const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
-  const [tokenBalanceRaw, setTokenBalanceRaw] = useState<bigint | null>(null);
-
-  // Fetch token balance for send-all in token mode
-  useEffect(() => {
-    if (!stableBalance.isActive || !stableBalance.tokenIdentifier) return;
-    wallet.getInfo({}).then(info => {
-      if (!info || !stableBalance.tokenIdentifier) return;
-      const tb = getTokenBalance(info.tokenBalances, stableBalance.tokenIdentifier);
-      setTokenBalanceRaw(tb?.balance ?? null);
-    }).catch(() => {});
-  }, [wallet, stableBalance.isActive, stableBalance.tokenIdentifier]);
+  const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance);
 
   const [step, setStep] = useState<PaymentStep>('amount');
   const [amount, setAmount] = useState<string>('');
@@ -64,16 +54,16 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   // Token send-all: format token balance as display string using BigInt math
   // (matches formatTokenAmount used by the balance header)
   const tokenBalanceDisplay = useMemo(() => {
-    if (!tokenBalanceRaw || !stableBalance.displayConfig) return null;
+    if (!tokenBalance || !stableBalance.displayConfig) return null;
     const { decimals, fractionSize } = stableBalance.displayConfig;
     const divisor = BigInt(10 ** decimals);
-    const wholePart = tokenBalanceRaw / divisor;
-    const fractionalPart = tokenBalanceRaw % divisor;
+    const wholePart = tokenBalance / divisor;
+    const fractionalPart = tokenBalance % divisor;
     const fractionalStr = fractionalPart.toString().padStart(decimals, '0').slice(0, fractionSize);
     return `${wholePart}.${fractionalStr}`;
-  }, [tokenBalanceRaw, stableBalance.displayConfig]);
+  }, [tokenBalance, stableBalance.displayConfig]);
 
-  const hasTokenBalance = tokenBalanceRaw !== null && tokenBalanceRaw > 0n;
+  const hasTokenBalance = tokenBalance !== undefined && tokenBalance > 0n;
   const isSendAllToken = isTokenMode && hasTokenBalance && amount === tokenBalanceDisplay && feesIncluded;
   const description = useMemo(() => {
     const metadataArr = JSON.parse(parsed.metadataStr);
@@ -86,7 +76,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   }, [parsed]);
 
   const handleToggleDenomination = () => {
-    setIsTokenMode(prev => !prev);
+    balance.setIsTokenMode?.(!isTokenMode);
     setAmount('');
     setFeesIncluded(false);
   };
@@ -96,21 +86,50 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   }, [step]);
 
   const onAmountNext = async () => {
-    let sats: number;
-    if (isTokenMode && stableBalance.displayConfig && stableBalance.btcFiatRate > 0) {
-      const fiatAmount = parseFloat(amount);
-      if (!fiatAmount || fiatAmount <= 0) {
-        setError('Please enter a valid amount');
-        return;
-      }
-      sats = fiatToSats(fiatAmount, stableBalance.btcFiatRate);
-    } else {
-      sats = parseInt(amount, 10);
-    }
-    if (!sats || sats <= 0) {
-      setError('Please enter a valid amount');
+    if (commentAllowed && commentMaxLen && comment.length > commentMaxLen) {
+      setError(`Comment must be at most ${commentMaxLen} characters`);
       return;
     }
+
+    // Token send-all bypasses validation — amount goes directly as tokenBalance to the SDK
+    if (isSendAllToken && stableBalance.tokenIdentifier && tokenBalance) {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const resp = await onPrepare({
+          amount: tokenBalance,
+          comment: comment ? comment : undefined,
+          payRequest: parsed,
+          feePolicy: feesIncluded ? 'feesIncluded' : undefined,
+          tokenIdentifier: stableBalance.tokenIdentifier,
+          conversionOptions: {
+            conversionType: { type: 'toBitcoin', fromTokenIdentifier: stableBalance.tokenIdentifier },
+          },
+        });
+        setPrepareResponse(resp);
+        setStep('confirm');
+      } catch (err) {
+        logger.error(LogCategory.PAYMENT, 'Failed to prepare LNURL Pay', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setError(`Failed to prepare LNURL Pay: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      } finally {
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    // Validate input and balance
+    const validationError = balance.validateAmount(amount, feesIncluded);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    // Safe to parse — validateAmount already confirmed the input is valid
+    const sats = balance.parseInputToSats(amount)!;
+
+    // LNURL range constraints (sats mode only — token mode is validated by the SDK)
     if (!isTokenMode) {
       if (minSats && sats < minSats) {
         setError(`Amount must be at least ₿${minSats.toLocaleString()}`);
@@ -121,31 +140,16 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
         return;
       }
     }
-    if (commentAllowed && commentMaxLen && comment.length > commentMaxLen) {
-      setError(`Comment must be at most ${commentMaxLen} characters`);
-      return;
-    }
 
     setIsLoading(true);
     setError(null);
     try {
-      const prepareRequest: PrepareLnurlPayRequest = {
+      const resp = await onPrepare({
         amount: BigInt(sats),
         comment: comment ? comment : undefined,
         payRequest: parsed,
         feePolicy: feesIncluded ? 'feesIncluded' : undefined,
-      };
-
-      // Token send-all: pass conversion options and token identifier
-      if (isSendAllToken && stableBalance.tokenIdentifier && tokenBalanceRaw) {
-        prepareRequest.amount = tokenBalanceRaw;
-        prepareRequest.tokenIdentifier = stableBalance.tokenIdentifier;
-        prepareRequest.conversionOptions = {
-          conversionType: { type: 'toBitcoin', fromTokenIdentifier: stableBalance.tokenIdentifier },
-        };
-      }
-
-      const resp = await onPrepare(prepareRequest);
+      });
       setPrepareResponse(resp);
       setStep('confirm');
     } catch (err) {
@@ -176,11 +180,9 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   if (step === 'confirm' && prepareResponse) {
     const confirmAmountSats = isSendAllToken
       ? BigInt(prepareResponse.amountSats)
-      : isTokenMode && stableBalance.btcFiatRate > 0
-        ? BigInt(fiatToSats(parseFloat(amount), stableBalance.btcFiatRate))
-        : BigInt(parseInt(amount, 10));
+      : BigInt(balance.parseInputToSats(amount) || 0);
     return (
-      <ConfirmStep amountSats={confirmAmountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} error={error} isLoading={isLoading} onConfirm={onConfirm} />
+      <ConfirmStep amountSats={confirmAmountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} error={error} isLoading={isLoading} onBack={() => { setPrepareResponse(null); setStep('amount'); }} onConfirm={onConfirm} />
     );
   }
 
@@ -217,8 +219,8 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
             inputMode={isTokenMode ? 'decimal' : 'numeric'}
             value={amount}
             onChange={(e) => {
-              if (isTokenMode && stableBalance.displayConfig) {
-                const sanitized = sanitizeTokenInput(e.target.value, stableBalance.displayConfig.fractionSize);
+              if (isTokenMode && balance.config) {
+                const sanitized = sanitizeTokenInput(e.target.value, balance.config.fractionSize);
                 if (sanitized !== null) {
                   setAmount(sanitized);
                   setFeesIncluded(false);
@@ -228,8 +230,8 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
                 setFeesIncluded(false);
               }
             }}
-            placeholder={isTokenMode && stableBalance.displayConfig
-              ? `Enter amount in ${stableBalance.displayConfig.symbol}`
+            placeholder={isTokenMode && balance.config
+              ? `Enter amount in ${balance.config.symbol}`
               : `Between ${minSats.toLocaleString('en-US').replace(/,/g, ' ')} and ${maxSats.toLocaleString('en-US').replace(/,/g, ' ')} sats`
             }
             className="w-full p-4 pr-16 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
@@ -237,10 +239,10 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
             min={isTokenMode ? undefined : minSats}
             max={isTokenMode ? undefined : maxSats}
           />
-          {hasTokenConfig && stableBalance.displayConfig && (
+          {hasTokenConfig && balance.config && (
             <CurrencySwitcher
               isTokenMode={isTokenMode}
-              tokenSymbol={stableBalance.displayConfig.symbol}
+              tokenSymbol={balance.config.symbol}
               onSwitch={handleToggleDenomination}
               disabled={isLoading}
             />
@@ -249,19 +251,26 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
 
         {/* Quick amount buttons */}
         <div className="flex gap-2 mt-3">
-          {(isTokenMode ? TOKEN_QUICK_AMOUNTS : [1000, 10000, 100000].filter(v => v >= minSats && v <= maxSats)).map((quickAmount) => (
-            <button
-              key={quickAmount}
-              onClick={() => { setAmount(String(quickAmount)); setFeesIncluded(false); }}
-              className={`flex-1 py-2 text-sm font-medium rounded-lg transition-all ${
-                amountNum === quickAmount && !isSendAll
-                  ? 'bg-spark-primary text-white'
-                  : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
-              }`}
-            >
-              {formatQuickAmount(quickAmount, stableBalance.displayConfig, isTokenMode)}
-            </button>
-          ))}
+          {(isTokenMode ? TOKEN_QUICK_AMOUNTS : [1000, 10000, 100000].filter(v => v >= minSats && v <= maxSats)).map((quickAmount) => {
+            const disabled = balance.exceedsBalance(quickAmount);
+            const isSelected = amountNum === quickAmount && !isSendAll;
+            return (
+              <button
+                key={quickAmount}
+                onClick={() => { setAmount(String(quickAmount)); setFeesIncluded(false); }}
+                disabled={disabled}
+                className={`flex-1 py-2 text-sm font-medium rounded-lg transition-all ${
+                  isSelected
+                    ? 'bg-spark-primary text-white'
+                    : disabled
+                      ? 'opacity-40 cursor-not-allowed border border-spark-border text-spark-text-secondary'
+                      : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
+                }`}
+              >
+                {formatQuickAmount(quickAmount, balance.config, isTokenMode)}
+              </button>
+            );
+          })}
           {(hasTokenBalance || (!stableBalance.isActive && sendAllAmount !== null && sendAllAmount >= minSats)) && (
             <button
               onClick={() => {

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -6,7 +6,13 @@ import ConfirmStep from '../steps/ConfirmStep';
 import { logger, LogCategory } from '@/services/logger';
 import { SpinnerIcon } from '@/components/Icons';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
-import { TOKEN_QUICK_AMOUNTS, sanitizeTokenInput, formatQuickAmount } from '../../../utils/tokenFormatting';
+import {
+  TOKEN_QUICK_AMOUNTS,
+  sanitizeTokenInput,
+  formatQuickAmount,
+  formatTokenAmount,
+  tokenAmountDisplaysAsZero,
+} from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 
@@ -64,7 +70,59 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   }, [tokenBalance, stableBalance.displayConfig]);
 
   const hasTokenBalance = tokenBalance !== undefined && tokenBalance > 0n;
+
+  // BTC balance expressed in the token (fiat) display unit. Capped at maxSats
+  // (LNURL upper bound) so Send All never overshoots the LNURL service's range.
+  const sendAllBtcInTokenDisplay = useMemo(() => {
+    if (!isTokenMode || !stableBalance.displayConfig) return null;
+    if (balanceSats === undefined || balanceSats <= 0) return null;
+    if (stableBalance.btcFiatRate <= 0) return null;
+    const cappedSats = Math.min(balanceSats, maxSats);
+    if (cappedSats < minSats) return null;
+    const fiat = (cappedSats / 100_000_000) * stableBalance.btcFiatRate;
+    return fiat.toFixed(stableBalance.displayConfig.fractionSize);
+  }, [isTokenMode, balanceSats, maxSats, minSats, stableBalance.btcFiatRate, stableBalance.displayConfig]);
+
   const isSendAllToken = isTokenMode && hasTokenBalance && amount === tokenBalanceDisplay && feesIncluded;
+  const isSendAllBtcInTokenMode = isTokenMode
+    && !hasTokenBalance
+    && sendAllBtcInTokenDisplay !== null
+    && amount === sendAllBtcInTokenDisplay
+    && feesIncluded;
+
+  // Send All in token mode is meaningless when both balance sources round
+  // below the displayable threshold (e.g. <$0.01 for USDB).
+  const tokenSendAllBelowThreshold = useMemo(() => {
+    if (!isTokenMode || !stableBalance.displayConfig) return false;
+    const threshold = BigInt(10 ** (stableBalance.displayConfig.decimals - stableBalance.displayConfig.fractionSize));
+    if (tokenBalance !== undefined && tokenBalance >= threshold) return false;
+    if (balanceSats !== undefined && balanceSats > 0 && stableBalance.btcFiatRate > 0) {
+      const fiat = (balanceSats / 100_000_000) * stableBalance.btcFiatRate;
+      const baseUnits = BigInt(Math.round(fiat * 10 ** stableBalance.displayConfig.decimals));
+      if (baseUnits >= threshold) return false;
+    }
+    return true;
+  }, [isTokenMode, stableBalance.displayConfig, tokenBalance, balanceSats, stableBalance.btcFiatRate]);
+
+  // LNURL min/max range expressed in the token (fiat) display unit. Lets the
+  // user see the supported range without mentally converting from sats.
+  // Both bounds get a ~ prefix because the values are exchange-rate-derived.
+  // Sub-threshold values (e.g. 1 sat at typical BTC prices rounds below
+  // $0.01) snap up to the smallest displayable amount ($0.01) instead of
+  // rendering as "0.00" or "< $0.01".
+  const tokenRangeDisplay = useMemo(() => {
+    if (!isTokenMode || !stableBalance.displayConfig || stableBalance.btcFiatRate <= 0) return null;
+    const config = stableBalance.displayConfig;
+    const minDisplayable = BigInt(10 ** (config.decimals - config.fractionSize));
+    const formatSats = (sats: number) => {
+      const fiat = (sats / 100_000_000) * stableBalance.btcFiatRate;
+      const baseUnits = BigInt(Math.round(fiat * 10 ** config.decimals));
+      return tokenAmountDisplaysAsZero(baseUnits, config)
+        ? formatTokenAmount(minDisplayable, config)
+        : formatTokenAmount(baseUnits, config);
+    };
+    return `~${formatSats(minSats)} – ~${formatSats(maxSats)}`;
+  }, [isTokenMode, stableBalance.displayConfig, stableBalance.btcFiatRate, minSats, maxSats]);
   const description = useMemo(() => {
     const metadataArr = JSON.parse(parsed.metadataStr);
     for (let i = 0; i < metadataArr.length; i++) {
@@ -105,6 +163,32 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
           conversionOptions: {
             conversionType: { type: 'toBitcoin', fromTokenIdentifier: stableBalance.tokenIdentifier },
           },
+        });
+        setPrepareResponse(resp);
+        setStep('confirm');
+      } catch (err) {
+        logger.error(LogCategory.PAYMENT, 'Failed to prepare LNURL Pay', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setError(`Failed to prepare LNURL Pay: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      } finally {
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    // BTC send-all displayed in token mode — use the raw sats balance (capped
+    // at maxSats) to avoid losing precision through fiat→sats round-tripping.
+    if (isSendAllBtcInTokenMode && balanceSats !== undefined) {
+      const cappedSats = Math.min(balanceSats, maxSats);
+      setIsLoading(true);
+      setError(null);
+      try {
+        const resp = await onPrepare({
+          amount: BigInt(cappedSats),
+          comment: comment ? comment : undefined,
+          payRequest: parsed,
+          feePolicy: 'feesIncluded',
         });
         setPrepareResponse(resp);
         setStep('confirm');
@@ -191,7 +275,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     : amount !== '' && parseInt(amount) > 0;
   const amountNum = isTokenMode ? parseFloat(amount) || 0 : parseInt(amount) || 0;
   const isSendAllSats = !stableBalance.isActive && sendAllAmount !== null && amountNum === sendAllAmount && feesIncluded;
-  const isSendAll = isSendAllSats || isSendAllToken;
+  const isSendAll = isSendAllSats || isSendAllToken || isSendAllBtcInTokenMode;
 
   // Inline balance error — surface "Amount exceeds available balance" as the
   // user types instead of waiting for Continue. Computed inline (not via
@@ -215,9 +299,13 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
           <label className="block text-sm font-medium text-spark-text-primary">
             Amount
           </label>
-          {!isTokenMode && (
+          {!isTokenMode ? (
             <span className="text-xs text-spark-text-secondary">
               {minSats.toLocaleString('en-US').replace(/,/g, ' ')} – {maxSats.toLocaleString('en-US').replace(/,/g, ' ')}
+            </span>
+          ) : tokenRangeDisplay && (
+            <span className="text-xs text-spark-text-secondary">
+              {tokenRangeDisplay}
             </span>
           )}
         </div>
@@ -279,21 +367,31 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
               </button>
             );
           })}
-          {(hasTokenBalance || (!stableBalance.isActive && sendAllAmount !== null && sendAllAmount >= minSats)) && (
+          {(hasTokenBalance
+            || sendAllBtcInTokenDisplay !== null
+            || (sendAllAmount !== null && sendAllAmount >= minSats)) && (
             <button
               onClick={() => {
                 if (hasTokenBalance && tokenBalanceDisplay) {
                   if (!isTokenMode) setIsTokenMode(true);
                   setAmount(tokenBalanceDisplay);
+                } else if (sendAllBtcInTokenDisplay !== null) {
+                  // In token mode without token balance — fill with BTC sats
+                  // converted to fiat (capped at maxSats). Avoids dropping a
+                  // raw sats integer into a fiat-denominated input.
+                  setAmount(sendAllBtcInTokenDisplay);
                 } else if (sendAllAmount !== null) {
                   setAmount(String(sendAllAmount));
                 }
                 setFeesIncluded(true);
               }}
+              disabled={tokenSendAllBelowThreshold}
               className={`flex-1 py-2 text-sm font-medium rounded-lg transition-all ${
-                isSendAll
-                  ? 'bg-spark-primary text-white'
-                  : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
+                tokenSendAllBelowThreshold
+                  ? 'opacity-40 cursor-not-allowed border border-spark-border text-spark-text-secondary'
+                  : isSendAll
+                    ? 'bg-spark-primary text-white'
+                    : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
               }`}
             >
               Send All

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -29,8 +29,7 @@ interface LnurlWorkflowProps {
 
 const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, balanceSats, tokenBalance, onBack, onRun, onPrepare, onPay }) => {
   const stableBalance = useStableBalance();
-  const hasTokenConfig = !!stableBalance.displayConfig;
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
+  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive);
   const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance);
 
   const [step, setStep] = useState<PaymentStep>('amount');
@@ -142,6 +141,16 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
   useEffect(() => {
     setError(null);
   }, [step]);
+
+  // Force the input back to sats mode when stable balance is deactivated.
+  // See AmountStep for details — same behavior here.
+  useEffect(() => {
+    if (!stableBalance.isActive && isTokenMode) {
+      setIsTokenMode(false);
+      setAmount('');
+      setFeesIncluded(false);
+    }
+  }, [stableBalance.isActive, isTokenMode, setIsTokenMode]);
 
   const onAmountNext = async () => {
     if (commentAllowed && commentMaxLen && comment.length > commentMaxLen) {
@@ -335,7 +344,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
             min={isTokenMode ? undefined : minSats}
             max={isTokenMode ? undefined : maxSats}
           />
-          {hasTokenConfig && balance.config && (
+          {stableBalance.isActive && balance.config && (
             <CurrencySwitcher
               isTokenMode={isTokenMode}
               tokenSymbol={balance.config.symbol}

--- a/src/features/send/workflows/SparkWorkflow.tsx
+++ b/src/features/send/workflows/SparkWorkflow.tsx
@@ -7,15 +7,17 @@ interface SparkWorkflowProps {
   amountSats: bigint;
   feesIncluded?: boolean;
   conversionEstimate?: ConversionEstimate | null;
+  balanceSats?: number;
+  tokenBalance?: bigint;
   onBack: () => void;
   onSend: (options?: SendPaymentOptions) => Promise<void>;
 }
 
-const SparkWorkflow: React.FC<SparkWorkflowProps> = ({ method, amountSats, feesIncluded, conversionEstimate, onSend }) => {
+const SparkWorkflow: React.FC<SparkWorkflowProps> = ({ method, amountSats, feesIncluded, conversionEstimate, balanceSats, tokenBalance, onBack, onSend }) => {
   // Currently no fee exposed for spark address
   const feesSat: number | null = method.type === 'sparkAddress' ? null : null;
   const handleSend = () => onSend();
-  return <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} error={null} isLoading={false} onConfirm={handleSend} />;
+  return <ConfirmStep amountSats={amountSats} feesSat={feesSat} feesIncluded={feesIncluded} conversionEstimate={conversionEstimate} balanceSats={balanceSats} tokenBalance={tokenBalance} error={null} isLoading={false} onBack={onBack} onConfirm={handleSend} />;
 };
 
 export default SparkWorkflow;

--- a/src/hooks/useAmountInput.ts
+++ b/src/hooks/useAmountInput.ts
@@ -1,0 +1,97 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useStableBalance } from '../contexts/StableBalanceContext';
+import {
+  parseAmountToSats,
+  sanitizeTokenInput,
+  type TokenDisplayConfig,
+} from '../utils/tokenFormatting';
+
+export interface UseAmountInputResult {
+  /** The raw display string bound to the input. Holds fiat in token mode, sats otherwise. */
+  amountInput: string;
+  /** Set the input from a user-typed value; sanitizes per current mode. */
+  setAmount: (value: string) => void;
+  /**
+   * Set the input from a known-good value (e.g. quick-amount buttons, send-all).
+   * Skips sanitization — the caller is responsible for passing a sane string.
+   */
+  setAmountInput: (value: string) => void;
+  /** Clear the input and any quick-amount selection state. */
+  resetAmount: () => void;
+  /** Whether the input is in fiat (token) mode. */
+  isTokenMode: boolean;
+  setIsTokenMode: (value: boolean | ((prev: boolean) => boolean)) => void;
+  /** Toggle between fiat (token) and sats; clears the input. */
+  toggleDenomination: () => void;
+  /** Token display config from StableBalanceContext (null when not configured). */
+  config: TokenDisplayConfig | null;
+  hasTokenConfig: boolean;
+  /** BTC→fiat rate exposed for callers that need it directly. */
+  btcFiatRate: number;
+  /** Parse the current input (or a passed string) to sats. Returns null when invalid. */
+  parseToSats: (input?: string) => number | null;
+  /** Current input parsed to sats; 0 when input is empty or invalid. */
+  amountSats: number;
+}
+
+/**
+ * Owns the shared state and parsing for an "amount input" — used by send, buy,
+ * and receive flows. Centralizes:
+ *   - input string state with mode-aware sanitization
+ *   - token (fiat) vs sats mode toggle, initialized from StableBalanceContext
+ *   - fiat→sats parsing via the shared `parseAmountToSats` utility
+ *
+ * Components still own their own validation rules (min/max, balance checks, etc.)
+ * — this hook only handles input plumbing.
+ */
+export function useAmountInput(initialAmount: string = ''): UseAmountInputResult {
+  const stableBalance = useStableBalance();
+  const config = stableBalance.displayConfig;
+  const hasTokenConfig = !!config;
+  const btcFiatRate = stableBalance.btcFiatRate;
+
+  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
+  const [amountInput, setAmountInput] = useState(initialAmount);
+
+  const setAmount = useCallback(
+    (value: string) => {
+      if (isTokenMode && config) {
+        const sanitized = sanitizeTokenInput(value, config.fractionSize);
+        if (sanitized !== null) setAmountInput(sanitized);
+      } else {
+        setAmountInput(value.replace(/[^0-9]/g, ''));
+      }
+    },
+    [isTokenMode, config],
+  );
+
+  const resetAmount = useCallback(() => setAmountInput(''), []);
+
+  const toggleDenomination = useCallback(() => {
+    setIsTokenMode((prev) => !prev);
+    setAmountInput('');
+  }, []);
+
+  const parseToSats = useCallback(
+    (input?: string): number | null =>
+      parseAmountToSats(input ?? amountInput, isTokenMode, btcFiatRate),
+    [amountInput, isTokenMode, btcFiatRate],
+  );
+
+  const amountSats = useMemo(() => parseToSats() ?? 0, [parseToSats]);
+
+  return {
+    amountInput,
+    setAmount,
+    setAmountInput,
+    resetAmount,
+    isTokenMode,
+    setIsTokenMode,
+    toggleDenomination,
+    config,
+    hasTokenConfig,
+    btcFiatRate,
+    parseToSats,
+    amountSats,
+  };
+}

--- a/src/hooks/useAmountInput.ts
+++ b/src/hooks/useAmountInput.ts
@@ -1,14 +1,25 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useStableBalance } from '../contexts/StableBalanceContext';
 import {
   parseAmountToSats,
   sanitizeTokenInput,
+  tokenAmountDisplaysAsZero,
   type TokenDisplayConfig,
 } from '../utils/tokenFormatting';
 import type { Sats } from '../types/sats';
 
+export interface UseAmountInputOptions {
+  /** Pre-fill the input on mount (e.g. when re-opening a dialog with a value). */
+  initialAmount?: string;
+  /** User's BTC balance in sats. Required for the BTC→token display helpers. */
+  balanceSats?: number;
+  /** User's token balance in base units. Required for the token-balance display helper. */
+  tokenBalance?: bigint;
+}
+
 export interface UseAmountInputResult {
-  /** The raw display string bound to the input. Holds fiat in token mode, sats otherwise. */
+  // ----- Input state -----
+  /** Display string bound to the input. Holds fiat in token mode, sats otherwise. */
   amountInput: string;
   /** Set the input from a user-typed value; sanitizes per current mode. */
   setAmount: (value: string) => void;
@@ -17,41 +28,75 @@ export interface UseAmountInputResult {
    * Skips sanitization — the caller is responsible for passing a sane string.
    */
   setAmountInput: (value: string) => void;
-  /** Clear the input and any quick-amount selection state. */
+  /** Clear the input. */
   resetAmount: () => void;
-  /** Whether the input is in fiat (token) mode. */
+
+  // ----- Mode -----
   isTokenMode: boolean;
   setIsTokenMode: (value: boolean | ((prev: boolean) => boolean)) => void;
   /** Toggle between fiat (token) and sats; clears the input. */
   toggleDenomination: () => void;
-  /** Token display config from StableBalanceContext (null when not configured). */
+
+  // ----- Stable balance state (encapsulated; no need to call useStableBalance) -----
+  /** True when stable balance is currently active — gates the CurrencySwitcher. */
+  isStableBalanceActive: boolean;
+  /** SDK token identifier (e.g. for routing token send-all payments). */
+  tokenIdentifier: string | null;
+  /** Token symbol for display (e.g. "$"). Null when not configured. */
+  tokenSymbol: string | null;
+  /** Underlying display config — escape hatch for callers that need the full shape. */
   config: TokenDisplayConfig | null;
-  hasTokenConfig: boolean;
-  /** BTC→fiat rate exposed for callers that need it directly. */
+  /** BTC→fiat rate. Escape hatch; prefer the formatting helpers. */
   btcFiatRate: number;
-  /** Parse the current input (or a passed string) to a validated Sats value. Returns null when invalid. */
+
+  // ----- Parsing -----
+  /** Parse the current input (or a passed string) to a validated Sats value. */
   parseToSats: (input?: string) => Sats | null;
   /** Current input parsed to Sats; null when input is empty or invalid. */
   amountSats: Sats | null;
+
+  // ----- Display helpers -----
+  /**
+   * The user's full token balance formatted as a display string (e.g. "10.50").
+   * Null when there's no token balance or no display config. Used as the Send
+   * All target value in token mode.
+   */
+  tokenBalanceDisplay: string | null;
+  /**
+   * Convert a sats value to a token display string (e.g. 50000 → "38.96").
+   * Returns null if the result rounds below the displayable threshold (e.g.
+   * <$0.01). Used to render BTC sats in token mode without dropping a raw
+   * sats integer into a fiat-denominated input.
+   */
+  formatSatsAsTokenDisplay: (sats: number) => string | null;
+  /**
+   * Whether Send All in token mode would be unusable (combined balance rounds
+   * below the displayable threshold). Components use this to disable the
+   * Send All button instead of letting the user click it for no effect.
+   */
+  tokenSendAllBelowThreshold: boolean;
 }
 
 /**
- * Owns the shared state and parsing for an "amount input" — used by send, buy,
- * and receive flows. Centralizes:
- *   - input string state with mode-aware sanitization
- *   - token (fiat) vs sats mode toggle, initialized from StableBalanceContext
- *   - fiat→sats parsing via the shared `parseAmountToSats` utility
+ * Single source of truth for amount input behavior across send, buy, and
+ * receive flows. Owns:
  *
- * Components still own their own validation rules (min/max, balance checks, etc.)
- * — this hook only handles input plumbing.
+ *   - Input string state with mode-aware sanitization
+ *   - Token (fiat) vs sats mode toggle, initialized from StableBalanceContext
+ *   - Auto-reset to sats mode when stable balance is deactivated mid-flow
+ *   - fiat→sats parsing via the shared `parseAmountToSats` utility
+ *   - Display helpers for token-balance, BTC-as-fiat, and sub-threshold checks
+ *
+ * Consumers should NOT call `useStableBalance()` directly for amount-input
+ * concerns — pass balances in here and use the returned helpers.
  */
-export function useAmountInput(initialAmount: string = ''): UseAmountInputResult {
+export function useAmountInput(options: UseAmountInputOptions = {}): UseAmountInputResult {
+  const { initialAmount = '', balanceSats, tokenBalance } = options;
   const stableBalance = useStableBalance();
   const config = stableBalance.displayConfig;
-  const hasTokenConfig = !!config;
   const btcFiatRate = stableBalance.btcFiatRate;
 
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
+  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive);
   const [amountInput, setAmountInput] = useState(initialAmount);
 
   const setAmount = useCallback(
@@ -73,6 +118,17 @@ export function useAmountInput(initialAmount: string = ''): UseAmountInputResult
     setAmountInput('');
   }, []);
 
+  // Auto-reset to sats mode when stable balance is deactivated mid-flow.
+  // Without this, the CurrencySwitcher disappears in the consumer but
+  // isTokenMode stays true, leaving a fiat value in the input that's no
+  // longer toggleable.
+  useEffect(() => {
+    if (!stableBalance.isActive && isTokenMode) {
+      setIsTokenMode(false);
+      setAmountInput('');
+    }
+  }, [stableBalance.isActive, isTokenMode]);
+
   const parseToSats = useCallback(
     (input?: string): Sats | null =>
       parseAmountToSats(input ?? amountInput, isTokenMode, btcFiatRate),
@@ -80,6 +136,40 @@ export function useAmountInput(initialAmount: string = ''): UseAmountInputResult
   );
 
   const amountSats = useMemo(() => parseToSats(), [parseToSats]);
+
+  const tokenBalanceDisplay = useMemo<string | null>(() => {
+    if (!tokenBalance || !config) return null;
+    const { decimals, fractionSize } = config;
+    const divisor = BigInt(10 ** decimals);
+    const wholePart = tokenBalance / divisor;
+    const fractionalPart = tokenBalance % divisor;
+    const fractionalStr = fractionalPart.toString().padStart(decimals, '0').slice(0, fractionSize);
+    return `${wholePart}.${fractionalStr}`;
+  }, [tokenBalance, config]);
+
+  const formatSatsAsTokenDisplay = useCallback<(sats: number) => string | null>(
+    (sats) => {
+      if (!config || !btcFiatRate || btcFiatRate <= 0) return null;
+      if (!Number.isFinite(sats) || sats <= 0) return null;
+      const fiat = (sats / 100_000_000) * btcFiatRate;
+      const baseUnits = BigInt(Math.round(fiat * 10 ** config.decimals));
+      if (tokenAmountDisplaysAsZero(baseUnits, config)) return null;
+      return fiat.toFixed(config.fractionSize);
+    },
+    [config, btcFiatRate],
+  );
+
+  const tokenSendAllBelowThreshold = useMemo<boolean>(() => {
+    if (!isTokenMode || !config) return false;
+    const threshold = BigInt(10 ** (config.decimals - config.fractionSize));
+    if (tokenBalance !== undefined && tokenBalance >= threshold) return false;
+    if (balanceSats !== undefined && balanceSats > 0 && btcFiatRate > 0) {
+      const fiat = (balanceSats / 100_000_000) * btcFiatRate;
+      const baseUnits = BigInt(Math.round(fiat * 10 ** config.decimals));
+      if (baseUnits >= threshold) return false;
+    }
+    return true;
+  }, [isTokenMode, config, tokenBalance, balanceSats, btcFiatRate]);
 
   return {
     amountInput,
@@ -89,10 +179,15 @@ export function useAmountInput(initialAmount: string = ''): UseAmountInputResult
     isTokenMode,
     setIsTokenMode,
     toggleDenomination,
+    isStableBalanceActive: stableBalance.isActive,
+    tokenIdentifier: stableBalance.tokenIdentifier,
+    tokenSymbol: config?.symbol ?? null,
     config,
-    hasTokenConfig,
     btcFiatRate,
     parseToSats,
     amountSats,
+    tokenBalanceDisplay,
+    formatSatsAsTokenDisplay,
+    tokenSendAllBelowThreshold,
   };
 }

--- a/src/hooks/useAmountInput.ts
+++ b/src/hooks/useAmountInput.ts
@@ -5,6 +5,7 @@ import {
   sanitizeTokenInput,
   type TokenDisplayConfig,
 } from '../utils/tokenFormatting';
+import type { Sats } from '../types/sats';
 
 export interface UseAmountInputResult {
   /** The raw display string bound to the input. Holds fiat in token mode, sats otherwise. */
@@ -28,10 +29,10 @@ export interface UseAmountInputResult {
   hasTokenConfig: boolean;
   /** BTC→fiat rate exposed for callers that need it directly. */
   btcFiatRate: number;
-  /** Parse the current input (or a passed string) to sats. Returns null when invalid. */
-  parseToSats: (input?: string) => number | null;
-  /** Current input parsed to sats; 0 when input is empty or invalid. */
-  amountSats: number;
+  /** Parse the current input (or a passed string) to a validated Sats value. Returns null when invalid. */
+  parseToSats: (input?: string) => Sats | null;
+  /** Current input parsed to Sats; null when input is empty or invalid. */
+  amountSats: Sats | null;
 }
 
 /**
@@ -73,12 +74,12 @@ export function useAmountInput(initialAmount: string = ''): UseAmountInputResult
   }, []);
 
   const parseToSats = useCallback(
-    (input?: string): number | null =>
+    (input?: string): Sats | null =>
       parseAmountToSats(input ?? amountInput, isTokenMode, btcFiatRate),
     [amountInput, isTokenMode, btcFiatRate],
   );
 
-  const amountSats = useMemo(() => parseToSats() ?? 0, [parseToSats]);
+  const amountSats = useMemo(() => parseToSats(), [parseToSats]);
 
   return {
     amountInput,

--- a/src/types/sats.test.ts
+++ b/src/types/sats.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { toSats, toSdkAmountNumber, MAX_SATS, addSats, gtSats, ZERO_SATS } from './sats';
+
+describe('toSats', () => {
+  it('accepts valid bigint values', () => {
+    expect(toSats(0n)).toBe(0n);
+    expect(toSats(1n)).toBe(1n);
+    expect(toSats(100_000_000n)).toBe(100_000_000n);
+    expect(toSats(MAX_SATS)).toBe(MAX_SATS);
+  });
+
+  it('accepts valid integer numbers', () => {
+    expect(toSats(0)).toBe(0n);
+    expect(toSats(100_000)).toBe(100_000n);
+    expect(toSats(Number(MAX_SATS))).toBe(MAX_SATS);
+  });
+
+  it('rejects values above MAX_SATS even when within MAX_SAFE_INTEGER', () => {
+    // MAX_SAFE_INTEGER (~9e15) is far above MAX_SATS (2.1e15), so anything
+    // between them must still be rejected.
+    expect(toSats(Number.MAX_SAFE_INTEGER)).toBeNull();
+  });
+
+  it('rejects negative values', () => {
+    expect(toSats(-1n)).toBeNull();
+    expect(toSats(-1)).toBeNull();
+  });
+
+  it('rejects non-integer numbers', () => {
+    expect(toSats(1.5)).toBeNull();
+    expect(toSats(NaN)).toBeNull();
+    expect(toSats(Infinity)).toBeNull();
+    expect(toSats(-Infinity)).toBeNull();
+  });
+
+  it('rejects values above the 21M BTC cap', () => {
+    expect(toSats(MAX_SATS + 1n)).toBeNull();
+    expect(toSats(MAX_SATS * 2n)).toBeNull();
+  });
+});
+
+describe('toSdkAmountNumber', () => {
+  it('converts safe Sats to a Number', () => {
+    expect(toSdkAmountNumber(0n as never)).toBe(0);
+    expect(toSdkAmountNumber(100_000n as never)).toBe(100_000);
+    expect(toSdkAmountNumber(MAX_SATS)).toBe(Number(MAX_SATS));
+  });
+
+  it('returns null for values exceeding MAX_SAFE_INTEGER (defensive)', () => {
+    // toSats() prevents this in normal flow, but the helper is a backstop.
+    const overflow = (BigInt(Number.MAX_SAFE_INTEGER) + 1n) as never;
+    expect(toSdkAmountNumber(overflow)).toBeNull();
+  });
+});
+
+describe('arithmetic helpers', () => {
+  it('addSats adds two Sats values', () => {
+    const a = toSats(100n)!;
+    const b = toSats(200n)!;
+    expect(addSats(a, b)).toBe(300n);
+  });
+
+  it('gtSats compares Sats values', () => {
+    const a = toSats(100n)!;
+    const b = toSats(200n)!;
+    expect(gtSats(b, a)).toBe(true);
+    expect(gtSats(a, b)).toBe(false);
+    expect(gtSats(a, a)).toBe(false);
+  });
+
+  it('ZERO_SATS is zero', () => {
+    expect(ZERO_SATS).toBe(0n);
+  });
+});

--- a/src/types/sats.ts
+++ b/src/types/sats.ts
@@ -1,0 +1,60 @@
+/**
+ * Branded type for Bitcoin satoshi amounts.
+ *
+ * Internally stored as `bigint` so we never lose precision when typing or
+ * doing arithmetic on large values. The brand prevents passing arbitrary
+ * `bigint` or `number` values where a validated sats amount is expected —
+ * callers must go through `toSats()` (or one of its variants) to construct.
+ *
+ * SDK methods that accept `number` (e.g. `receivePayment.amountSats`,
+ * `buyBitcoin.amountSats`) should be called via `toSdkAmountNumber()` so
+ * the safe-integer overflow check happens in exactly one place.
+ */
+export type Sats = bigint & { readonly __brand: 'Sats' };
+
+/** 21M BTC × 10⁸ sats — absolute upper bound for any valid Bitcoin amount. */
+export const MAX_SATS: Sats = (21_000_000n * 100_000_000n) as Sats;
+
+/** Constant zero, typed as Sats. */
+export const ZERO_SATS: Sats = 0n as Sats;
+
+/**
+ * Construct a `Sats` from a bigint or number. Returns null if the input
+ * is negative, non-integer, non-finite, or exceeds 21M BTC. Use this at
+ * every boundary where untyped numeric input enters the sats domain.
+ */
+export function toSats(n: bigint | number): Sats | null {
+  let value: bigint;
+  if (typeof n === 'bigint') {
+    value = n;
+  } else {
+    if (!Number.isFinite(n) || !Number.isInteger(n)) return null;
+    value = BigInt(n);
+  }
+  if (value < 0n || value > MAX_SATS) return null;
+  return value as Sats;
+}
+
+/**
+ * Convert a `Sats` value to a JS `number` for SDK methods that expect
+ * `amountSats: number`. Returns null if the value exceeds
+ * `Number.MAX_SAFE_INTEGER` — should never happen for `Sats` values that
+ * passed `toSats()` (MAX_SATS = 2.1×10¹⁵ is well below 2⁵³ ≈ 9×10¹⁵), but
+ * we re-check here as a runtime backstop in case future changes raise the
+ * cap.
+ */
+export function toSdkAmountNumber(sats: Sats): number | null {
+  if (sats > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+  return Number(sats);
+}
+
+/** Add two Sats values. */
+export function addSats(a: Sats, b: Sats): Sats {
+  return (a + b) as Sats;
+}
+
+/** True when `a > b`. Use instead of raw `>` so callers can't accidentally
+ * compare a Sats against a plain bigint or number. */
+export function gtSats(a: Sats, b: Sats): boolean {
+  return a > b;
+}

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -122,6 +122,28 @@ export function fiatToSats(fiatAmount: number, btcFiatRate: number): number {
 }
 
 /**
+ * Parse a user-entered amount string to sats.
+ * - Token mode: input is fiat (e.g. "10.50") → converts via btcFiatRate
+ * - Sats mode: input is integer sats
+ * Returns null when the input can't produce a positive sats value.
+ */
+export function parseAmountToSats(
+  input: string,
+  isTokenMode: boolean,
+  btcFiatRate: number,
+): number | null {
+  if (isTokenMode) {
+    if (!btcFiatRate || btcFiatRate <= 0) return null;
+    const fiat = Number(input);
+    if (!Number.isFinite(fiat) || fiat <= 0) return null;
+    return fiatToSats(fiat, btcFiatRate);
+  }
+  const sats = Number(input);
+  if (!Number.isInteger(sats) || sats <= 0) return null;
+  return sats;
+}
+
+/**
  * Extract displayable token amount from a payment.
  * - Token payments (details.type === 'token'): amount/fee are in token units
  * - Conversion payments: token step's amount/fee are in token units

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -125,22 +125,28 @@ export function fiatToSats(fiatAmount: number, btcFiatRate: number): number {
  * Parse a user-entered amount string to sats.
  * - Token mode: input is fiat (e.g. "10.50") → converts via btcFiatRate
  * - Sats mode: input is integer sats
- * Returns null when the input can't produce a positive sats value.
+ * Returns null when the input can't produce a positive sats value, or when
+ * the result exceeds JS safe-integer range (such values would lose precision
+ * and overflow the SDK's u64 wire type, causing silent hangs / garbage).
  */
 export function parseAmountToSats(
   input: string,
   isTokenMode: boolean,
   btcFiatRate: number,
 ): number | null {
+  let result: number;
   if (isTokenMode) {
     if (!btcFiatRate || btcFiatRate <= 0) return null;
     const fiat = Number(input);
     if (!Number.isFinite(fiat) || fiat <= 0) return null;
-    return fiatToSats(fiat, btcFiatRate);
+    result = fiatToSats(fiat, btcFiatRate);
+  } else {
+    const sats = Number(input);
+    if (!Number.isInteger(sats) || sats <= 0) return null;
+    result = sats;
   }
-  const sats = Number(input);
-  if (!Number.isInteger(sats) || sats <= 0) return null;
-  return sats;
+  if (!Number.isSafeInteger(result)) return null;
+  return result;
 }
 
 /**

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -1,4 +1,5 @@
 import type { TokenMetadata, FiatCurrency, Payment } from '@breeztech/breez-sdk-spark';
+import { toSats, type Sats } from '../types/sats';
 
 export interface TokenDisplayConfig {
   symbol: string;
@@ -122,31 +123,43 @@ export function fiatToSats(fiatAmount: number, btcFiatRate: number): number {
 }
 
 /**
- * Parse a user-entered amount string to sats.
+ * Parse a user-entered amount string to a validated `Sats` value.
  * - Token mode: input is fiat (e.g. "10.50") → converts via btcFiatRate
- * - Sats mode: input is integer sats
+ * - Sats mode: input is integer sats — parsed via BigInt so a 16-digit
+ *   string doesn't lose precision before the bounds check
+ *
  * Returns null when the input can't produce a positive sats value, or when
- * the result exceeds JS safe-integer range (such values would lose precision
- * and overflow the SDK's u64 wire type, causing silent hangs / garbage).
+ * the result exceeds the absolute Bitcoin max (21M BTC). Callers can rely
+ * on a non-null return being safe to pass anywhere in the sats domain.
  */
 export function parseAmountToSats(
   input: string,
   isTokenMode: boolean,
   btcFiatRate: number,
-): number | null {
-  let result: number;
+): Sats | null {
   if (isTokenMode) {
     if (!btcFiatRate || btcFiatRate <= 0) return null;
     const fiat = Number(input);
     if (!Number.isFinite(fiat) || fiat <= 0) return null;
-    result = fiatToSats(fiat, btcFiatRate);
-  } else {
-    const sats = Number(input);
-    if (!Number.isInteger(sats) || sats <= 0) return null;
-    result = sats;
+    // fiat→sats requires float division; convert the rounded result to
+    // bigint and let toSats() perform the bounds check.
+    const satsNumber = fiatToSats(fiat, btcFiatRate);
+    if (!Number.isFinite(satsNumber)) return null;
+    if (!Number.isSafeInteger(satsNumber)) return null;
+    return toSats(BigInt(satsNumber));
   }
-  if (!Number.isSafeInteger(result)) return null;
-  return result;
+  // Sats mode: parse via BigInt to preserve precision on long inputs, then
+  // bounds-check via toSats.
+  const trimmed = input.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  let big: bigint;
+  try {
+    big = BigInt(trimmed);
+  } catch {
+    return null;
+  }
+  if (big <= 0n) return null;
+  return toSats(big);
 }
 
 /**


### PR DESCRIPTION
This PR addresses 
- https://github.com/breez/glow-web/issues/155

and adds send amount validation against available balance.

## Changes
- Validate send amounts against available balance before preparing payment
- Account for stable balance when validating (SDK uses either BTC or tokens, not both)
- Validate total cost (amount + fees) in confirmation step
- Disable quick amount buttons that exceed available balance
- Add back navigation from LNURL confirm step
- Show "Amount exceeds available balance" inline as the user types (no Continue click required)
- Read balance live from a new `WalletInfoContext` so validation reflects mid-flow updates (auto-conversion, incoming payments) without reopening the dialog
- Extract `useAmountInput` hook + `parseAmountToSats` utility; centralize all amount-input plumbing (input state, mode toggle, sanitization, parsing, conversions, threshold checks) so send/buy/receive share one source of truth
- Cap Cash App purchases at $100k (their weekly verified-user limit)
- Introduce branded `Sats = bigint & { __brand }` type with a single validated constructor (`toSats`); migrate send/buy/receive to use it
- Eliminate string-passing for amounts between components (no more `parseInt(amount)` round-trips)
- Send All in token mode now works when token balance is 0 but BTC balance > 0 — fills the input with the USDB equivalent of the BTC balance, sends the raw sats to avoid round-trip precision loss
- Send All button disables in token mode when both balance sources round below the displayable threshold (e.g. <$0.01 for USDB)
- LNURL min/max range now renders in fiat when in token mode (e.g. `~$0.01 – ~$78,054`) with `~` prefixes to mark it as exchange-rate-derived
- CurrencySwitcher visibility now gates on `stableBalance.isActive` so toggling stable balance off globally hides the dialog's mode toggle in real time
- Receive: clear amount input when the invoice dialog closes so it doesn't persist a stale value on the next open

## Edge cases
- Convert fiat amounts to sats before comparing against balance
- Zero token balance falls back to BTC change
- Missing token balance falls back to sats-only check
- Token send-all bypasses input parsing/validation — amount goes directly to the SDK as the raw token balance
- `WalletInfoContext` is split from the SDK context so SDK consumers don't re-render on every sync
- Reject amounts that exceed `Number.MAX_SAFE_INTEGER` (sats) or 21M BTC (absolute Bitcoin cap) at the parser; surfaces as "Invalid amount"
- Sub-displayable LNURL minimums (e.g. 1 sat ≈ $0.00076) snap up to the smallest displayable unit ($0.01) instead of rendering as `0.00` or `< $0.01`
- BTC-in-token-mode Send All passes the raw sats balance to the SDK (capped at LNURL maxSats) — avoids the few-sat precision loss that would otherwise occur from fiat→sats round-tripping
- Stable balance toggled off mid-flow: `isTokenMode` auto-resets to false and amount input clears in all four flows (send, lnurl, buy, receive)

## Test plan

### Send — amount step (sats mode)
- [x] With balance ₿X, type X+1 → "Amount exceeds available balance" shows; Continue is gated
- [x] With balance ₿X, type X-1 → no error; Continue proceeds
- [x] Quick amounts above balance render disabled (greyed, not clickable)
- [x] Click Send All → input fills with full balance, Continue proceeds; showns an error if fee-included total is not affordable.

### Send — amount step (token mode)
- [x] With token balance T worth less than payment, but BTC balance covers the rest → amount allowed
- [x] Amount exceeding both token and BTC balances → "Amount exceeds available balance"
- [x] Toggle currency while a value is entered → input clears, no leftover error
- [ ] Token balance 0 + BTC balance > 0: Send All fills input with USDB equivalent of BTC balance and submits using raw sats (no precision loss)
- [x] Token balance < $0.01 AND BTC equivalent < $0.01: Send All button is disabled (greyed) in token mode

### Send — confirm step
- [x] LNURL confirm step now has a Back button → returns to amount entry preserving the typed amount

### Live balance updates
- [x] Open send dialog with balance ₿X. From another device, send a payment that raises balance to ₿Y. Without closing the dialog: previously-disabled quick buttons re-enable, previously-rejected amounts now pass validation
- [x] Same with stable balance active and an incoming auto-conversion (token credit while dialog is open) — new token balance is used immediately

### Stable Balance reactivity
- [x] Open send/receive/buy dialog while in token mode. Verify `CurrencySwitcher`(₿<=>$) is visible.
- [x] Switch back to sats mode, `CurrencySwitcher`(₿<=>$) should not be visible on send/receive/buy dialogs.

### LNURL Pay
- [x] Below `minSendable` → "Amount must be at least ₿X"
- [x] Above `maxSendable` or above balance → corresponding error; whichever is smaller wins
- [x] Token send-all (stable balance active) → Continue proceeds, confirm step shows the converted sats total
- [x] Token mode: range hint above the input shows fiat-equivalent bounds with `~` prefix (e.g. `~$0.01 – ~$78,054`)

### Buy Bitcoin — Cash App
- [x] Amount step accepts both sats and token (fiat) input
- [x] Currency switcher toggles cleanly and clears the input
- [x] Quick amounts populate the field in both modes
- [x] Continue with valid amount → QR (desktop) or external redirect (mobile)
- [x] Continue is disabled with empty/zero amount
- [x] Close and reopen dialog → amount field is empty (state reset)
- [x] Enter > $100k worth of sats or USDB → "Invalid amount" inline, Continue disabled

### Receive — Lightning invoice with custom amount
- [x] Enter normal amount in sats mode → invoice generates with that amount
- [x] Enter normal amount in token (fiat) mode → invoice generates with the fiat-converted sats amount
- [x] Enter very large value (e.g. 17 digits in sats, 14 digits in USDB) → "Invalid amount" inline, Generate Invoice disabled (previously: created a 1-sat invoice silently or threw a WASM error)
- [x] Currency switcher toggles cleanly and clears the input
- [x] Type an amount, close the dialog, reopen → input is empty (no stale value)