### PR TITLE
Fix blinking orange dot on failed payments

### DIFF
--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -121,8 +121,8 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onPayme
 
   const renderTransactionItem = (tx: Payment, index: number) => {
     const isReceive = tx.paymentType === 'receive';
-    const isPending = tx.status === 'pending' || tx.conversionDetails?.status === 'pending';
     const isFailed = tx.status === 'failed';
+    const isPending = !isFailed && (tx.status === 'pending' || tx.conversionDetails?.status === 'pending');
 
     return (
       <li


### PR DESCRIPTION
## Summary
- Failed Lightning payments with pending `conversionDetails` were showing a pulsing orange dot (pending indicator) instead of just the "Failed" badge
- Root cause: `isPending` checked `conversionDetails?.status === 'pending'` without first checking if the payment itself was failed
- Fix: compute `isFailed` first and gate `isPending` on `!isFailed`

## Test plan
- [ ] Verify failed payments show "Failed" badge without blinking orange dot
- [ ] Verify pending payments still show pulsing orange dot
- [ ] Verify completed payments show no pending indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)