### PR TITLE
Refresh wallet data on paymentFailed and paymentPending events

### DIFF
--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -199,10 +199,12 @@ export function useBreezSdk(
       logger.info(LogCategory.PAYMENT, 'Payment pending event received', {
         payment: JSON.parse(JSON.stringify(event.payment)),
       });
+      refreshWalletData(false);
     } else if (event.type === 'paymentFailed') {
       logger.info(LogCategory.PAYMENT, 'Payment failed event received', {
         payment: JSON.parse(JSON.stringify(event.payment)),
       });
+      refreshWalletData(false);
     } else if (event.type === 'claimedDeposits') {
       logger.info(LogCategory.PAYMENT, 'Deposits claimed', { count: event.claimedDeposits.length });
       showToastRef.current('success', 'Deposits Claimed Successfully', `${event.claimedDeposits.length} deposits were claimed`);


### PR DESCRIPTION
## Summary
- `paymentSucceeded` event handler called `refreshWalletData()` but `paymentFailed` and `paymentPending` did not
- This caused failed/pending payments to stay visually stuck in their previous state until the next `synced` event
- Root cause of the "blinking orange dot" on a failed Lightning payment — the SDK emitted `paymentFailed` but the app never refreshed, so the UI kept showing the payment as pending

## Test plan
- [ ] Send a Lightning payment that fails — verify it immediately shows as "Failed" without needing a manual refresh or cache clear
- [ ] Send a Lightning payment that goes pending — verify pending state is reflected immediately
- [ ] Verify paymentSucceeded still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)