### PR TITLE
Fix passkey login executing twice (regression)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,13 +217,9 @@ const AppContent: React.FC = () => {
       <FiatDataProvider>
         <StableBalanceProvider>
           <StableBalanceFormatterBridge formatterRef={formatPaymentAmountRef} />
-          {sdk.isConnected ? (
-            <ContactsProvider>
-              {renderCurrentScreen()}
-            </ContactsProvider>
-          ) : (
-            renderCurrentScreen()
-          )}
+          <ContactsProvider>
+            {renderCurrentScreen()}
+          </ContactsProvider>
           {sdk.celebrationPayment !== null && (
             <PaymentReceivedCelebration
               payment={sdk.celebrationPayment}


### PR DESCRIPTION
## Summary
- The Stable Balance commit (`b7319a0`) reintroduced the conditional `ContactsProvider` wrapping that was fixed in `7b44d4d`
- When `isConnected` flips to `true`, React tears down and remounts the entire subtree, resetting `PasskeyPage` state back to `detecting` and forcing a second WebAuthn flow
- Fix: make `ContactsProvider` unconditional again (safe because `useContacts` already handles `wallet === null`)

## Test plan
- [ ] Open Glow in incognito browser, use existing passkey — should only prompt once
- [ ] Open Glow in normal browser with cleared cache, use existing passkey — single prompt
- [ ] New user onboarding flow — completes without repeating steps
- [ ] Returning user with saved passkey — auto-reconnects without extra prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)