### PR TITLE
fix: display LNURL-Pay comments for received payments

### DIFF
--- a/src/components/PaymentDetailsDialog.tsx
+++ b/src/components/PaymentDetailsDialog.tsx
@@ -180,21 +180,24 @@ const PaymentDetailsDialog: React.FC<PaymentDetailsDialogProps> = ({ optionalPay
               )
             )}
 
-            {payment.details?.type === 'lightning' && payment.details.lnurlPayInfo?.comment && (
-              payment.details.lnurlPayInfo.comment.length > LONG_TEXT_THRESHOLD ? (
+            {payment.details?.type === 'lightning' && (() => {
+              const comment = payment.details.lnurlPayInfo?.comment
+                ?? payment.details.lnurlReceiveMetadata?.senderComment;
+              if (!comment) return null;
+              return comment.length > LONG_TEXT_THRESHOLD ? (
                 <CollapsibleCodeField
                   label="Comment"
-                  value={payment.details.lnurlPayInfo.comment}
+                  value={comment}
                   isVisible={visibleFields.comment}
                   onToggle={() => toggleField('comment')}
                 />
               ) : (
                 <PaymentInfoRow
                   label="Comment"
-                  value={payment.details.lnurlPayInfo.comment}
+                  value={comment}
                 />
-              )
-            )}
+              );
+            })()}
 
             {payment.details?.type === 'lightning' && payment.details.invoice && (
               <CollapsibleCodeField

--- a/src/utils/paymentDescription.ts
+++ b/src/utils/paymentDescription.ts
@@ -11,9 +11,16 @@ const tickerToDisplayName = (ticker: string): string =>
 const hasConversionInfo = (details?: PaymentDetails): boolean =>
   !!details && 'conversionInfo' in details && details.conversionInfo != null;
 
+/** Truncate text to maxLen characters, appending "..." if shortened */
+const truncate = (text: string, maxLen: number): string =>
+  text.length > maxLen ? `${text.slice(0, maxLen)}…` : text;
+
 export function getPaymentDescription(payment: Payment, findContactByAddress?: ContactLookup, fiatCurrencyName?: string | null): string {
   if (payment.method === 'lightning') {
     if (payment.details?.type === 'lightning') {
+      const comment = payment.details.lnurlPayInfo?.comment
+        ?? payment.details.lnurlReceiveMetadata?.senderComment;
+      if (comment) return truncate(comment, 50);
       if (payment.details.lnurlPayInfo?.lnAddress) {
         const contact = findContactByAddress?.(payment.details.lnurlPayInfo.lnAddress);
         const isSend = payment.paymentType === 'send';


### PR DESCRIPTION
## Summary
- The UI only checked `lnurlPayInfo.comment` (populated for **sent** payments), missing `lnurlReceiveMetadata.senderComment` where the SDK stores comments for **received** LNURL-Pay payments
- Now both sources are checked in the transaction list title (truncated to 50 chars) and the payment details dialog
- Works retroactively — the SDK syncs LNURL metadata from the server, so older payments already have the data in IndexedDB

## Test plan
- [ ] Send a payment to a glow wallet via LNURL-Pay with a comment — verify comment appears as the transaction title
- [ ] Tap the transaction — verify comment shows in the details dialog
- [ ] Send a payment **from** glow with a comment — verify it still displays correctly (no regression)
- [ ] Verify long comments (>50 chars) are truncated in the title with "…"
- [ ] Verify long comments (>35 chars) use the collapsible field in the details dialog

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)