### PR TITLE
feat: specify amount when buying via Cash App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -213,7 +213,7 @@ const AppContent: React.FC = () => {
   };
 
   return (
-    <WalletProvider client={sdk.sdk} isConnected={sdk.isConnected}>
+    <WalletProvider client={sdk.sdk} isConnected={sdk.isConnected} subscribeToSdkEvents={sdk.subscribeToSdkEvents}>
       <FiatDataProvider>
         <StableBalanceProvider>
           <StableBalanceFormatterBridge formatterRef={formatPaymentAmountRef} />

--- a/src/components/StableBalanceToggleFlow.tsx
+++ b/src/components/StableBalanceToggleFlow.tsx
@@ -123,9 +123,12 @@ const StableBalanceToggleFlow: React.FC<StableBalanceToggleFlowProps> = ({
     }
   }, [wallet, direction, getOrFetchFiatData]);
 
-  // Use a ref so the isOpen effect always calls the latest startEstimation
+  // Use refs so the isOpen effect snapshots the latest props/callbacks
+  // without re-firing when they change mid-flow.
   const startEstimationRef = useRef(startEstimation);
   startEstimationRef.current = startEstimation;
+  const restorePromptRef = useRef(restorePrompt);
+  restorePromptRef.current = restorePrompt;
 
   // Reset state when flow opens
   useEffect(() => {
@@ -135,7 +138,7 @@ const StableBalanceToggleFlow: React.FC<StableBalanceToggleFlowProps> = ({
       setError(null);
       setInfo(null);
 
-      if (restorePrompt || !hasAcceptedStableDisclaimer()) {
+      if (restorePromptRef.current || !hasAcceptedStableDisclaimer()) {
         setStep('disclaimer');
       } else {
         startEstimationRef.current();

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -13,6 +13,7 @@ import {
   AlertTriangleIcon,
   CheckIcon,
   ExternalLinkIcon,
+  BackIcon,
 } from '../Icons';
 
 // ============================================
@@ -95,9 +96,19 @@ DialogCard.displayName = 'DialogCard';
 export const DialogHeader: React.FC<{
   title: string;
   onClose: () => void;
+  onBack?: () => void;
   icon?: ReactNode;
-}> = ({ title, onClose, icon }) => (
+}> = ({ title, onClose, onBack, icon }) => (
   <div className="flex justify-center items-center mb-5 relative px-8">
+    {onBack && (
+      <button
+        onClick={onBack}
+        aria-label="Back"
+        className="absolute left-0 top-1/2 -translate-y-1/2 py-2 pl-6 pr-2 -ml-6 text-spark-text-muted hover:text-spark-text-primary transition-colors rounded-lg hover:bg-white/5"
+      >
+        <BackIcon />
+      </button>
+    )}
     <div className="flex items-center gap-2 min-w-0 max-w-full">
       {icon && <span className="text-spark-primary flex-shrink-0">{icon}</span>}
       <h2 className="font-display text-lg font-bold text-spark-text-primary truncate">{title}</h2>
@@ -105,7 +116,8 @@ export const DialogHeader: React.FC<{
     </div>
     <button
       onClick={onClose}
-      className="absolute right-0 top-1/2 -translate-y-1/2 p-2 -mr-2 text-spark-text-muted hover:text-spark-error transition-colors rounded-lg hover:bg-white/5"
+      aria-label="Close"
+      className="absolute right-0 top-1/2 -translate-y-1/2 py-2 pl-2 pr-6 -mr-6 text-spark-text-muted hover:text-spark-error transition-colors rounded-lg hover:bg-white/5"
     >
       <CloseIcon />
     </button>
@@ -210,6 +222,7 @@ export const CollapsibleCodeField: React.FC<{
 export const CopyableText: React.FC<{
   text: string;
   truncate?: boolean;
+  hideText?: boolean;
   showShare?: boolean;
   onCopied?: () => void;
   onShareError?: () => void;
@@ -220,7 +233,7 @@ export const CopyableText: React.FC<{
   textToShare?: string;
   shareLabel?: string;
   'data-testid'?: string;
-}> = ({ text, truncate = false, showShare = false, onCopied, onShareError, label = 'Address', additionalActions, textColor = 'text-spark-text-muted', textToCopy, textToShare, shareLabel, 'data-testid': testId }) => {
+}> = ({ text, truncate = false, hideText = false, showShare = false, onCopied, onShareError, label = 'Address', additionalActions, textColor = 'text-spark-text-muted', textToCopy, textToShare, shareLabel, 'data-testid': testId }) => {
   const [copied, setCopied] = React.useState(false);
   const [canShare, setCanShare] = React.useState(false);
 
@@ -266,14 +279,16 @@ export const CopyableText: React.FC<{
   return (
     <div className="flex flex-col items-center gap-4 w-full" data-testid={testId}>
       {/* Clickable text display */}
-      <button
-        onClick={handleCopy}
-        className={`text-center font-mono text-xs sm:text-sm break-all hover:opacity-80 transition-opacity ${textColor}`}
-        title="Tap to copy"
-        data-testid="copyable-text-content"
-      >
-        {displayText}
-      </button>
+      {!hideText && (
+        <button
+          onClick={handleCopy}
+          className={`text-center font-mono text-xs sm:text-sm break-all hover:opacity-80 transition-opacity ${textColor}`}
+          title="Tap to copy"
+          data-testid="copyable-text-content"
+        >
+          {displayText}
+        </button>
+      )}
 
       {/* Action buttons */}
       <div className="flex gap-2">

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -1,20 +1,35 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import type { BreezSdk } from '@breeztech/breez-sdk-spark';
+import type { SdkEventHandler, SdkEventUnsubscribe } from '../hooks/useBreezSdk';
+
+type SubscribeToSdkEvents = (handler: SdkEventHandler) => SdkEventUnsubscribe;
 
 interface WalletContextValue {
   sdk: BreezSdk | null;
   isConnected: boolean;
+  subscribeToSdkEvents: SubscribeToSdkEvents;
 }
 
-const WalletContext = createContext<WalletContextValue>({ sdk: null, isConnected: false });
+const noopSubscribe: SubscribeToSdkEvents = () => () => {};
+
+const WalletContext = createContext<WalletContextValue>({
+  sdk: null,
+  isConnected: false,
+  subscribeToSdkEvents: noopSubscribe,
+});
 
 export const WalletProvider: React.FC<{
   children: React.ReactNode;
   client: BreezSdk | null;
   isConnected?: boolean;
-}> = ({ children, client, isConnected = false }) => (
-  <WalletContext.Provider value={{ sdk: client, isConnected }}>{children}</WalletContext.Provider>
-);
+  subscribeToSdkEvents?: SubscribeToSdkEvents;
+}> = ({ children, client, isConnected = false, subscribeToSdkEvents = noopSubscribe }) => {
+  const value = useMemo(
+    () => ({ sdk: client, isConnected, subscribeToSdkEvents }),
+    [client, isConnected, subscribeToSdkEvents]
+  );
+  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
+};
 
 /**
  * Returns the connected BreezSdk instance.
@@ -33,4 +48,15 @@ export const useWallet = (): BreezSdk => {
  */
 export const useWalletConnection = () => {
   return useContext(WalletContext);
+};
+
+/**
+ * Subscribe to the app-wide SDK event stream. Returns the stable subscribe
+ * function; call it with a handler and invoke the returned unsubscribe when
+ * you're done. Feature hooks should prefer this over calling
+ * `sdk.addEventListener` directly so the app only maintains one SDK-level
+ * listener.
+ */
+export const useSdkEvents = (): SubscribeToSdkEvents => {
+  return useContext(WalletContext).subscribeToSdkEvents;
 };

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -1,12 +1,21 @@
-import React, { useState, useMemo } from 'react';
+import React from 'react';
 import {
   BottomSheetContainer,
   BottomSheetCard,
   DialogHeader,
+  PrimaryButton,
+  FormError,
+  QRCodeContainer,
+  CopyableText,
+  LoadingSpinner,
 } from '../../components/ui';
+import CurrencySwitcher from '../../components/ui/CurrencySwitcher';
 import type { Network } from '@breeztech/breez-sdk-spark';
 import { CurrencyIcon, MoonPayIcon, CashAppIcon } from '../../components/Icons';
-import { getBuyProviderSettings, filterProvidersByNetwork, type BuyBitcoinProvider } from '../../services/settings';
+import { type BuyBitcoinProvider } from '../../services/settings';
+import { useToast } from '../../contexts/ToastContext';
+import { formatQuickAmount } from '../../utils/tokenFormatting';
+import { useBuyBitcoin } from './hooks/useBuyBitcoin';
 
 const providerMeta: Record<BuyBitcoinProvider, { name: string; icon: React.ReactNode; loadingIcon: React.ReactNode }> = {
   moonpay: {
@@ -37,6 +46,12 @@ const providerMeta: Record<BuyBitcoinProvider, { name: string; icon: React.React
   },
 };
 
+const cashAppHeaderIcon = (
+  <div className="w-5 h-5 rounded bg-[#00D64F] flex items-center justify-center p-0.5">
+    <CashAppIcon className="w-full h-full text-[#00D64F]" />
+  </div>
+);
+
 interface BuyBitcoinDialogProps {
   isOpen: boolean;
   onClose: () => void;
@@ -50,51 +65,153 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
   onBuyBitcoin,
   network,
 }) => {
-  const [loading, setLoading] = useState<BuyBitcoinProvider | null>(null);
-  // Re-read provider settings each time the dialog opens, filtered by network
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const enabledProviders = useMemo(() => filterProvidersByNetwork(getBuyProviderSettings(), network), [isOpen, network]);
+  const { showToast } = useToast();
+  const buy = useBuyBitcoin({
+    isOpen,
+    network,
+    onSelectRedirectProvider: onBuyBitcoin,
+    onMobileRedirectComplete: onClose,
+  });
 
-  const handleSelectProvider = async (provider: BuyBitcoinProvider) => {
-    setLoading(provider);
-    try {
-      await onBuyBitcoin(provider);
-      onClose();
-    } catch {
-      // Error handling is done in useBreezSdk
-    } finally {
-      setLoading(null);
-    }
+  const handleSelect = async (provider: BuyBitcoinProvider) => {
+    await buy.selectProvider(provider);
+    if (provider === 'moonpay') onClose();
   };
 
   return (
     <BottomSheetContainer isOpen={isOpen} onClose={onClose} showBackdrop>
       <BottomSheetCard>
-        <DialogHeader
-          title="Buy Bitcoin"
-          onClose={onClose}
-          icon={<CurrencyIcon size="md" />}
-        />
+        {buy.step === 'select' && (
+          <>
+            <DialogHeader
+              title="Buy Bitcoin"
+              onClose={onClose}
+              icon={<CurrencyIcon size="md" />}
+            />
+            <div className="space-y-3">
+              {buy.enabledProviders.map((provider) => {
+                const meta = providerMeta[provider];
+                const isLoading = buy.redirectingProvider === provider;
+                return (
+                  <button
+                    key={provider}
+                    onClick={() => handleSelect(provider)}
+                    disabled={buy.redirectingProvider !== null}
+                    className="w-full flex items-center gap-4 p-4 rounded-2xl border border-spark-border hover:border-spark-primary/40 hover:bg-spark-primary/5 transition-all text-left disabled:opacity-50"
+                  >
+                    {isLoading ? meta.loadingIcon : meta.icon}
+                    <span className="font-display font-semibold text-spark-text-primary text-sm">
+                      {isLoading ? 'Redirecting…' : meta.name}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
 
-        <div className="space-y-3">
-          {enabledProviders.map((provider) => {
-            const meta = providerMeta[provider];
-            const isLoading = loading === provider;
-            return (
-              <button
-                key={provider}
-                onClick={() => handleSelectProvider(provider)}
-                disabled={loading !== null}
-                className="w-full flex items-center gap-4 p-4 rounded-2xl border border-spark-border hover:border-spark-primary/40 hover:bg-spark-primary/5 transition-all text-left disabled:opacity-50"
+        {buy.step === 'amount' && (
+          <>
+            <DialogHeader
+              title="Buy with Cash App"
+              onClose={onClose}
+              onBack={buy.goBackToSelect}
+              icon={cashAppHeaderIcon}
+            />
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-spark-text-primary mb-2">
+                  Amount
+                </label>
+                <div className="relative">
+                  <input
+                    type={buy.isTokenMode ? 'text' : 'number'}
+                    inputMode={buy.isTokenMode ? 'decimal' : 'numeric'}
+                    value={buy.amountInput}
+                    onChange={(e) => buy.setAmount(e.target.value)}
+                    placeholder={
+                      buy.isTokenMode && buy.tokenConfig
+                        ? `Enter amount in ${buy.tokenConfig.symbol}`
+                        : 'Enter amount in satoshis'
+                    }
+                    disabled={buy.isGenerating}
+                    min={buy.isTokenMode ? undefined : 1}
+                    className="w-full p-4 pr-16 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                    data-testid="cashapp-amount-input"
+                  />
+                  {buy.hasTokenConfig && buy.tokenConfig && (
+                    <CurrencySwitcher
+                      isTokenMode={buy.isTokenMode}
+                      tokenSymbol={buy.tokenConfig.symbol}
+                      onSwitch={buy.toggleDenomination}
+                      disabled={buy.isGenerating}
+                    />
+                  )}
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                {buy.quickAmounts.map((quickAmount) => (
+                  <button
+                    key={quickAmount}
+                    type="button"
+                    onClick={() => buy.setQuickAmount(quickAmount)}
+                    disabled={buy.isGenerating}
+                    className={`flex-1 py-2 rounded-lg text-sm font-mono font-medium transition-all ${
+                      buy.amountInput === String(quickAmount)
+                        ? 'bg-spark-primary text-white'
+                        : 'bg-transparent border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
+                    }`}
+                  >
+                    {formatQuickAmount(quickAmount, buy.tokenConfig, buy.isTokenMode)}
+                  </button>
+                ))}
+              </div>
+
+              <p className="text-xs text-spark-text-muted">
+                Cash App will show the equivalent amount in your local currency and charge your Cash or BTC balance.
+              </p>
+
+              <FormError error={buy.error} />
+
+              <PrimaryButton
+                onClick={buy.generate}
+                disabled={buy.isGenerating || !buy.validAmount}
+                className="w-full"
+                data-testid="cashapp-continue-button"
               >
-                {isLoading ? meta.loadingIcon : meta.icon}
-                <span className="font-display font-semibold text-spark-text-primary text-sm">
-                  {isLoading ? 'Redirecting…' : meta.name}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+                {buy.isGenerating ? <LoadingSpinner size="small" /> : 'Continue'}
+              </PrimaryButton>
+            </div>
+          </>
+        )}
+
+        {buy.step === 'qr' && buy.cashAppUrl && buy.generatedAmountSats !== null && (
+          <>
+            <DialogHeader
+              title="Buy with Cash App"
+              onClose={onClose}
+              onBack={buy.goBackToAmount}
+              icon={cashAppHeaderIcon}
+            />
+            <div className="flex flex-col items-center gap-6 pt-2">
+              <p className="text-center text-sm text-spark-text-secondary">
+                Scan this code with Cash App
+              </p>
+
+              <QRCodeContainer value={buy.cashAppUrl} />
+
+              <CopyableText
+                text={buy.cashAppUrl}
+                hideText
+                showShare
+                label="Cash App link"
+                onCopied={() => showToast('success', 'Copied!')}
+                onShareError={() => showToast('error', 'Failed to share')}
+              />
+            </div>
+          </>
+        )}
       </BottomSheetCard>
     </BottomSheetContainer>
   );

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -71,6 +71,7 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
     network,
     onSelectRedirectProvider: onBuyBitcoin,
     onMobileRedirectComplete: onClose,
+    onInvoicePaid: onClose,
   });
 
   const handleSelect = async (provider: BuyBitcoinProvider) => {

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -3,6 +3,7 @@ import type { Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '../../../contexts/WalletContext';
 import { useStableBalance } from '../../../contexts/StableBalanceContext';
 import { usePlatform } from '../../../hooks/usePlatform';
+import { useInvoicePaid } from '../../../hooks/useInvoicePaid';
 import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
 import {
@@ -31,6 +32,8 @@ export interface UseBuyBitcoinOptions {
   onSelectRedirectProvider: (provider: BuyBitcoinProvider) => Promise<void>;
   /** Called after a mobile Cash App redirect; the caller typically closes the dialog. */
   onMobileRedirectComplete: () => void;
+  /** Called when the displayed QR invoice is paid; the caller typically closes the dialog. */
+  onInvoicePaid: () => void;
 }
 
 export interface UseBuyBitcoinReturn {
@@ -66,6 +69,7 @@ export function useBuyBitcoin({
   network,
   onSelectRedirectProvider,
   onMobileRedirectComplete,
+  onInvoicePaid,
 }: UseBuyBitcoinOptions): UseBuyBitcoinReturn {
   const sdk = useWallet();
   const stableBalance = useStableBalance();
@@ -196,6 +200,16 @@ export function useBuyBitcoin({
       setIsGenerating(false);
     }
   }, [amountSats, isMobile, sdk, onMobileRedirectComplete]);
+
+  // Cash App URLs are `https://cash.app/launch/lightning/<bolt11>`. Extract the
+  // invoice only while we're showing the QR so the bus subscription pauses
+  // once we leave that step.
+  const activeInvoice = useMemo(() => {
+    if (step !== 'qr' || !cashAppUrl) return null;
+    return cashAppUrl.split('/').pop() ?? null;
+  }, [step, cashAppUrl]);
+
+  useInvoicePaid(activeInvoice, onInvoicePaid);
 
   const goBackToSelect = useCallback(() => {
     setStep('select');

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Network } from '@breeztech/breez-sdk-spark';
+import { useWallet } from '../../../contexts/WalletContext';
+import { useStableBalance } from '../../../contexts/StableBalanceContext';
+import { usePlatform } from '../../../hooks/usePlatform';
+import { logger, LogCategory } from '../../../services/logger';
+import { formatError } from '../../../utils/formatError';
+import {
+  fiatToSats,
+  sanitizeTokenInput,
+  TOKEN_QUICK_AMOUNTS,
+  type TokenDisplayConfig,
+} from '../../../utils/tokenFormatting';
+import {
+  getBuyProviderSettings,
+  filterProvidersByNetwork,
+  type BuyBitcoinProvider,
+} from '../../../services/settings';
+
+export type BuyStep = 'select' | 'amount' | 'qr';
+
+const CASH_APP_QUICK_AMOUNTS_SATS = [10000, 50000, 100000];
+const MIN_CASH_APP_SATS = 1;
+
+export interface UseBuyBitcoinOptions {
+  /** Whether the dialog is open — used to reset state when closed. */
+  isOpen: boolean;
+  /** Current network; filters the provider list (e.g. Cash App is mainnet-only). */
+  network?: Network;
+  /** Called for providers that redirect externally (MoonPay). */
+  onSelectRedirectProvider: (provider: BuyBitcoinProvider) => Promise<void>;
+  /** Called after a mobile Cash App redirect; the caller typically closes the dialog. */
+  onMobileRedirectComplete: () => void;
+}
+
+export interface UseBuyBitcoinReturn {
+  // State
+  step: BuyStep;
+  enabledProviders: BuyBitcoinProvider[];
+  redirectingProvider: BuyBitcoinProvider | null;
+  /** Display string bound to the input. Holds fiat in token mode, sats otherwise. */
+  amountInput: string;
+  cashAppUrl: string | null;
+  generatedAmountSats: number | null;
+  isGenerating: boolean;
+  error: string | null;
+  validAmount: boolean;
+  isMobile: boolean;
+  quickAmounts: number[];
+  // Token mode
+  isTokenMode: boolean;
+  hasTokenConfig: boolean;
+  tokenConfig: TokenDisplayConfig | null;
+  // Actions
+  selectProvider: (provider: BuyBitcoinProvider) => Promise<void>;
+  setAmount: (value: string) => void;
+  setQuickAmount: (value: number) => void;
+  toggleDenomination: () => void;
+  generate: () => Promise<void>;
+  goBackToSelect: () => void;
+  goBackToAmount: () => void;
+}
+
+export function useBuyBitcoin({
+  isOpen,
+  network,
+  onSelectRedirectProvider,
+  onMobileRedirectComplete,
+}: UseBuyBitcoinOptions): UseBuyBitcoinReturn {
+  const sdk = useWallet();
+  const stableBalance = useStableBalance();
+  const platform = usePlatform();
+  const isMobile = platform.isIOS || platform.isAndroid;
+
+  const hasTokenConfig = !!stableBalance.displayConfig;
+  const tokenConfig = stableBalance.displayConfig;
+
+  const [step, setStep] = useState<BuyStep>('select');
+  const [redirectingProvider, setRedirectingProvider] = useState<BuyBitcoinProvider | null>(null);
+  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive && hasTokenConfig);
+  const [amountInput, setAmountInput] = useState('');
+  const [cashAppUrl, setCashAppUrl] = useState<string | null>(null);
+  const [generatedAmountSats, setGeneratedAmountSats] = useState<number | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enabledProviders = useMemo(
+    () => filterProvidersByNetwork(getBuyProviderSettings(), network),
+    // Re-read when the dialog opens so updates from settings are reflected.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isOpen, network]
+  );
+
+  // Reset local state whenever the dialog closes.
+  useEffect(() => {
+    if (!isOpen) {
+      setStep('select');
+      setRedirectingProvider(null);
+      setIsTokenMode(stableBalance.isActive && hasTokenConfig);
+      setAmountInput('');
+      setCashAppUrl(null);
+      setGeneratedAmountSats(null);
+      setIsGenerating(false);
+      setError(null);
+    }
+  }, [isOpen, stableBalance.isActive, hasTokenConfig]);
+
+  const selectProvider = useCallback(
+    async (provider: BuyBitcoinProvider) => {
+      if (provider === 'cashApp') {
+        setStep('amount');
+        return;
+      }
+      setRedirectingProvider(provider);
+      try {
+        await onSelectRedirectProvider(provider);
+      } catch {
+        // Errors from redirect providers are handled upstream (toast + logging).
+      } finally {
+        setRedirectingProvider(null);
+      }
+    },
+    [onSelectRedirectProvider]
+  );
+
+  const setAmount = useCallback(
+    (value: string) => {
+      if (isTokenMode && tokenConfig) {
+        const sanitized = sanitizeTokenInput(value, tokenConfig.fractionSize);
+        if (sanitized !== null) {
+          setAmountInput(sanitized);
+          setError((prev) => (prev ? null : prev));
+        }
+      } else {
+        setAmountInput(value.replace(/[^0-9]/g, ''));
+        setError((prev) => (prev ? null : prev));
+      }
+    },
+    [isTokenMode, tokenConfig]
+  );
+
+  const setQuickAmount = useCallback((value: number) => {
+    setAmountInput(String(value));
+    setError(null);
+  }, []);
+
+  const toggleDenomination = useCallback(() => {
+    setIsTokenMode((prev) => !prev);
+    setAmountInput('');
+    setError(null);
+  }, []);
+
+  // Convert the input string to sats based on the current mode.
+  const amountSats = useMemo(() => {
+    if (amountInput === '') return 0;
+    if (isTokenMode && tokenConfig && stableBalance.btcFiatRate > 0) {
+      const fiat = parseFloat(amountInput);
+      if (!fiat || fiat <= 0) return 0;
+      return fiatToSats(fiat, stableBalance.btcFiatRate);
+    }
+    const sats = parseInt(amountInput, 10);
+    return Number.isFinite(sats) ? sats : 0;
+  }, [amountInput, isTokenMode, tokenConfig, stableBalance.btcFiatRate]);
+
+  const generate = useCallback(async () => {
+    if (!amountSats || amountSats < MIN_CASH_APP_SATS) {
+      setError(`Amount must be at least ₿${MIN_CASH_APP_SATS.toLocaleString()}`);
+      return;
+    }
+    setError(null);
+    setIsGenerating(true);
+
+    // Pre-open a blank tab synchronously during the user gesture so mobile
+    // browsers let us navigate it later without tripping popup blockers.
+    const mobileTab = isMobile ? window.open('', '_blank') : null;
+
+    try {
+      const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats });
+      setGeneratedAmountSats(amountSats);
+      if (isMobile) {
+        if (mobileTab) {
+          mobileTab.location.href = response.url;
+        } else {
+          window.location.href = response.url;
+        }
+        onMobileRedirectComplete();
+      } else {
+        setCashAppUrl(response.url);
+        setStep('qr');
+      }
+    } catch (e) {
+      mobileTab?.close();
+      logger.error(LogCategory.SDK, 'Failed to create Cash App buy URL', { error: formatError(e) });
+      setError('Failed to create invoice. Please try again.');
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [amountSats, isMobile, sdk, onMobileRedirectComplete]);
+
+  const goBackToSelect = useCallback(() => {
+    setStep('select');
+    setAmountInput('');
+    setError(null);
+  }, []);
+
+  const goBackToAmount = useCallback(() => {
+    setStep('amount');
+    setCashAppUrl(null);
+  }, []);
+
+  const validAmount = amountInput !== '' && amountSats >= MIN_CASH_APP_SATS;
+
+  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : CASH_APP_QUICK_AMOUNTS_SATS;
+
+  return {
+    step,
+    enabledProviders,
+    redirectingProvider,
+    amountInput,
+    cashAppUrl,
+    generatedAmountSats,
+    isGenerating,
+    error,
+    validAmount,
+    isMobile,
+    quickAmounts,
+    isTokenMode,
+    hasTokenConfig,
+    tokenConfig,
+    selectProvider,
+    setAmount,
+    setQuickAmount,
+    toggleDenomination,
+    generate,
+    goBackToSelect,
+    goBackToAmount,
+  };
+}

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -8,7 +8,6 @@ import { formatError } from '../../../utils/formatError';
 import {
   fiatToSats,
   sanitizeTokenInput,
-  TOKEN_QUICK_AMOUNTS,
   type TokenDisplayConfig,
 } from '../../../utils/tokenFormatting';
 import {
@@ -20,6 +19,7 @@ import {
 export type BuyStep = 'select' | 'amount' | 'qr';
 
 const CASH_APP_QUICK_AMOUNTS_SATS = [10000, 50000, 100000];
+const CASH_APP_QUICK_AMOUNTS_TOKEN = [5, 10, 25];
 const MIN_CASH_APP_SATS = 1;
 
 export interface UseBuyBitcoinOptions {
@@ -210,7 +210,7 @@ export function useBuyBitcoin({
 
   const validAmount = amountInput !== '' && amountSats >= MIN_CASH_APP_SATS;
 
-  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : CASH_APP_QUICK_AMOUNTS_SATS;
+  const quickAmounts = isTokenMode ? CASH_APP_QUICK_AMOUNTS_TOKEN : CASH_APP_QUICK_AMOUNTS_SATS;
 
   return {
     step,

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -11,6 +11,7 @@ import { LightningBoltIcon } from '../../components/Icons';
 import { useStableBalance } from '../../contexts/StableBalanceContext';
 import {
   TOKEN_QUICK_AMOUNTS,
+  SATS_QUICK_AMOUNTS,
   formatQuickAmount,
   sanitizeTokenInput,
   fiatToSats,
@@ -29,8 +30,6 @@ interface AmountPanelProps {
   onCreateInvoice: () => void;
   onClose: () => void;
 }
-
-const RECEIVE_QUICK_AMOUNTS_SATS = [100, 1000, 10000, 100000];
 
 const AmountPanel: React.FC<AmountPanelProps> = ({
   isOpen,
@@ -58,7 +57,7 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
     setDisplayAmount('');
   };
 
-  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : RECEIVE_QUICK_AMOUNTS_SATS;
+  const quickAmounts = isTokenMode ? TOKEN_QUICK_AMOUNTS : SATS_QUICK_AMOUNTS;
 
   const handleAmountChange = (value: string) => {
     if (isTokenMode && config) {

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -79,6 +79,9 @@ export interface BreezSdkState {
   prfAvailable: boolean;
 }
 
+export type SdkEventHandler = (event: SdkEvent) => void;
+export type SdkEventUnsubscribe = () => void;
+
 export interface BreezSdkActions {
   connectWallet: (seed: Seed, restore: boolean, passkeyLabel?: string) => Promise<void>;
   refreshWalletData: (showLoading?: boolean) => Promise<void>;
@@ -87,6 +90,7 @@ export interface BreezSdkActions {
   handleBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
   clearError: () => void;
   dismissCelebration: () => void;
+  subscribeToSdkEvents: (handler: SdkEventHandler) => SdkEventUnsubscribe;
 }
 
 // ============================================
@@ -115,6 +119,19 @@ export function useBreezSdk(
   const eventListenerIdRef = useRef<string | null>(null);
   const shownPaymentIdsRef = useRef<Set<string>>(new Set());
   const sdkRef = useLatest(sdk);
+
+  // In-app event bus: feature hooks subscribe here instead of creating their
+  // own SDK-level listeners, so we only ever register one listener per SDK.
+  const eventSubscribersRef = useRef<Set<SdkEventHandler>>(new Set());
+  const subscribeToSdkEvents = useCallback<BreezSdkActions['subscribeToSdkEvents']>(
+    (handler) => {
+      eventSubscribersRef.current.add(handler);
+      return () => {
+        eventSubscribersRef.current.delete(handler);
+      };
+    },
+    []
+  );
 
   // Stable refs for callbacks used in event handler
   const showToastRef = useLatest(showToast);
@@ -213,6 +230,16 @@ export function useBreezSdk(
       showToastRef.current('error', 'Failed to Claim Deposits', `${event.unclaimedDeposits.length} deposits could not be claimed`);
       fetchUnclaimedDeposits();
     }
+
+    // Fan out to feature subscribers. Each handler is isolated so one throwing
+    // does not prevent the others from running.
+    eventSubscribersRef.current.forEach((handler) => {
+      try {
+        handler(event);
+      } catch (e) {
+        logger.error(LogCategory.SDK, 'SDK event subscriber threw', { error: formatError(e) });
+      }
+    });
   }, [refreshWalletData, fetchUnclaimedDeposits, isSyncingRef, showToastRef]);
 
   // ----------------------------------------
@@ -475,5 +502,6 @@ export function useBreezSdk(
     handleBuyBitcoin,
     clearError: () => setError(null),
     dismissCelebration: () => setCelebrationPayment(null),
+    subscribeToSdkEvents,
   };
 }

--- a/src/hooks/useInvoicePaid.ts
+++ b/src/hooks/useInvoicePaid.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react';
+import { useSdkEvents } from '../contexts/WalletContext';
+
+/**
+ * Fire `onPaid` when a `paymentSucceeded` event arrives for the given
+ * Lightning invoice (bolt11). Pass `null`/`undefined` to pause listening.
+ *
+ * Uses the app-wide SDK event bus, so no SDK-level listener is created.
+ */
+export function useInvoicePaid(
+  bolt11: string | null | undefined,
+  onPaid: () => void,
+): void {
+  const subscribe = useSdkEvents();
+  const onPaidRef = useRef(onPaid);
+
+  useEffect(() => {
+    onPaidRef.current = onPaid;
+  }, [onPaid]);
+
+  useEffect(() => {
+    if (!bolt11) return;
+    const target = bolt11.toLowerCase();
+
+    return subscribe((event) => {
+      if (event.type !== 'paymentSucceeded') return;
+      const details = event.payment.details;
+      if (!details || details.type !== 'lightning') return;
+      if (details.invoice.toLowerCase() === target) {
+        onPaidRef.current();
+      }
+    });
+  }, [bolt11, subscribe]);
+}

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -197,7 +197,8 @@ const WalletPage: React.FC<WalletPageProps> = ({
           onOpenBuyBitcoin={() => {
             if (enabledBuyProviders.length === 0) {
               onOpenBuyProviders();
-            } else if (enabledBuyProviders.length === 1) {
+            } else if (enabledBuyProviders.length === 1 && enabledBuyProviders[0] === 'moonpay') {
+              // MoonPay can redirect directly; Cash App needs amount entry via the dialog.
               setIsBuyLoading(true);
               onBuyBitcoin(enabledBuyProviders[0]).finally(() => setIsBuyLoading(false));
             } else {

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -156,7 +156,7 @@ export function getTokenAmountFromPayment(payment: Payment): TokenPaymentInfo | 
 }
 
 /** Quick amount presets for token-denominated inputs. */
-export const TOKEN_QUICK_AMOUNTS = [1, 5, 10];
+export const TOKEN_QUICK_AMOUNTS = [5, 10, 25];
 
 /** Quick amount presets for sat-denominated inputs. */
 export const SATS_QUICK_AMOUNTS = [1000, 10000, 100000];

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -156,7 +156,7 @@ export function getTokenAmountFromPayment(payment: Payment): TokenPaymentInfo | 
 }
 
 /** Quick amount presets for token-denominated inputs. */
-export const TOKEN_QUICK_AMOUNTS = [5, 10, 25];
+export const TOKEN_QUICK_AMOUNTS = [1, 5, 10];
 
 /** Quick amount presets for sat-denominated inputs. */
 export const SATS_QUICK_AMOUNTS = [1000, 10000, 100000];


### PR DESCRIPTION
## Summary
Glow previously passed amountless Lightning invoices to Cash App, with this approach users were limited to paying from their BTC balance. This PR adds an amount-entry step to the Cash App flow so users can also complete the purchase using their USD cash balance.

Selecting Cash App now opens an amount step; on desktop the specified invoice is shown as a QR code, and on mobile the user is redirected to Cash App via deep link. 

## Test plan
- [ ] Press Buy button → select Cash App → enter sats amount → desktop shows QR, mobile redirects to app via external browser
- [ ] Click each token quick amount (\$5 / \$10 / \$25) and sats quick amount (₿10 000 / ₿50 000 / ₿100 000) → Generated invoice uses the correctly converted sats value
- [ ] Tap Back/Close icons near bottom-sheet edges: hit area reaches the card border without dead space.
- [ ] QR screen: Copy + Share buttons work