### PR TITLE
chore: upgrade @breeztech/breez-sdk-spark to 0.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "wasm-example-app",
       "version": "0.1.0",
       "dependencies": {
-        "@breeztech/breez-sdk-spark": "^0.13.1",
+        "@breeztech/breez-sdk-spark": "^0.13.5",
         "@headlessui/react": "^1.7.17",
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@breeztech/breez-sdk-spark": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.13.1.tgz",
-      "integrity": "sha512-ZVAs4VltIvLRGUgMB1YNi3Ei78SFFYueB6n8cvA+4lO97DrLw44fHSHxZDZiHLRA/Fdgp/WSvEAE3f3jUyycoA==",
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.13.5.tgz",
+      "integrity": "sha512-0IZNLMl4Wxecb4AAJoUTzwrelBFFf1pm6MjmgxHnm3Y0AVTwyeDnoxZDk+weWBx8U8zW229YZ17M0O9cL8HiDA==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
-    "@breeztech/breez-sdk-spark": "^0.13.1",
+    "@breeztech/breez-sdk-spark": "^0.13.5",
     "@headlessui/react": "^1.7.17",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",


### PR DESCRIPTION
## Summary
- Bumps `@breeztech/breez-sdk-spark` from `^0.13.1` to `^0.13.5`.
- No app code changes required: type check and unit tests pass as-is.

Closes #182

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` passes (41/41)
- [ ] Smoke test wallet flows on staging