### PR TITLE
chore: upgrade @breeztech/breez-sdk-spark to 0.13.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "wasm-example-app",
       "version": "0.1.0",
       "dependencies": {
-        "@breeztech/breez-sdk-spark": "^0.13.5",
+        "@breeztech/breez-sdk-spark": "^0.13.6",
         "@headlessui/react": "^1.7.17",
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
@@ -407,9 +407,9 @@
       }
     },
     "node_modules/@breeztech/breez-sdk-spark": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.13.5.tgz",
-      "integrity": "sha512-0IZNLMl4Wxecb4AAJoUTzwrelBFFf1pm6MjmgxHnm3Y0AVTwyeDnoxZDk+weWBx8U8zW229YZ17M0O9cL8HiDA==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.13.6.tgz",
+      "integrity": "sha512-vu5Zw2UV4Oe2lLxRPqMcPruhAlJTuRLXzf7yButcfj5mZ/Ea4LID1AC7EYwdbGGt8crdMYxu7qgT1U1BbyScKg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
-    "@breeztech/breez-sdk-spark": "^0.13.5",
+    "@breeztech/breez-sdk-spark": "^0.13.6",
     "@headlessui/react": "^1.7.17",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -363,16 +363,17 @@ export function useBreezSdk(
 
   const handleBuyBitcoin = useCallback(async (provider: BuyBitcoinProvider) => {
     if (!sdk) return;
+    // CashApp requires an amount and is driven by the BuyBitcoinDialog amount step
+    // (see useBuyBitcoin.generate), so this top-level handler only covers
+    // redirect-only providers like MoonPay.
+    if (provider === 'cashApp') return;
 
     // Pre-open a blank tab synchronously (during user gesture) to avoid popup blockers.
-    // On mobile/PWA this will likely return null — we fall back to same-tab navigation.
+    // On mobile/PWA this will likely return null, we fall back to same-tab navigation.
     const newTab = window.open('', '_blank');
 
     try {
-      const request = provider === 'cashApp'
-        ? { type: 'cashApp' as const }
-        : { type: 'moonpay' as const };
-      const response = await sdk.buyBitcoin(request);
+      const response = await sdk.buyBitcoin({ type: 'moonpay' });
       if (newTab) {
         newTab.location.href = response.url;
       } else {


### PR DESCRIPTION
## Summary
- Bumps `@breeztech/breez-sdk-spark` from `^0.13.5` to `^0.13.6`.
- Adapts to the only breaking change in the range, [SDK PR #834](https://github.com/breez/spark-sdk/pull/834): `BuyBitcoinRequest::CashApp::amount_sats` is now required (`u64`) instead of optional. The CashApp flow already collects an amount in `useBuyBitcoin.generate` and passes it to `sdk.buyBitcoin`, so the only fix is in the top-level `handleBuyBitcoin` (in `useBreezSdk.ts`), which is now narrowed to redirect-only providers (MoonPay). The CashApp branch there was unreachable: `useBuyBitcoin.selectProvider` short-circuits CashApp to the amount step before invoking `onSelectRedirectProvider`.
- Other commit in the range is internal: stale-reservation cleanup ordering. No app impact.

## SDK changelog
https://github.com/breez/spark-sdk/compare/0.13.5...0.13.6

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` passes (41/41)
- [ ] Smoke test MoonPay redirect on staging
- [ ] Smoke test CashApp amount flow + QR/redirect on staging