### PR TITLE
feat: separate passkey create and sign-in entry points

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { ContactsProvider } from './contexts/ContactsContext';
 import { useIOSViewportFix } from './hooks/useIOSViewportFix';
 import type { Seed, Payment } from '@breeztech/breez-sdk-spark';
 
-type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey';
+type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'passkeyCreate';
 
 // Bridge component that feeds StableBalance formatter back to useBreezSdk via a mutable ref
 const StableBalanceFormatterBridge: React.FC<{ formatterRef: React.MutableRefObject<((payment: Payment) => string) | undefined> }> = ({ formatterRef }) => {
@@ -83,7 +83,7 @@ const AppContent: React.FC = () => {
 
   // Render screens
   const renderCurrentScreen = () => {
-    if (sdk.isLoading && currentScreen !== 'restore' && currentScreen !== 'passkey') {
+    if (sdk.isLoading && currentScreen !== 'restore' && currentScreen !== 'passkey' && currentScreen !== 'passkeyCreate') {
       return (
         <div className="absolute inset-0 bg-spark-void/95 backdrop-blur-sm z-50 flex items-center justify-center">
           <LoadingSpinner />
@@ -97,6 +97,7 @@ const AppContent: React.FC = () => {
           <HomePage
             onRestoreWallet={() => setCurrentScreen('restore')}
             onCreateNewWallet={() => setCurrentScreen('generate')}
+            onCreatePasskey={() => setCurrentScreen('passkeyCreate')}
             onUsePasskey={() => setCurrentScreen('passkey')}
             prfAvailable={sdk.prfAvailable}
           />
@@ -112,6 +113,20 @@ const AppContent: React.FC = () => {
             }}
             sdkConnected={passkeySdkConnected}
             onFlowComplete={handlePasskeyFlowComplete}
+          />
+        );
+
+      case 'passkeyCreate':
+        return (
+          <PasskeyPage
+            onWalletRestored={handlePasskeyConnect}
+            onBack={() => {
+              setPasskeySdkConnected(false);
+              setCurrentScreen('home');
+            }}
+            sdkConnected={passkeySdkConnected}
+            onFlowComplete={handlePasskeyFlowComplete}
+            skipDetection
           />
         );
 
@@ -178,6 +193,7 @@ const AppContent: React.FC = () => {
             <HomePage
               onRestoreWallet={() => setCurrentScreen('restore')}
               onCreateNewWallet={() => setCurrentScreen('generate')}
+              onCreatePasskey={() => setCurrentScreen('passkeyCreate')}
               onUsePasskey={() => setCurrentScreen('passkey')}
               prfAvailable={sdk.prfAvailable}
             />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,6 +100,7 @@ const AppContent: React.FC = () => {
             onCreatePasskey={() => setCurrentScreen('passkeyCreate')}
             onUsePasskey={() => setCurrentScreen('passkey')}
             prfAvailable={sdk.prfAvailable}
+            hasPasskeyBefore={sdk.hasPasskeyBefore}
           />
         );
 

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -23,6 +23,7 @@ import {
   setPasskeyMode,
   clearPasskeyMode,
   getWallet,
+  hasPasskeyHistory,
 } from '../services/passkeyService';
 
 
@@ -77,6 +78,7 @@ export interface BreezSdkState {
   hasRejectedDeposits: boolean;
   celebrationPayment: Payment | null;
   prfAvailable: boolean;
+  hasPasskeyBefore: boolean;
 }
 
 export type SdkEventHandler = (event: SdkEvent) => void;
@@ -495,6 +497,7 @@ export function useBreezSdk(
     hasRejectedDeposits,
     celebrationPayment,
     prfAvailable,
+    hasPasskeyBefore: hasPasskeyHistory(),
     // Actions
     connectWallet,
     refreshWalletData,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -16,6 +16,7 @@ const STARS = [
 interface HomePageProps {
   onRestoreWallet: () => void;
   onCreateNewWallet: () => void;
+  onCreatePasskey: () => void;
   onUsePasskey: () => void;
   prfAvailable: boolean;
 }
@@ -23,6 +24,7 @@ interface HomePageProps {
 const HomePage: React.FC<HomePageProps> = ({
   onRestoreWallet,
   onCreateNewWallet,
+  onCreatePasskey,
   onUsePasskey,
   prfAvailable,
 }) => {
@@ -129,13 +131,20 @@ const HomePage: React.FC<HomePageProps> = ({
         <div className="w-full max-w-xs space-y-4 min-h-[11rem]">
           {prfAvailable && !showMnemonicFlow ? (
             <>
-              {/* Primary: Use Passkey (default when PRF available) */}
               <button
-                onClick={onUsePasskey}
-                data-testid="create-wallet-passkey-button"
+                onClick={onCreatePasskey}
+                data-testid="create-passkey-button"
                 className="button w-full py-4 text-base tracking-wider"
               >
-                Use Passkey
+                Create a passkey
+              </button>
+
+              <button
+                onClick={onUsePasskey}
+                data-testid="use-passkey-button"
+                className="button-secondary w-full py-4 rounded-xl font-display font-semibold text-sm tracking-wide"
+              >
+                I already have a passkey
               </button>
 
               <button

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -19,6 +19,8 @@ interface HomePageProps {
   onCreatePasskey: () => void;
   onUsePasskey: () => void;
   prfAvailable: boolean;
+  /** True when this device has previously used a passkey (prioritize sign-in). */
+  hasPasskeyBefore?: boolean;
 }
 
 const HomePage: React.FC<HomePageProps> = ({
@@ -27,9 +29,11 @@ const HomePage: React.FC<HomePageProps> = ({
   onCreatePasskey,
   onUsePasskey,
   prfAvailable,
+  hasPasskeyBefore = false,
 }) => {
   const [starsAnimating, setStarsAnimating] = useState(false);
   const [showMnemonicFlow, setShowMnemonicFlow] = useState(false);
+  const [showCreateWarning, setShowCreateWarning] = useState(false);
   const { handleTap: handleLogoTap } = useSecretTap(5, 2000, false, () => setShowMnemonicFlow(v => !v));
 
   // Trigger star animation on mount
@@ -130,30 +134,87 @@ const HomePage: React.FC<HomePageProps> = ({
         {/* CTA Buttons */}
         <div className="w-full max-w-xs space-y-4 min-h-[11rem]">
           {prfAvailable && !showMnemonicFlow ? (
-            <>
-              <button
-                onClick={onCreatePasskey}
-                data-testid="create-passkey-button"
-                className="button w-full py-4 text-base tracking-wider"
-              >
-                Create a passkey
-              </button>
+            hasPasskeyBefore ? (
+              showCreateWarning ? (
+                <>
+                  <div className="text-center space-y-2 mb-2">
+                    <p className="text-spark-text-primary text-sm font-display font-semibold">
+                      Are you sure?
+                    </p>
+                    <p className="text-spark-text-secondary text-xs leading-relaxed">
+                      Creating a new passkey will generate a separate account.
+                      Your existing account will not be affected, but you will
+                      need to sign in with your original passkey to access it.
+                    </p>
+                  </div>
 
-              <button
-                onClick={onUsePasskey}
-                data-testid="use-passkey-button"
-                className="button-secondary w-full py-4 rounded-xl font-display font-semibold text-sm tracking-wide"
-              >
-                I already have a passkey
-              </button>
+                  <button
+                    onClick={onCreatePasskey}
+                    data-testid="confirm-create-passkey-button"
+                    className="button w-full py-4 text-base tracking-wider"
+                  >
+                    Create new account
+                  </button>
 
-              <button
-                onClick={() => setShowMnemonicFlow(true)}
-                className="text-spark-text-muted text-xs hover:text-spark-text-secondary transition-colors w-full text-center py-2"
-              >
-                Use Recovery Phrase Instead
-              </button>
-            </>
+                  <button
+                    onClick={() => setShowCreateWarning(false)}
+                    className="button-secondary w-full py-4 rounded-xl font-display font-semibold text-sm tracking-wide"
+                  >
+                    Go Back
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={onUsePasskey}
+                    data-testid="use-passkey-button"
+                    className="button w-full py-4 text-base tracking-wider"
+                  >
+                    Sign in with passkey
+                  </button>
+
+                  <button
+                    onClick={() => setShowCreateWarning(true)}
+                    data-testid="create-passkey-button"
+                    className="button-secondary w-full py-4 rounded-xl font-display font-semibold text-sm tracking-wide"
+                  >
+                    Create a new passkey
+                  </button>
+
+                  <button
+                    onClick={() => setShowMnemonicFlow(true)}
+                    className="text-spark-text-muted text-xs hover:text-spark-text-secondary transition-colors w-full text-center py-2"
+                  >
+                    Use Recovery Phrase Instead
+                  </button>
+                </>
+              )
+            ) : (
+              <>
+                <button
+                  onClick={onCreatePasskey}
+                  data-testid="create-passkey-button"
+                  className="button w-full py-4 text-base tracking-wider"
+                >
+                  Get Started
+                </button>
+
+                <button
+                  onClick={onUsePasskey}
+                  data-testid="use-passkey-button"
+                  className="button-secondary w-full py-4 rounded-xl font-display font-semibold text-sm tracking-wide"
+                >
+                  I already have a passkey
+                </button>
+
+                <button
+                  onClick={() => setShowMnemonicFlow(true)}
+                  className="text-spark-text-muted text-xs hover:text-spark-text-secondary transition-colors w-full text-center py-2"
+                >
+                  Use Recovery Phrase Instead
+                </button>
+              </>
+            )
           ) : (
             <>
               {/* Mnemonic flow */}

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -67,6 +67,8 @@ interface PasskeyPageProps {
   onBack: () => void;
   sdkConnected?: boolean;
   onFlowComplete?: () => void;
+  /** Skip the listLabels() detection step and start directly at the create-passkey review screen. */
+  skipDetection?: boolean;
 }
 
 // ============================================
@@ -78,9 +80,10 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
   onBack,
   sdkConnected,
   onFlowComplete,
+  skipDetection = false,
 }) => {
-  const [phase, setPhase] = useState<Phase>('detecting');
-  const [isNewUser, setIsNewUser] = useState(false);
+  const [phase, setPhase] = useState<Phase>(skipDetection ? 'review' : 'detecting');
+  const [isNewUser, setIsNewUser] = useState(skipDetection);
   const [labels, setLabels] = useState<string[]>([]);
   const [selectedLabel, setSelectedLabel] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -14,6 +14,8 @@ import { logger, LogCategory } from './logger';
 
 // Storage key — presence signals passkey mode
 const PASSKEY_LABEL_KEY = 'passkeyLabel';
+// Persistent flag — survives logout/cancel, remembers this device has used a passkey
+const PASSKEY_REGISTERED_KEY = 'passkeyRegistered';
 
 /**
  * Create a fresh Passkey instance.
@@ -62,18 +64,29 @@ export function isPasskeyMode(): boolean {
 
 /**
  * Set passkey mode by storing the label.
+ * Also marks this device as having used a passkey (persistent hint).
  */
 export function setPasskeyMode(label?: string): void {
   localStorage.setItem(PASSKEY_LABEL_KEY, label ?? 'Default');
+  localStorage.setItem(PASSKEY_REGISTERED_KEY, '1');
 }
 
 /**
  * Clear passkey mode.
- * Does NOT clear the persistent "passkey registered" flag — the passkey
+ * Does NOT clear the persistent "passkey registered" flag: the passkey
  * still exists on the device and should be reused on next login.
  */
 export function clearPasskeyMode(): void {
   localStorage.removeItem(PASSKEY_LABEL_KEY);
+}
+
+/**
+ * Check if this device has ever successfully used a passkey.
+ * Survives logout and cancelled prompts so the home screen can
+ * prioritize the sign-in path for returning users.
+ */
+export function hasPasskeyHistory(): boolean {
+  return localStorage.getItem(PASSKEY_REGISTERED_KEY) === '1';
 }
 
 /**


### PR DESCRIPTION
## Summary
- HomePage replaces the single "Use Passkey" CTA with two persistent buttons: "Create a passkey" and "I already have a passkey", styled to match the mnemonic mode primary/secondary pattern.
- New `passkeyCreate` route in `App.tsx` renders `PasskeyPage` with a `skipDetection` prop so it lands directly on the create review screen, bypassing the `listLabels()` WebAuthn discovery call.
- The "I already have a passkey" path keeps the existing detection flow and its silent fallthrough to the review screen when no credential is found, so a user who picks the wrong button still ends up in the right place.

## Why
A single shared entry point cannot distinguish first-time users from returning users without invoking WebAuthn's discovery flow, which surfaces an OS dialog with password-manager import options. New users see this and find it confusing. Splitting the entry points lets first-timers go straight into registration without seeing the discovery prompt.

## Test plan
- [ ] Clean browser, no passkey: tap "Create a passkey" → lands on review screen, no discovery prompt
- [ ] Same browser after onboarding completes: tap "I already have a passkey" → label picker appears (existing flow)
- [ ] Clean browser, no passkey: tap "I already have a passkey" → discovery cancels, falls through to review (existing fallback)
- [ ] Mnemonic flows ("Get Started", "Restore from Backup") unaffected
- [ ] Toggle between passkey and mnemonic modes works as before
- [ ] Type-check passes (`npx tsc --noEmit`)