### PR TITLE
Onboarding UI polish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -302,6 +302,7 @@ const AppContent: React.FC = () => {
               setUserScreen('home');
             }}
             sdkConnected={passkeySdkConnected}
+            isSecuringSeed={sdk.isSecuringSeed}
             onFlowComplete={handlePasskeyFlowComplete}
             skipDetection
           />

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -448,20 +448,27 @@ export function useBreezSdk(
       // is emitted by the storage layer, so we don't double-log here.
       if (source !== 'secureStorage') {
         if (passkeyLabel != null && secureStorage.isSupported()) {
-          // F3: biometric-bound store. The write triggers a
-          // BiometricPrompt that may or may not be visible (iOS
-          // sometimes reuses the Keychain grace period from the
-          // preceding passkey ceremony). Flip isSecuringSeed
-          // unconditionally: when the prompt does appear, the loading
-          // copy provides matching context; when it doesn't, the
-          // transition is too brief to read.
-          setIsSecuringSeed(true);
+          // F3 storeSeed may or may not surface a BiometricPrompt.
+          // If the platform grace period covers it (the common case
+          // when onboarding chains right after a passkey ceremony),
+          // the call returns in tens of milliseconds. Defer the label
+          // flip so the silent path never reads "Setting up biometric
+          // unlock…" at all; only when storeSeed is still in flight
+          // past 250ms (i.e. a prompt is actually visible) does the
+          // label change to provide context.
+          const labelDeferMs = 250;
+          let flipped = false;
+          const flipTimer = setTimeout(() => {
+            flipped = true;
+            setIsSecuringSeed(true);
+          }, labelDeferMs);
           try {
             await secureStorage.storeSeed(seed);
           } catch {
             // Intentionally swallowed — see comment above.
           } finally {
-            setIsSecuringSeed(false);
+            clearTimeout(flipTimer);
+            if (flipped) setIsSecuringSeed(false);
           }
         } else if (deviceOnlyStorage.isSupported()) {
           // Non-passkey on native: encrypted-at-rest storage with no

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -448,33 +448,20 @@ export function useBreezSdk(
       // is emitted by the storage layer, so we don't double-log here.
       if (source !== 'secureStorage') {
         if (passkeyLabel != null && secureStorage.isSupported()) {
-          // F3: biometric-bound store. On Android the write triggers a
-          // visible BiometricPrompt, so we flip `isSecuringSeed`
-          // around the await to swap the onboarding loading copy from
-          // "Starting Glow…" to "Setting up biometric unlock…" —
-          // otherwise the prompt looks like it appeared out of nowhere
-          // on top of an unrelated loading screen. On iOS, the
-          // Keychain's biometric grace period reuses the
-          // authentication from the preceding passkey ceremony, so no
-          // visible prompt appears — flipping the label would be
-          // misleading. Keep the generic "Starting Glow…" copy on iOS.
-          const shouldShowSecuringLabel =
-            typeof window !== 'undefined' &&
-            // Capacitor runtime global access mirrors nativePasskeyPrfProvider.ts
-            (window as unknown as {
-              Capacitor?: { getPlatform?: () => string };
-            }).Capacitor?.getPlatform?.() === 'android';
-          if (shouldShowSecuringLabel) {
-            setIsSecuringSeed(true);
-          }
+          // F3: biometric-bound store. The write triggers a
+          // BiometricPrompt that may or may not be visible (iOS
+          // sometimes reuses the Keychain grace period from the
+          // preceding passkey ceremony). Flip isSecuringSeed
+          // unconditionally: when the prompt does appear, the loading
+          // copy provides matching context; when it doesn't, the
+          // transition is too brief to read.
+          setIsSecuringSeed(true);
           try {
             await secureStorage.storeSeed(seed);
           } catch {
             // Intentionally swallowed — see comment above.
           } finally {
-            if (shouldShowSecuringLabel) {
-              setIsSecuringSeed(false);
-            }
+            setIsSecuringSeed(false);
           }
         } else if (deviceOnlyStorage.isSupported()) {
           // Non-passkey on native: encrypted-at-rest storage with no

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -448,14 +448,9 @@ export function useBreezSdk(
       // is emitted by the storage layer, so we don't double-log here.
       if (source !== 'secureStorage') {
         if (passkeyLabel != null && secureStorage.isSupported()) {
-          // F3 storeSeed may or may not surface a BiometricPrompt.
-          // If the platform grace period covers it (the common case
-          // when onboarding chains right after a passkey ceremony),
-          // the call returns in tens of milliseconds. Defer the label
-          // flip so the silent path never reads "Setting up biometric
-          // unlock…" at all; only when storeSeed is still in flight
-          // past 250ms (i.e. a prompt is actually visible) does the
-          // label change to provide context.
+          // Only flip the label if storeSeed actually prompts. The
+          // platform grace period often returns within 250ms, in which
+          // case we never show "Setting up biometric unlock…".
           const labelDeferMs = 250;
           let flipped = false;
           const flipTimer = setTimeout(() => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -139,7 +139,7 @@ const HomePage: React.FC<HomePageProps> = ({
                   data-testid="create-passkey-button"
                   className="button w-full py-4 text-base tracking-wider"
                 >
-                  Get Started
+                  Create Passkey
                 </button>
 
                 <button

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -100,7 +100,7 @@ interface PasskeyPageProps {
    */
   isSecuringSeed?: boolean;
   onFlowComplete?: () => void;
-  /** Skip the listLabels() detection step and start directly at the create-passkey review screen. */
+  /** Skip the listLabels() detection step and start the create-passkey flow directly. */
   skipDetection?: boolean;
   /**
    * Read-and-clear function for the "first sign-in after fresh install"
@@ -129,7 +129,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
   consumeFreshInstallSignal,
 }) => {
   // AASA verification runs first for both paths; the post-AASA transition
-  // branches on `skipDetection` to either jump straight to 'review' (new
+  // branches on `skipDetection` to either jump straight to 'creating' (new
   // user via Create Passkey CTA) or 'detecting' (existing user via Use
   // Passkey CTA).
   const [phase, setPhase] = useState<Phase>('aasa-checking');
@@ -230,7 +230,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
         logger.warn(LogCategory.AUTH, 'Domain association check threw (unexpected)', {
           error: e instanceof Error ? e.message : String(e),
         });
-        setPhase(skipDetection ? 'review' : 'detecting');
+        setPhase(skipDetection ? 'creating' : 'detecting');
         return;
       }
 
@@ -247,7 +247,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       // provider couldn't verify (offline / no verification source),
       // not that verification failed.
       setAasaFailure(null);
-      setPhase(skipDetection ? 'review' : 'detecting');
+      setPhase(skipDetection ? 'creating' : 'detecting');
     };
 
     run();
@@ -446,8 +446,9 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
           detectingFailCountRef.current = 0;
           // Skip aasa-checking: it was already verified earlier in
           // this session and re-running it would bounce through the
-          // skipDetection -> review path, putting the user right back
-          // on the create flow they just came from.
+          // skipDetection -> creating path, re-firing createPasskey()
+          // and putting the user right back on the create flow they
+          // just came from.
           setPhase('detecting');
           return;
         }
@@ -905,9 +906,10 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             // We're entering this branch from a `passkeyCreate` route
             // (skipDetection=true), and the aasa-checking effect's
             // post-success transition reads skipDetection and routes
-            // back to 'review' — bouncing the user right back to the
-            // create flow. AASA was already verified earlier in this
-            // session, so re-running it is redundant anyway.
+            // to 'creating', which would re-fire createPasskey() and
+            // bounce the user right back to the create flow. AASA was
+            // already verified earlier in this session, so re-running
+            // it is redundant anyway.
             setPhase('detecting');
           }}>
             Use Passkey

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -444,11 +444,9 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
           // Reset detect-fail counter so the upcoming sign-in attempt
           // gets the fresh-install retry budget if applicable.
           detectingFailCountRef.current = 0;
-          // Skip aasa-checking: it was already verified earlier in
-          // this session and re-running it would bounce through the
-          // skipDetection -> creating path, re-firing createPasskey()
-          // and putting the user right back on the create flow they
-          // just came from.
+          // Skip aasa-checking. Re-running it under skipDetection=true
+          // would route through 'creating' and re-fire createPasskey(),
+          // bouncing the user back to the flow they just came from.
           setPhase('detecting');
           return;
         }
@@ -902,14 +900,9 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             // Reset detect-fail counter so this entry into detecting
             // gets the fresh-install retry budget if applicable.
             detectingFailCountRef.current = 0;
-            // Route DIRECTLY to detecting, skipping aasa-checking.
-            // We're entering this branch from a `passkeyCreate` route
-            // (skipDetection=true), and the aasa-checking effect's
-            // post-success transition reads skipDetection and routes
-            // to 'creating', which would re-fire createPasskey() and
-            // bounce the user right back to the create flow. AASA was
-            // already verified earlier in this session, so re-running
-            // it is redundant anyway.
+            // Skip aasa-checking. Under skipDetection=true it would
+            // route to 'creating' and re-fire createPasskey(), bouncing
+            // the user back to the flow they just came from.
             setPhase('detecting');
           }}>
             Use Passkey

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -21,7 +21,6 @@ import {
 import type { DomainAssociation } from '@/services/passkeyPrfProvider';
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs } from '@/services/logExport';
-import StepperBar from '@/components/OnboardingStepper';
 import { useLatest } from '../hooks/useLatest';
 
 // ============================================
@@ -75,20 +74,6 @@ type Phase =
   // Shared
   | 'connecting'      // Connect to Nostr step: getWallet() in progress (prompt)
   | 'initializing';   // Initialize step: SDK connecting
-
-/** Step index for the new user inline stepper (3 steps). */
-function newUserStepIndex(phase: Phase): number {
-  // review/aasa-checking/detecting are pre-flight phases where step 1
-  // hasn't started yet. Returning 0 surfaces step 1 as "next up"
-  // rather than the bare-default 3 which the stepper renders as
-  // "all done" — visually wrong for a screen that's literally
-  // titled "Create your passkey".
-  if (phase === 'review' || phase === 'aasa-checking' || phase === 'detecting') return 0;
-  if (phase === 'creating') return 0;
-  if (phase === 'new-storing') return 1;
-  if (phase === 'connecting' || phase === 'initializing') return 2;
-  return 3; // all complete (post-flow)
-}
 
 
 // ============================================
@@ -1012,13 +997,6 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
   return (
     <PageLayout onBack={onBack} footer={footer} title="Get Started">
       <div className="max-w-xl mx-auto w-full flex flex-col min-h-full">
-        {/* Hide the stepper while an error is showing: the user isn't
-            actively progressing through a step, and a half-filled bar
-            below an "already exists" / "couldn't create" AlertCard
-            reads as visual clutter rather than progress feedback. */}
-        {isNewUser && !error && (
-          <StepperBar stepCount={3} activeIndex={newUserStepIndex(phase)} />
-        )}
         <div className="mt-6 space-y-4 flex flex-col flex-1">
           {content}
           {error && (

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -1,18 +1,10 @@
 /**
  * Passkey Service.
  *
- * Wraps the Breez SDK's Passkey class to provide passkey-based wallet
- * creation and restoration functionality.
- *
- * Uses a module-level singleton Passkey instance so the SDK's internal
- * `nostr_keys: OnceCell` cache survives across calls. With the prior
- * "fresh instance per operation" pattern, every call to `saveLabel` /
- * `listLabels` re-derived the Nostr identity from scratch, firing a
- * fresh PRF prompt. The singleton lets the SDK reuse a cached identity
- * after the first successful derivation in a given session.
- *
- * The singleton must be invalidated whenever the underlying credential
- * or relay configuration changes (logout, RP switch, deletion-recovery).
+ * Wraps the Breez SDK's Passkey class. Holds a module-level singleton
+ * so the SDK's internal Nostr-identity cache survives across calls
+ * (otherwise `saveLabel`/`listLabels` would re-prompt for PRF each time).
+ * Invalidate the singleton when the credential or relay config changes.
  */
 
 import { Passkey, Wallet, NostrRelayConfig } from '@breeztech/breez-sdk-spark';
@@ -32,17 +24,6 @@ const KNOWN_CREDENTIALS_KEY = 'passkeyKnownCredentials';
 
 let cachedPasskey: Passkey | null = null;
 
-/**
- * Lazy singleton accessor for the SDK Passkey instance.
- *
- * The SDK keeps an internal `OnceCell` for the derived Nostr identity;
- * reusing the same instance across calls preserves that cache and
- * prevents redundant PRF prompts on follow-up Nostr operations
- * (`saveLabel`, `listLabels`) within the same session. The wallet seed
- * (`getWallet`) uses a different salt and still requires its own PRF
- * call. Tier 2 of the passkey UX overhaul collapses both into a single
- * assertion via dual-salt PRF.
- */
 function getPasskey(): Passkey {
   if (cachedPasskey !== null) return cachedPasskey;
   const breezApiKey = import.meta.env.VITE_BREEZ_API_KEY;
@@ -53,12 +34,6 @@ function getPasskey(): Passkey {
   return cachedPasskey;
 }
 
-/**
- * Discard the cached Passkey instance. Called whenever the underlying
- * credential or relay configuration changes (logout, deletion-recovery,
- * future RP switch). Forces the next call to construct a fresh instance
- * with an empty Nostr-identity cache.
- */
 function invalidatePasskey(): void {
   cachedPasskey = null;
 }
@@ -144,10 +119,6 @@ export async function clearPasskeyHistory(): Promise<void> {
   }
   localStorage.removeItem(PASSKEY_REGISTERED_KEY);
   localStorage.removeItem(KNOWN_CREDENTIALS_KEY);
-  // The cached Nostr identity is keyed off the now-deleted passkey;
-  // reusing it after the next create would still derive against the
-  // previous PRF output (whatever the SDK happened to keep in the
-  // OnceCell). Drop the singleton so the next call rebuilds.
   invalidatePasskey();
 }
 
@@ -186,12 +157,6 @@ export function setPasskeyMode(label?: string): void {
  * Clear passkey mode.
  * Does NOT clear the persistent "passkey registered" flag: the passkey
  * still exists on the device and should be reused on next login.
- *
- * Invalidates the cached Passkey instance so the next sign-in starts
- * from a clean SDK state. The user could log in with a different label
- * after logout and the cached Nostr identity (tied to the same RP, but
- * potentially derived under a different account context) should not
- * leak across sessions.
  */
 export function clearPasskeyMode(): void {
   localStorage.removeItem(PASSKEY_LABEL_KEY);

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -1,11 +1,18 @@
 /**
  * Passkey Service.
  *
- * Wraps the Breez SDK's Passkey class to provide
- * passkey-based wallet creation and restoration functionality.
+ * Wraps the Breez SDK's Passkey class to provide passkey-based wallet
+ * creation and restoration functionality.
  *
- * Creates a fresh Passkey instance per operation so that no stale
- * PRF session or cached state can survive between wizard steps.
+ * Uses a module-level singleton Passkey instance so the SDK's internal
+ * `nostr_keys: OnceCell` cache survives across calls. With the prior
+ * "fresh instance per operation" pattern, every call to `saveLabel` /
+ * `listLabels` re-derived the Nostr identity from scratch, firing a
+ * fresh PRF prompt. The singleton lets the SDK reuse a cached identity
+ * after the first successful derivation in a given session.
+ *
+ * The singleton must be invalidated whenever the underlying credential
+ * or relay configuration changes (logout, RP switch, deletion-recovery).
  */
 
 import { Passkey, Wallet, NostrRelayConfig } from '@breeztech/breez-sdk-spark';
@@ -23,16 +30,37 @@ const PASSKEY_REGISTERED_KEY = 'passkeyRegistered';
 // was wiped (defense-in-depth: protects against localStorage clears).
 const KNOWN_CREDENTIALS_KEY = 'passkeyKnownCredentials';
 
+let cachedPasskey: Passkey | null = null;
+
 /**
- * Create a fresh Passkey instance.
- * No caching — each call gets a clean instance with no stale state.
+ * Lazy singleton accessor for the SDK Passkey instance.
+ *
+ * The SDK keeps an internal `OnceCell` for the derived Nostr identity;
+ * reusing the same instance across calls preserves that cache and
+ * prevents redundant PRF prompts on follow-up Nostr operations
+ * (`saveLabel`, `listLabels`) within the same session. The wallet seed
+ * (`getWallet`) uses a different salt and still requires its own PRF
+ * call. Tier 2 of the passkey UX overhaul collapses both into a single
+ * assertion via dual-salt PRF.
  */
-function createPasskeyInstance(): Passkey {
+function getPasskey(): Passkey {
+  if (cachedPasskey !== null) return cachedPasskey;
   const breezApiKey = import.meta.env.VITE_BREEZ_API_KEY;
   const relayConfig: NostrRelayConfig | undefined = breezApiKey
     ? { breezApiKey }
     : undefined;
-  return new Passkey(passkeyPrfProvider, relayConfig ?? null);
+  cachedPasskey = new Passkey(passkeyPrfProvider, relayConfig ?? null);
+  return cachedPasskey;
+}
+
+/**
+ * Discard the cached Passkey instance. Called whenever the underlying
+ * credential or relay configuration changes (logout, deletion-recovery,
+ * future RP switch). Forces the next call to construct a fresh instance
+ * with an empty Nostr-identity cache.
+ */
+function invalidatePasskey(): void {
+  cachedPasskey = null;
 }
 
 /**
@@ -116,6 +144,11 @@ export async function clearPasskeyHistory(): Promise<void> {
   }
   localStorage.removeItem(PASSKEY_REGISTERED_KEY);
   localStorage.removeItem(KNOWN_CREDENTIALS_KEY);
+  // The cached Nostr identity is keyed off the now-deleted passkey;
+  // reusing it after the next create would still derive against the
+  // previous PRF output (whatever the SDK happened to keep in the
+  // OnceCell). Drop the singleton so the next call rebuilds.
+  invalidatePasskey();
 }
 
 /**
@@ -128,7 +161,7 @@ export async function isPrfAvailable(): Promise<boolean> {
     return false;
   }
 
-  const passkey = createPasskeyInstance();
+  const passkey = getPasskey();
   return await passkey.isAvailable();
 }
 
@@ -153,9 +186,16 @@ export function setPasskeyMode(label?: string): void {
  * Clear passkey mode.
  * Does NOT clear the persistent "passkey registered" flag: the passkey
  * still exists on the device and should be reused on next login.
+ *
+ * Invalidates the cached Passkey instance so the next sign-in starts
+ * from a clean SDK state. The user could log in with a different label
+ * after logout and the cached Nostr identity (tied to the same RP, but
+ * potentially derived under a different account context) should not
+ * leak across sessions.
  */
 export function clearPasskeyMode(): void {
   localStorage.removeItem(PASSKEY_LABEL_KEY);
+  invalidatePasskey();
 }
 
 /**
@@ -172,7 +212,7 @@ export function hasPasskeyHistory(): boolean {
  */
 export async function listLabels(): Promise<string[]> {
   logger.info(LogCategory.AUTH, 'Listing labels from nostr relays');
-  const passkey = createPasskeyInstance();
+  const passkey = getPasskey();
   return await passkey.listLabels();
 }
 
@@ -181,7 +221,7 @@ export async function listLabels(): Promise<string[]> {
  */
 export async function saveLabel(label: string): Promise<void> {
   logger.info(LogCategory.AUTH, 'Saving label to nostr relays');
-  const passkey = createPasskeyInstance();
+  const passkey = getPasskey();
   await passkey.storeLabel(label);
 }
 
@@ -198,7 +238,7 @@ export async function getWallet(label?: string): Promise<Wallet> {
 
   logger.info(LogCategory.AUTH, 'Deriving wallet via passkey');
 
-  const passkey = createPasskeyInstance();
+  const passkey = getPasskey();
   try {
     const wallet = await passkey.getWallet(effectiveLabel);
     logger.info(LogCategory.AUTH, 'Passkey wallet derived successfully');


### PR DESCRIPTION
- Skip review stage for new users
  - Renamed "Get Started" label to "Create Passkey" on home page
- Drop new-user stepper
- Don't show "Setting up biometric unlock..." label when the biometric step completes silently within the grace window