### PR TITLE
feat(passkey): Passkey & Labels settings page with one-tap label switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,45 @@ const result = await wallet.newSdkMethod({ param: value });
 4. Pass prop through WalletPage to SideMenu
 5. Add screen type and case in `src/App.tsx`
 
+### Adding Passkey & Labels items
+
+The Settings → Passkey entry opens the **Passkey & Labels** hub at `src/pages/PasskeySettingsPage.tsx`. The hub has three sub-pages:
+
+- Passkey: `src/pages/PasskeyManagementPage.tsx`
+- Labels: `src/pages/LabelsPage.tsx`
+- Local State: `src/pages/PasskeyLocalStatePage.tsx`
+
+**Screen wiring (in `src/App.tsx`):**
+The screen types `'passkeySettings'`, `'passkeyManagement'`, `'labels'`, and `'passkeyLocalState'` each layer on top of `renderSettingsPage()` + `renderPasskeySettingsPage()` so the back stack stays consistent.
+
+**Adding a new sub-page to the hub:**
+1. Create the page under `src/pages/`
+2. Register a row inside `PasskeySettingsPage.tsx` that navigates to the new screen
+3. Add a screen type string in `src/App.tsx` and a case that renders the new page on top of `renderPasskeySettingsPage()`
+
+**Dev gating:**
+The Settings entry is gated behind `isDevMode` (toggled via `useSecretTap`). Keep new hub items dev-only until they are ready for production.
+
+**Switching active passkey label:**
+Use `sdk.switchPasskeyLabel(label)` from `useBreezSdk` to switch the active label without bouncing through the home page. This triggers a fresh PRF prompt and reconnects the SDK with the new label.
+
+```tsx
+const { sdk } = useBreezSdk();
+await sdk.switchPasskeyLabel(nextLabel);
+```
+
+### Passkey Metadata
+
+Per-device passkey metadata lives in `src/services/passkeyService.ts` and is persisted in `localStorage`:
+
+- `passkeyRegistered`: whether a passkey has been registered on this device
+- `passkeyKnownCredentials`: known credential IDs for this device
+- `passkeyLabel`: active label for the current passkey
+- `passkeyFirstSeenAt`: timestamp of the first successful PRF ceremony
+- `passkeyLastSeenAt`: timestamp of the most recent successful PRF ceremony
+
+Call `markPasskeyUsed()` after any successful PRF ceremony to update `passkeyLastSeenAt` (and seed `passkeyFirstSeenAt` on first use).
+
 ### Build Notes
 - `npm run dev` works with npm-linked SDK packages
 - `npm run build` may fail with linked packages (vite polyfill resolution)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,10 @@ import FiatCurrenciesPage from './pages/FiatCurrenciesPage';
 import BuyProvidersPage from './pages/BuyProvidersPage';
 import UnlockPage from './pages/UnlockPage';
 import UnlockingPage from './pages/UnlockingPage';
+import PasskeySettingsPage from './pages/PasskeySettingsPage';
+import PasskeyManagementPage from './pages/PasskeyManagementPage';
+import LabelsPage from './pages/LabelsPage';
+import PasskeyLocalStatePage from './pages/PasskeyLocalStatePage';
 import { ContactsProvider } from './contexts/ContactsContext';
 
 import { useIOSViewportFix } from './hooks/useIOSViewportFix';
@@ -30,7 +34,7 @@ import { STATUS_BAR_LOADING } from './utils/statusBarManager';
 import { useBackButton } from './hooks/useBackButton';
 import type { Seed, Payment } from '@breeztech/breez-sdk-spark';
 
-type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'passkeyCreate' | 'unlock' | 'unlocking';
+type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'passkeyCreate' | 'unlock' | 'unlocking' | 'passkeySettings' | 'passkeyManagement' | 'labels' | 'passkeyLocalState';
 
 // Full-screen dim spinner shown while sdk.isLoading is true (logout in
 // progress, SDK reconnect, etc). Wrapped as its own component so the
@@ -134,7 +138,13 @@ const AppContent: React.FC = () => {
         setUserScreen('wallet');
         return true;
       case 'fiatCurrencies':
+      case 'passkeySettings':
         setUserScreen('settings');
+        return true;
+      case 'passkeyManagement':
+      case 'labels':
+      case 'passkeyLocalState':
+        setUserScreen('passkeySettings');
         return true;
       case 'buyProviders':
         setUserScreen(buyProvidersSource === 'settings' ? 'settings' : 'wallet');
@@ -255,6 +265,18 @@ const AppContent: React.FC = () => {
         config={sdk.config}
         onOpenFiatCurrencies={() => setUserScreen('fiatCurrencies')}
         onOpenBuyProviders={() => { setBuyProvidersSource('settings'); setUserScreen('buyProviders'); }}
+        onOpenPasskeySettings={() => setUserScreen('passkeySettings')}
+      />
+    );
+
+    // Backdrop beneath the three sub-pages so their close animations
+    // reveal the hub rather than skipping back to Settings.
+    const renderPasskeySettingsPage = () => (
+      <PasskeySettingsPage
+        onBack={() => setUserScreen('settings')}
+        onOpenPasskey={() => setUserScreen('passkeyManagement')}
+        onOpenLabels={() => setUserScreen('labels')}
+        onOpenLocalState={() => setUserScreen('passkeyLocalState')}
       />
     );
 
@@ -346,6 +368,51 @@ const AppContent: React.FC = () => {
             {renderWalletPage()}
             {renderSettingsPage()}
             <FiatCurrenciesPage onBack={() => setUserScreen('settings')} />
+          </>
+        );
+
+      case 'passkeySettings':
+        return (
+          <>
+            {renderWalletPage()}
+            {renderSettingsPage()}
+            {renderPasskeySettingsPage()}
+          </>
+        );
+
+      case 'passkeyManagement':
+        return (
+          <>
+            {renderWalletPage()}
+            {renderSettingsPage()}
+            {renderPasskeySettingsPage()}
+            <PasskeyManagementPage onBack={() => setUserScreen('passkeySettings')} />
+          </>
+        );
+
+      case 'labels':
+        return (
+          <>
+            {renderWalletPage()}
+            {renderSettingsPage()}
+            {renderPasskeySettingsPage()}
+            <LabelsPage
+              onBack={() => setUserScreen('passkeySettings')}
+              onSwitchLabel={async (label) => {
+                await sdk.switchPasskeyLabel(label);
+                setUserScreen('wallet');
+              }}
+            />
+          </>
+        );
+
+      case 'passkeyLocalState':
+        return (
+          <>
+            {renderWalletPage()}
+            {renderSettingsPage()}
+            {renderPasskeySettingsPage()}
+            <PasskeyLocalStatePage onBack={() => setUserScreen('passkeySettings')} />
           </>
         );
 

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -29,6 +29,7 @@ import {
   clearPasskeyMode,
   getWallet,
   hasPasskeyHistory,
+  markLabelUsed,
 } from '../services/passkeyService';
 import { secureStorage, deviceOnlyStorage, SecureStorageError } from '../services/secureStorage';
 import { passkeyPrfProvider } from '../services/passkeyPrfProvider';
@@ -220,6 +221,11 @@ export interface BreezSdkActions {
    * `connectWallet` and updates `startupState` based on the outcome.
    */
   retryUnlock: () => Promise<void>;
+  /**
+   * Disconnect, derive the new wallet via passkey, reconnect with it.
+   * Throws on PRF cancel / network failure / SDK error.
+   */
+  switchPasskeyLabel: (newLabel: string) => Promise<void>;
 }
 
 // ============================================
@@ -427,6 +433,7 @@ export function useBreezSdk(
       // becomes unavailable later (e.g. KEY_INVALIDATED on biometric change).
       if (passkeyLabel != null) {
         setPasskeyMode(passkeyLabel);
+        markLabelUsed(passkeyLabel);
       }
 
       // Persist the seed itself — but skip this entirely when the seed was
@@ -573,6 +580,102 @@ export function useBreezSdk(
     clearNetworkOverride();
     showToast('success', 'Successfully logged out');
   }, [sdk, showToast]);
+
+  const switchPasskeyLabel = useCallback(async (newLabel: string): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+
+    // PRF first so a cancel here leaves the active wallet untouched.
+    let wallet;
+    try {
+      wallet = await getWallet(newLabel);
+    } catch (e) {
+      setIsLoading(false);
+      throw e;
+    }
+
+    if (sdk) {
+      try {
+        await sdk.disconnect();
+      } catch (e) {
+        logger.warn(LogCategory.SDK, 'SDK disconnect failed during label switch', {
+          error: formatError(e),
+        });
+      }
+    }
+    setSdk(null);
+    setIsConnected(false);
+    setIsSyncing(true);
+    setWalletInfo(null);
+    setTransactions([]);
+    setUnclaimedDeposits([]);
+    setHasRejectedDeposits(false);
+    setCelebrationPayment(null);
+    setCachedStableTicker(null);
+    clearStableRestorePrompted();
+    shownPaymentIdsRef.current.clear();
+
+    if (secureStorage.isSupported()) {
+      try {
+        await secureStorage.clearSeed();
+      } catch {
+        // storeSeed below overwrites anyway.
+      }
+    }
+
+    let connectedSdk: BreezSdk | undefined;
+    try {
+      const cfg = buildConnectConfig();
+      setConfig(cfg);
+
+      connectedSdk = await connect({
+        config: cfg,
+        seed: wallet.seed,
+        storageDir: 'spark-wallet-example',
+      });
+      setSdk(connectedSdk);
+      setPasskeyMode(wallet.label);
+
+      if (secureStorage.isSupported()) {
+        try {
+          await secureStorage.storeSeed(wallet.seed);
+        } catch {
+          // In-memory seed keeps the session alive; relaunch re-prompts.
+        }
+      }
+
+      const [info, txns] = await Promise.all([
+        connectedSdk.getInfo({}),
+        connectedSdk.listPayments({ offset: 0, limit: 100 }),
+      ]);
+      setWalletInfo(info);
+      setTransactions(filterOngoingConversionPayments(txns.payments));
+      setIsConnected(true);
+      markLabelUsed(wallet.label);
+
+      try {
+        const result = await connectedSdk.listUnclaimedDeposits({});
+        setUnclaimedDeposits(result.deposits);
+        setHasRejectedDeposits(result.deposits.some(d => isDepositRejected(d.txid, d.vout)));
+      } catch (e) {
+        logger.warn(LogCategory.SDK, 'Deposit fetch failed after label switch', {
+          error: formatError(e),
+        });
+      }
+    } catch (e) {
+      const errorMsg = formatError(e);
+      logger.error(LogCategory.SDK, 'Failed to connect after label switch', { error: errorMsg });
+      if (connectedSdk) {
+        try { await connectedSdk.disconnect(); } catch { /* best-effort */ }
+        setSdk(null);
+      }
+      setError('Failed to switch label. Please try again.');
+      throw e;
+    } finally {
+      setIsSyncing(false);
+      setIsLoading(false);
+    }
+  }, [sdk]);
 
   // Re-run the biometric unlock flow after the user cancelled or was locked
   // out on the previous attempt. Called by UnlockPage's "Unlock" button,
@@ -1029,5 +1132,6 @@ export function useBreezSdk(
       return v;
     },
     retryUnlock,
+    switchPasskeyLabel,
   };
 }

--- a/src/pages/LabelsPage.tsx
+++ b/src/pages/LabelsPage.tsx
@@ -157,8 +157,14 @@ const LabelsPage: React.FC<LabelsPageProps> = ({ onBack, onSwitchLabel }) => {
     }
   };
 
+  const footer = !isLoading && loadError ? (
+    <PrimaryButton className="w-full" onClick={handleRetry}>
+      Try Again
+    </PrimaryButton>
+  ) : undefined;
+
   return (
-    <SlideInPage title="Labels" closeStyle="back" onClose={onBack} slideFrom="right">
+    <SlideInPage title="Labels" closeStyle="back" onClose={onBack} slideFrom="right" footer={footer}>
       <div className="p-4 space-y-4">
           {isLoading && (
             <div className="flex items-center justify-center py-12">
@@ -171,11 +177,6 @@ const LabelsPage: React.FC<LabelsPageProps> = ({ onBack, onSwitchLabel }) => {
               <p className="text-spark-text-secondary text-sm wrap-break-word">
                 {loadError}
               </p>
-              <div className="mt-3">
-                <SecondaryButton onClick={handleRetry}>
-                  Try Again
-                </SecondaryButton>
-              </div>
             </AlertCard>
           )}
 

--- a/src/pages/LabelsPage.tsx
+++ b/src/pages/LabelsPage.tsx
@@ -1,0 +1,332 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import SlideInPage from '../components/layout/SlideInPage';
+import { AlertCard } from '../components/AlertCard';
+import LoadingSpinner from '../components/LoadingSpinner';
+import { ConfirmDialog, PrimaryButton, SecondaryButton, FormInput } from '../components/ui';
+import { CheckIcon, PlusIcon, WalletIcon } from '../components/Icons';
+import { listLabels, saveLabel, getLabelLastUsed } from '../services/passkeyService';
+import { useToast } from '@/contexts/ToastContext';
+import { logger, LogCategory } from '@/services/logger';
+
+interface LabelsPageProps {
+  onBack: () => void;
+  /** Reconnect with `label`. Throws on PRF cancel or connect failure. */
+  onSwitchLabel: (label: string) => Promise<void>;
+}
+
+const PASSKEY_LABEL_KEY = 'passkeyLabel';
+
+const ONE_MINUTE = 60_000;
+const ONE_HOUR = 60 * ONE_MINUTE;
+const ONE_DAY = 24 * ONE_HOUR;
+const ONE_WEEK = 7 * ONE_DAY;
+
+/**
+ * Render a "last used" timestamp as a coarse relative string. Buckets
+ * fall back to an absolute date once the gap exceeds a week, since at
+ * that point a relative count stops being scannable.
+ */
+function formatRelative(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < ONE_MINUTE) return 'just now';
+  if (diff < ONE_HOUR) {
+    const mins = Math.floor(diff / ONE_MINUTE);
+    return mins === 1 ? '1 min ago' : `${mins} min ago`;
+  }
+  if (diff < ONE_DAY) {
+    const hrs = Math.floor(diff / ONE_HOUR);
+    return hrs === 1 ? '1 hr ago' : `${hrs} hr ago`;
+  }
+  if (diff < ONE_WEEK) {
+    const days = Math.floor(diff / ONE_DAY);
+    return days === 1 ? 'yesterday' : `${days} days ago`;
+  }
+  return new Date(ts).toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+const LabelsPage: React.FC<LabelsPageProps> = ({ onBack, onSwitchLabel }) => {
+  const { showToast } = useToast();
+  const [labels, setLabels] = useState<string[]>([]);
+  // Snapshot last-used once when labels resolve so renders don't re-read
+  // localStorage. A switch made while this page is open won't surface its
+  // own freshly-stamped timestamp until reopen.
+  const [lastUsedMap, setLastUsedMap] = useState<Record<string, number | undefined>>({});
+  const [activeLabel] = useState<string | null>(() => localStorage.getItem(PASSKEY_LABEL_KEY));
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const [pendingSwitch, setPendingSwitch] = useState<string | null>(null);
+  const [isSwitching, setIsSwitching] = useState(false);
+
+  const cancelledRef = useRef(false);
+
+  // Async IIFE: setStates fire post-await to satisfy
+  // react-hooks/set-state-in-effect.
+  const loadLabels = useCallback(() => {
+    void (async () => {
+      let found: string[] | null = null;
+      let errorMsg: string | null = null;
+      try {
+        found = await listLabels();
+      } catch (e) {
+        errorMsg = e instanceof Error ? e.message : String(e);
+        logger.warn(LogCategory.AUTH, 'Failed to load labels for management page', {
+          error: errorMsg,
+        });
+      }
+      if (cancelledRef.current) return;
+      if (errorMsg !== null) {
+        setLoadError(errorMsg);
+        setIsLoading(false);
+        return;
+      }
+      setLoadError(null);
+      // Match PasskeyPage display order: oldest -> newest
+      const ordered = [...(found ?? [])].reverse();
+      setLabels(ordered);
+      // Build the last-used map in the same tick as the label set so the
+      // first render that paints the rows already has stable timestamps.
+      const map: Record<string, number | undefined> = {};
+      for (const label of ordered) {
+        map[label] = getLabelLastUsed(label);
+      }
+      setLastUsedMap(map);
+      setIsLoading(false);
+    })();
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    loadLabels();
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, [loadLabels]);
+
+  const handleRetry = () => {
+    setIsLoading(true);
+    setLoadError(null);
+    loadLabels();
+  };
+
+  const trimmed = newLabel.trim();
+  const isDuplicate = trimmed
+    ? labels.some((l) => l.toLowerCase() === trimmed.toLowerCase())
+    : false;
+  const canSave = !!trimmed && !isDuplicate && !isSaving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setIsSaving(true);
+    try {
+      await saveLabel(trimmed);
+      setLabels((prev) => (prev.includes(trimmed) ? prev : [...prev, trimmed]));
+      setNewLabel('');
+      setShowAddForm(false);
+      showToast('success', 'Label added', `"${trimmed}" is now available on this passkey.`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.error(LogCategory.AUTH, 'Failed to save label', { error: msg });
+      showToast('error', "Couldn't add label", msg);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleConfirmSwitch = async () => {
+    const target = pendingSwitch;
+    if (!target) return;
+    setPendingSwitch(null);
+    setIsSwitching(true);
+    try {
+      await onSwitchLabel(target);
+      // Parent navigates to wallet on success; nothing more to do here.
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.warn(LogCategory.AUTH, 'Label switch failed', { error: msg });
+      showToast('error', "Couldn't switch label", msg);
+      setIsSwitching(false);
+    }
+  };
+
+  return (
+    <SlideInPage title="Labels" closeStyle="back" onClose={onBack} slideFrom="right">
+      <div className="p-4 space-y-4">
+          {isLoading && (
+            <div className="flex items-center justify-center py-12">
+              <LoadingSpinner />
+            </div>
+          )}
+
+          {!isLoading && loadError && (
+            <AlertCard variant="error" title="Couldn't load labels">
+              <p className="text-spark-text-secondary text-sm wrap-break-word">
+                {loadError}
+              </p>
+              <div className="mt-3">
+                <SecondaryButton onClick={handleRetry}>
+                  Try Again
+                </SecondaryButton>
+              </div>
+            </AlertCard>
+          )}
+
+          {!isLoading && !loadError && labels.length === 0 && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center text-center">
+              <WalletIcon
+                size="xl"
+                className="w-14 h-14 text-spark-text-muted opacity-30 mb-4"
+              />
+              <div className="font-display font-semibold text-spark-text-primary mb-1">
+                No labels yet
+              </div>
+              <p className="text-spark-text-muted text-sm">
+                Add a label to organize multiple wallets under this passkey.
+              </p>
+            </div>
+          )}
+
+          {!isLoading && !loadError && (
+            <>
+              <div className="space-y-2">
+                {labels.map((label) => {
+                  const isActive = label === activeLabel;
+                  const cardClasses = `flex items-center gap-3 p-4 rounded-2xl border w-full text-left transition-colors ${
+                    isActive
+                      ? 'bg-spark-primary/10 border-spark-primary'
+                      : 'bg-spark-dark border-spark-border hover:border-spark-border-light hover:bg-white/5'
+                  } ${isSwitching ? 'opacity-50 pointer-events-none' : ''}`;
+
+                  const lastUsedTs = lastUsedMap[label];
+                  const subtitle = isActive
+                    ? 'Currently signed in'
+                    : lastUsedTs !== undefined
+                      ? `Last used ${formatRelative(lastUsedTs)}`
+                      : 'Tap to switch';
+
+                  const inner = (
+                    <>
+                      <div className="w-10 h-10 rounded-xl bg-spark-primary/10 flex items-center justify-center shrink-0">
+                        <WalletIcon size="md" className="text-spark-primary" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-display font-semibold text-spark-text-primary truncate">
+                          {label}
+                        </div>
+                        <div className="text-xs text-spark-text-muted">
+                          {subtitle}
+                        </div>
+                      </div>
+                      {isActive && (
+                        <div className="w-6 h-6 rounded-full bg-spark-primary flex items-center justify-center shrink-0">
+                          <CheckIcon size="sm" className="text-white" />
+                        </div>
+                      )}
+                    </>
+                  );
+
+                  // Active row is non-interactive; non-active rows open
+                  // the switch confirm.
+                  return isActive ? (
+                    <div key={label} className={cardClasses}>{inner}</div>
+                  ) : (
+                    <button
+                      key={label}
+                      type="button"
+                      onClick={() => setPendingSwitch(label)}
+                      disabled={isSwitching}
+                      className={cardClasses}
+                    >
+                      {inner}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Add new label */}
+              {!showAddForm ? (
+                <button
+                  type="button"
+                  onClick={() => setShowAddForm(true)}
+                  disabled={isSwitching}
+                  className={`w-full flex items-center justify-center gap-2 p-4 bg-spark-dark border border-spark-border rounded-2xl text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light transition-colors ${isSwitching ? 'opacity-50 pointer-events-none' : ''}`}
+                >
+                  <PlusIcon size="sm" />
+                  <span className="font-display font-medium">Add new label</span>
+                </button>
+              ) : (
+                <div className="bg-spark-dark border border-spark-primary rounded-2xl p-4 space-y-3">
+                  <div className="font-display font-semibold text-spark-text-primary">
+                    New label name
+                  </div>
+                  <FormInput
+                    id="new-label"
+                    type="text"
+                    value={newLabel}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      if (/^[a-zA-Z0-9 ]*$/.test(val) && val.length <= 24) {
+                        setNewLabel(val);
+                      }
+                    }}
+                    placeholder="e.g. Savings"
+                    autoFocus
+                    disabled={isSaving}
+                  />
+                  {isDuplicate && (
+                    <p className="text-spark-error text-xs">
+                      A label with this name already exists.
+                    </p>
+                  )}
+                  <div className="flex gap-2">
+                    <SecondaryButton
+                      className="flex-1"
+                      onClick={() => {
+                        setNewLabel('');
+                        setShowAddForm(false);
+                      }}
+                      disabled={isSaving}
+                    >
+                      Cancel
+                    </SecondaryButton>
+                    <PrimaryButton
+                      className="flex-1"
+                      onClick={handleSave}
+                      disabled={!canSave}
+                    >
+                      {isSaving ? 'Saving…' : 'Save'}
+                    </PrimaryButton>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={pendingSwitch !== null}
+        title="Switch label?"
+        message={
+          pendingSwitch
+            ? `Glow will reconnect using "${pendingSwitch}". You'll be asked to authenticate with your passkey.`
+            : ''
+        }
+        confirmLabel="Switch"
+        cancelLabel="Cancel"
+        variant="default"
+        onConfirm={handleConfirmSwitch}
+        onCancel={() => setPendingSwitch(null)}
+      />
+    </SlideInPage>
+  );
+};
+
+export default LabelsPage;

--- a/src/pages/PasskeyLocalStatePage.tsx
+++ b/src/pages/PasskeyLocalStatePage.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { Capacitor } from '@capacitor/core';
+import SlideInPage from '../components/layout/SlideInPage';
+import { ConfirmDialog } from '../components/ui';
+import { TrashIcon } from '../components/Icons';
+import { passkeyPrfProvider } from '../services/passkeyPrfProvider';
+import { clearAllLabelLastUsed } from '../services/passkeyService';
+import { useToast } from '@/contexts/ToastContext';
+import { logger, LogCategory } from '@/services/logger';
+
+interface PasskeyLocalStatePageProps {
+  onBack: () => void;
+}
+
+type ConfirmKind = 'forget' | 'wipe' | null;
+
+// `passkeyHome` is where the OS keeps the passkey itself. `systemDelete`
+// is the surface users navigate to remove it. The credential IDs Glow
+// tracks live in our own secure storage (plugin keychain on iOS,
+// Block Store + ESP on Android, localStorage on web), but the copy
+// intentionally doesn't name that storage layer.
+type PlatformCopy = {
+  passkeyHome: string;
+  systemDelete: string;
+};
+
+function getCopy(): PlatformCopy {
+  switch (Capacitor.getPlatform()) {
+    case 'ios':
+      return {
+        passkeyHome: 'iCloud Keychain',
+        systemDelete: 'Settings → Passwords',
+      };
+    case 'android':
+      return {
+        passkeyHome: 'Google Password Manager',
+        systemDelete: 'Google Password Manager',
+      };
+    default:
+      return {
+        passkeyHome: 'your browser or password manager',
+        systemDelete: 'your browser or password manager',
+      };
+  }
+}
+
+const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack }) => {
+  const { showToast } = useToast();
+  const [confirm, setConfirm] = useState<ConfirmKind>(null);
+  const [isWorking, setIsWorking] = useState(false);
+
+  const copy = getCopy();
+
+  const handleForget = () => {
+    // Keep the credential-IDs registry intact so the platform-level
+    // "already exists" check still refuses a duplicate Create.
+    localStorage.removeItem('passkeyRegistered');
+    localStorage.removeItem('passkeyFirstSeenAt');
+    localStorage.removeItem('passkeyLastSeenAt');
+    clearAllLabelLastUsed();
+    logger.warn(LogCategory.AUTH, 'User cleared passkey history (kept credential IDs)');
+    showToast('success', 'Passkey history cleared', 'Restart the app to see "Get Started".');
+    setConfirm(null);
+  };
+
+  const handleWipe = async () => {
+    setIsWorking(true);
+    let keychainCleared = true;
+    try {
+      await passkeyPrfProvider.clearKnownCredentialIds();
+    } catch (e) {
+      keychainCleared = false;
+      logger.warn(LogCategory.AUTH, 'clearKnownCredentialIds threw during wipe', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+    localStorage.removeItem('passkeyRegistered');
+    localStorage.removeItem('passkeyKnownCredentials');
+    localStorage.removeItem('passkeyFirstSeenAt');
+    localStorage.removeItem('passkeyLastSeenAt');
+    clearAllLabelLastUsed();
+    logger.warn(LogCategory.AUTH, 'User performed full passkey state wipe');
+    if (keychainCleared) {
+      showToast('success', 'Passkey state wiped', 'Local flag and tracked passkey IDs cleared.');
+    } else {
+      showToast('error', 'Partial wipe', 'Local cleared but tracked passkey IDs clear failed; check logs.');
+    }
+    setIsWorking(false);
+    setConfirm(null);
+  };
+
+  const items: Array<{
+    kind: ConfirmKind;
+    title: string;
+    description: string;
+  }> = [
+    {
+      kind: 'forget',
+      title: 'Forget passkey history',
+      description:
+        "Glow returns to the new-user welcome screen on this device. Your passkey is untouched, so trying to create another will still be refused as a duplicate.",
+    },
+    {
+      kind: 'wipe',
+      title: 'Wipe all passkey state',
+      description: `Same as above, plus Glow forgets the passkey IDs it tracks on this device. After this, you can register a new passkey on this device. The old one stays in ${copy.passkeyHome} until you delete it from ${copy.systemDelete}.`,
+    },
+  ];
+
+  return (
+    <SlideInPage title="Local State" closeStyle="back" onClose={onBack} slideFrom="right">
+      <div className="p-4 space-y-2">
+        {items.map((item) => (
+          <button
+            key={item.kind}
+            type="button"
+            onClick={() => setConfirm(item.kind)}
+            className="w-full flex items-start gap-3 p-4 bg-spark-dark border border-spark-border rounded-2xl text-left hover:border-spark-border-light hover:bg-white/5 transition-colors"
+          >
+            <div className="w-10 h-10 rounded-xl bg-spark-error/10 flex items-center justify-center shrink-0">
+              <TrashIcon size="sm" className="text-spark-error" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="font-display font-semibold text-spark-text-primary">
+                {item.title}
+              </div>
+              <p className="text-sm text-spark-text-muted mt-0.5">
+                {item.description}
+              </p>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <ConfirmDialog
+        isOpen={confirm === 'forget'}
+        title="Forget passkey history?"
+        message="On next launch, Glow will show the new-user welcome screen instead of jumping straight to passkey sign-in. Your passkey itself is not affected."
+        confirmLabel="Forget"
+        cancelLabel="Cancel"
+        variant="warning"
+        onConfirm={handleForget}
+        onCancel={() => setConfirm(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={confirm === 'wipe'}
+        title="Wipe all passkey state?"
+        message={`Glow forgets the welcome-screen marker and the passkey IDs it tracks on this device. Your passkey stays in ${copy.passkeyHome} until you delete it from ${copy.systemDelete}.`}
+        confirmLabel={isWorking ? 'Working…' : 'Wipe'}
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={handleWipe}
+        onCancel={() => setConfirm(null)}
+      />
+    </SlideInPage>
+  );
+};
+
+export default PasskeyLocalStatePage;

--- a/src/pages/PasskeyManagementPage.tsx
+++ b/src/pages/PasskeyManagementPage.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { Capacitor } from '@capacitor/core';
+import SlideInPage from '../components/layout/SlideInPage';
+import { PasskeyIcon } from '../components/Icons';
+import { getPasskeyMeta, hasPasskeyHistory } from '../services/passkeyService';
+
+interface PasskeyManagementPageProps {
+  onBack: () => void;
+}
+
+function formatTimestamp(ts: number | undefined): string {
+  if (!ts) return '';
+  try {
+    return new Date(ts).toLocaleString(undefined, {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return new Date(ts).toISOString();
+  }
+}
+
+// Hidden on web: UA heuristics can't reliably identify the credential
+// provider. Third-party password managers intercept across browsers,
+// and Apple's OS picker surfaces iCloud Keychain even in Chromium.
+function getStorageLabel(): string | null {
+  switch (Capacitor.getPlatform()) {
+    case 'ios': return 'iCloud Keychain';
+    case 'android': return 'Google Password Manager';
+    default: return null;
+  }
+}
+
+const PasskeyManagementPage: React.FC<PasskeyManagementPageProps> = ({ onBack }) => {
+  const [registered] = useState<boolean>(() => hasPasskeyHistory());
+  const [meta] = useState(() => getPasskeyMeta());
+  const storage = getStorageLabel();
+  const title = registered ? (storage ?? 'Passkey') : 'No passkey';
+  const hasTimestamps = registered && (meta.firstSeenAt || meta.lastSeenAt);
+
+  return (
+    <SlideInPage title="Passkey" closeStyle="back" onClose={onBack} slideFrom="right">
+      <div className="p-4 space-y-4">
+        <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-xl bg-spark-primary/15 flex items-center justify-center shrink-0">
+              <PasskeyIcon size="lg" className="text-spark-primary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="font-display font-semibold text-spark-text-primary">
+                {title}
+              </div>
+            </div>
+          </div>
+
+          {hasTimestamps && (
+            <div className="mt-4 border-t border-spark-border pt-3 space-y-1.5">
+              {meta.firstSeenAt && (
+                <div className="flex items-center justify-between gap-3 text-xs text-spark-text-muted">
+                  <span>First sign-in</span>
+                  <span>{formatTimestamp(meta.firstSeenAt)}</span>
+                </div>
+              )}
+              {meta.lastSeenAt && (
+                <div className="flex items-center justify-between gap-3 text-xs text-spark-text-muted">
+                  <span>Last sign-in</span>
+                  <span>{formatTimestamp(meta.lastSeenAt)}</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </SlideInPage>
+  );
+};
+
+export default PasskeyManagementPage;

--- a/src/pages/PasskeySettingsPage.tsx
+++ b/src/pages/PasskeySettingsPage.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import SlideInPage from '../components/layout/SlideInPage';
+import {
+  ChevronRightIcon,
+  PasskeyIcon,
+  WalletIcon,
+  TrashIcon,
+} from '../components/Icons';
+
+interface PasskeySettingsPageProps {
+  onBack: () => void;
+  onOpenPasskey: () => void;
+  onOpenLabels: () => void;
+  onOpenLocalState: () => void;
+}
+
+const PasskeySettingsPage: React.FC<PasskeySettingsPageProps> = ({
+  onBack,
+  onOpenPasskey,
+  onOpenLabels,
+  onOpenLocalState,
+}) => {
+  const items: Array<{
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+    onClick: () => void;
+  }> = [
+    {
+      icon: <PasskeyIcon size="md" className="text-spark-primary" />,
+      title: 'Passkey',
+      description: 'View passkey status and how to manage it on this device.',
+      onClick: onOpenPasskey,
+    },
+    {
+      icon: <WalletIcon size="md" className="text-spark-primary" />,
+      title: 'Labels',
+      description: 'Manage the labels associated with your passkey.',
+      onClick: onOpenLabels,
+    },
+    {
+      icon: <TrashIcon size="md" className="text-spark-primary" />,
+      title: 'Local State',
+      description: 'Reset locally stored passkey state on this device.',
+      onClick: onOpenLocalState,
+    },
+  ];
+
+  return (
+    <SlideInPage title="Passkey & Labels" closeStyle="back" onClose={onBack} slideFrom="right">
+      <div className="p-4 space-y-2">
+        {items.map((item) => (
+          <button
+            key={item.title}
+            type="button"
+            onClick={item.onClick}
+            className="w-full flex items-start gap-3 p-4 bg-spark-dark border border-spark-border rounded-2xl text-left hover:border-spark-border-light hover:bg-white/5 transition-colors"
+          >
+            <div className="w-10 h-10 rounded-xl bg-spark-primary/10 flex items-center justify-center shrink-0">
+              {item.icon}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="font-display font-semibold text-spark-text-primary">
+                {item.title}
+              </div>
+              <p className="text-sm text-spark-text-muted mt-0.5">
+                {item.description}
+              </p>
+            </div>
+            <div className="self-center text-spark-text-muted">
+              <ChevronRightIcon size="md" />
+            </div>
+          </button>
+        ))}
+      </div>
+    </SlideInPage>
+  );
+};
+
+export default PasskeySettingsPage;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -3,14 +3,11 @@ import { FormGroup, FormInput, LoadingSpinner, PrimaryButton, Switch } from '../
 import { getSettings, saveSettings, UserSettings } from '../services/settings';
 import type { Config, Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '@/contexts/WalletContext';
-import { CurrencyIcon, ChevronRightIcon, DownloadIcon } from '../components/Icons';
+import { CurrencyIcon, ChevronRightIcon, DownloadIcon, ShieldCheckIcon } from '../components/Icons';
 import SlideInPage from '../components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs, exportDatabaseState } from '@/services/logExport';
 import { useSecretTap } from '@/hooks/useSecretTap';
-import { useToast } from '@/contexts/ToastContext';
-import { isNativePlatform } from '@/services/nativePasskeyPrfProvider';
-import { passkeyPrfProvider } from '@/services/passkeyPrfProvider';
 
 const DEV_MODE_STORAGE_KEY = 'spark-dev-mode';
 
@@ -19,11 +16,17 @@ interface SettingsPageProps {
   config: Config | null;
   onOpenFiatCurrencies: () => void;
   onOpenBuyProviders: () => void;
+  onOpenPasskeySettings: () => void;
 }
 
-const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, config, onOpenFiatCurrencies, onOpenBuyProviders }) => {
+const SettingsPage: React.FC<SettingsPageProps> = ({
+  onBack,
+  config,
+  onOpenFiatCurrencies,
+  onOpenBuyProviders,
+  onOpenPasskeySettings,
+}) => {
   const wallet = useWallet();
-  const { showToast } = useToast();
   const {
     handleTap: devTap,
     activated: isDevMode,
@@ -184,60 +187,9 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, config, onOpenFiatC
     <SlideInPage title="Settings" onClose={onBack} slideFrom="left" footer={footer}>
       <div className="p-4">
         <div className="max-w-xl mx-auto w-full space-y-4">
-          {/* Dev Mode Network Selector */}
-          {isDevMode && (
-            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Network</h3>
-              <div className="flex gap-2">
-                {(['mainnet', 'regtest'] as Network[]).map((network) => (
-                  <button
-                    key={network}
-                    onClick={() => handleNetworkChange(network)}
-                    className={`flex-1 py-2.5 px-3 rounded-xl text-sm font-medium transition-all ${selectedNetwork === network
-                        ? 'bg-spark-primary text-white'
-                        : 'bg-spark-surface border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
-                      }`}
-                  >
-                    {network === 'mainnet' ? 'Mainnet' : 'Regtest'}
-                  </button>
-                ))}
-              </div>
-              <p className="text-xs text-spark-text-muted mt-2">
-                Changing network will reload the app and reconnect.
-              </p>
-            </div>
-          )}
-
-          {/* Dev Mode Fee Settings */}
-          {isDevMode && (
-            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Deposit Claim Fee</h3>
-              <FormGroup>
-                <div className="flex gap-2 items-center">
-                  <select
-                    value={feeType}
-                    onChange={(e) => setFeeType(e.currentTarget.value as 'fixed' | 'rate' | 'networkRecommended')}
-                    className="min-w-[160px] bg-spark-surface border border-spark-border rounded-xl px-3 py-3 text-spark-text-primary text-sm focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20"
-                    aria-label="Max fee type"
-                  >
-                    <option className="bg-spark-surface" value="fixed">Fixed (sats)</option>
-                    <option className="bg-spark-surface" value="rate">Rate (sat/vB)</option>
-                    <option className="bg-spark-surface" value="networkRecommended">Network + leeway</option>
-                  </select>
-                  <div className="flex-1">
-                    <FormInput
-                      id="deposit-fee-default"
-                      type="number"
-                      min={0}
-                      value={feeValue}
-                      onChange={(e) => setFeeValue(e.target.value)}
-                      placeholder={feeType === 'fixed' ? 'sats' : 'sat/vB'}
-                    />
-                  </div>
-                </div>
-              </FormGroup>
-            </div>
-          )}
+          {/* Order: page nav, exports, reconnect, toggles, inputs.
+              The "Save Changes" footer applies the toggles + inputs;
+              everything above it commits on tap. */}
 
           {/* Display */}
           <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
@@ -268,7 +220,25 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, config, onOpenFiatC
             </div>
           </div>
 
-          {/* SDK Logs */}
+          {/* Passkey & Labels */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Passkey</h3>
+              <button
+                className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+                type="button"
+                onClick={onOpenPasskeySettings}
+              >
+                <div className="flex items-center gap-3">
+                  <ShieldCheckIcon size="md" />
+                  <span>Passkey & Labels</span>
+                </div>
+                <ChevronRightIcon size="md" />
+              </button>
+            </div>
+          )}
+
+          {/* Diagnostics */}
           <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
             <h3 className="font-display font-semibold text-spark-text-primary mb-3">Diagnostics</h3>
             <button
@@ -286,176 +256,155 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, config, onOpenFiatC
             </button>
           </div>
 
-          {/* Dev Mode Advanced Settings */}
+          {/* Database */}
           {isDevMode && (
-            <>
-              <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-                <h3 className="font-display font-semibold text-spark-text-primary mb-3">Sync Settings</h3>
-                <FormGroup>
-                  <label htmlFor="sync-interval" className="block text-sm text-spark-text-secondary mb-1">
-                    Sync interval (seconds)
-                  </label>
-                  <FormInput
-                    id="sync-interval"
-                    type="number"
-                    min={0}
-                    value={syncIntervalSecs}
-                    onChange={(e) => setSyncIntervalSecs(e.target.value)}
-                    placeholder="e.g. 30"
-                  />
-                </FormGroup>
-              </div>
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Database</h3>
+              <button
+                className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors disabled:opacity-50"
+                type="button"
+                onClick={handleExportDb}
+                disabled={isExportingDb}
+              >
+                {isExportingDb ? (
+                  <LoadingSpinner size="small" />
+                ) : (
+                  <DownloadIcon size="md" />
+                )}
+                {isExportingDb ? 'Exporting...' : 'Export Database'}
+              </button>
+            </div>
+          )}
 
-              <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-                <h3 className="font-display font-semibold text-spark-text-primary mb-3">LNURL</h3>
-                <FormGroup>
-                  <label htmlFor="lnurl-domain" className="block text-sm text-spark-text-secondary mb-1">
-                    Custom domain
-                  </label>
-                  <FormInput
-                    id="lnurl-domain"
-                    type="text"
-                    value={lnurlDomain}
-                    onChange={(e) => setLnurlDomain(e.target.value)}
-                    placeholder="example.com"
-                  />
-                </FormGroup>
-              </div>
-
-              <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <span className="font-display font-medium text-spark-text-primary block">Prefer Spark</span>
-                    <span className="text-sm text-spark-text-muted">Use Spark address over Lightning invoice when available</span>
-                  </div>
-                  <Switch
-                    checked={preferSparkOverLightning}
-                    onChange={() => setPreferSparkOverLightning(!preferSparkOverLightning)}
-                  />
-                </div>
-              </div>
-
-              <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-                <h3 className="font-display font-semibold text-spark-text-primary mb-3">Database</h3>
-                <button
-                  className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors disabled:opacity-50"
-                  type="button"
-                  onClick={handleExportDb}
-                  disabled={isExportingDb}
-                >
-                  {isExportingDb ? (
-                    <LoadingSpinner size="small" />
-                  ) : (
-                    <DownloadIcon size="md" />
-                  )}
-                  {isExportingDb ? 'Exporting...' : 'Export Database'}
-                </button>
-              </div>
-
-              {/* Privacy Settings - Dev Mode only */}
-              <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-                <div className="flex items-center gap-2 mb-3">
-                  <h3 className="font-display font-semibold text-spark-text-primary">Privacy</h3>
-                  {isLoadingUserSettings && <LoadingSpinner size="small" />}
-                </div>
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <span className="font-display font-medium text-spark-text-primary block">Private Mode</span>
-                    <span className="text-sm text-spark-text-muted">Hide your address from public explorers (not suitable for zaps)</span>
-                  </div>
-                  <Switch
-                    checked={sparkPrivateModeEnabled}
-                    onChange={() => setSparkPrivateModeEnabled(!sparkPrivateModeEnabled)}
-                    disabled={isLoadingUserSettings}
-                  />
-                </div>
-              </div>
-
-              {/* Passkey state reset (dev mode). Two paths because
-                  testing the hardening flows benefits from cleaning
-                  different layers independently:
-                    - Flag-only: clears `passkeyRegistered` but leaves
-                      the plugin's iCloud-synced credential-IDs
-                      keychain entry intact. Use to reach the Get
-                      Started CTA while a real passkey still exists
-                      in iCloud Keychain — the path that exercises
-                      the platform's `excludeCredentialIds` refusal
-                      via PasskeyAlreadyExistsError.
-                    - Full wipe: clears flag + plugin keychain entry.
-                      Use after deleting the actual passkey from
-                      Settings -> Passwords to reach a true zero
-                      state for testing the new-user flow. */}
-              <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-                <h3 className="font-display font-semibold text-spark-text-primary mb-3">Passkey state (dev)</h3>
-                <div className="space-y-2">
+          {/* Network */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Network</h3>
+              <div className="flex gap-2">
+                {(['mainnet', 'regtest'] as Network[]).map((network) => (
                   <button
-                    type="button"
-                    onClick={() => {
-                      // Intentionally only clear the flag — leave
-                      // `passkeyKnownCredentials` in place. On native
-                      // the credential-IDs registry lives in the
-                      // iCloud-synced plugin keychain so this matters
-                      // less, but on web that localStorage entry IS
-                      // the registry. Wiping it here would empty the
-                      // browser's excludeCredentialIds list and
-                      // silently allow a duplicate passkey on the
-                      // next Create attempt — which is exactly the
-                      // "platform-level already-exists check still
-                      // fires" guarantee this button claims to
-                      // preserve.
-                      localStorage.removeItem('passkeyRegistered');
-                      logger.warn(LogCategory.AUTH, 'Dev: cleared passkeyRegistered flag (kept credential IDs)');
-                      showToast('success', 'Passkey history cleared', 'Restart the app to see "Get Started" CTA.');
-                    }}
-                    className="w-full bg-spark-surface border border-spark-border rounded-xl px-4 py-3 text-spark-text-primary text-sm hover:border-spark-border-light transition-colors text-left"
+                    key={network}
+                    onClick={() => handleNetworkChange(network)}
+                    className={`flex-1 py-2.5 px-3 rounded-xl text-sm font-medium transition-all ${selectedNetwork === network
+                        ? 'bg-spark-primary text-white'
+                        : 'bg-spark-surface border border-spark-border text-spark-text-secondary hover:text-spark-text-primary hover:border-spark-border-light'
+                      }`}
                   >
-                    <span className="font-medium block">Forget passkey history</span>
-                    <span className="text-spark-text-muted text-xs">
-                      {isNativePlatform()
-                        ? 'Clears local flag only. Keeps the iCloud-synced credential IDs so the platform-level "already exists" check still fires.'
-                        : 'Clears local flag only. Keeps tracked credential IDs in localStorage so the browser-level "already exists" check still fires.'}
-                    </span>
+                    {network === 'mainnet' ? 'Mainnet' : 'Regtest'}
                   </button>
-                  <button
-                    type="button"
-                    onClick={async () => {
-                      let keychainCleared = true;
-                      try {
-                        await passkeyPrfProvider.clearKnownCredentialIds();
-                      } catch (e) {
-                        keychainCleared = false;
-                        logger.warn(LogCategory.AUTH, 'Dev wipe: clearKnownCredentialIds threw', {
-                          error: e instanceof Error ? e.message : String(e),
-                        });
-                      }
-                      localStorage.removeItem('passkeyRegistered');
-                      localStorage.removeItem('passkeyKnownCredentials');
-                      logger.warn(LogCategory.AUTH, 'Dev: full passkey state wipe');
-                      if (keychainCleared) {
-                        showToast(
-                          'success',
-                          'Passkey state wiped',
-                          isNativePlatform()
-                            ? 'Local flag + iCloud-synced credential IDs cleared.'
-                            : 'Local flag + tracked credential IDs cleared.',
-                        );
-                      } else {
-                        showToast('error', 'Partial wipe', 'Local cleared but plugin keychain clear failed; check logs.');
-                      }
-                    }}
-                    className="w-full bg-spark-surface border border-spark-border rounded-xl px-4 py-3 text-spark-text-primary text-sm hover:border-spark-border-light transition-colors text-left"
-                  >
-                    <span className="font-medium block">Wipe all passkey state</span>
-                    <span className="text-spark-text-muted text-xs">
-                      {isNativePlatform()
-                        ? "Clears local flag AND the plugin's iCloud-synced credential-IDs entry. Pair with a Settings -> Passwords delete for a true zero state."
-                        : 'Clears local flag AND localStorage credential-IDs registry. Pair with a browser-level passkey delete (Chrome / Safari Passwords) for a true zero state.'}
-                    </span>
-                  </button>
-                </div>
+                ))}
               </div>
+              <p className="text-xs text-spark-text-muted mt-2">
+                Changing network will reload the app and reconnect.
+              </p>
+            </div>
+          )}
 
-            </>
+          {/* Privacy */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <h3 className="font-display font-semibold text-spark-text-primary">Privacy</h3>
+                {isLoadingUserSettings && <LoadingSpinner size="small" />}
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <span className="font-display font-medium text-spark-text-primary block">Private Mode</span>
+                  <span className="text-sm text-spark-text-muted">Hide your address from public explorers (not suitable for zaps)</span>
+                </div>
+                <Switch
+                  checked={sparkPrivateModeEnabled}
+                  onChange={() => setSparkPrivateModeEnabled(!sparkPrivateModeEnabled)}
+                  disabled={isLoadingUserSettings}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Prefer Spark */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <span className="font-display font-medium text-spark-text-primary block">Prefer Spark</span>
+                  <span className="text-sm text-spark-text-muted">Use Spark address over Lightning invoice when available</span>
+                </div>
+                <Switch
+                  checked={preferSparkOverLightning}
+                  onChange={() => setPreferSparkOverLightning(!preferSparkOverLightning)}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Deposit Claim Fee */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Deposit Claim Fee</h3>
+              <FormGroup>
+                <div className="flex gap-2 items-center">
+                  <select
+                    value={feeType}
+                    onChange={(e) => setFeeType(e.currentTarget.value as 'fixed' | 'rate' | 'networkRecommended')}
+                    className="min-w-[160px] bg-spark-surface border border-spark-border rounded-xl px-3 py-3 text-spark-text-primary text-sm focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20"
+                    aria-label="Max fee type"
+                  >
+                    <option className="bg-spark-surface" value="fixed">Fixed (sats)</option>
+                    <option className="bg-spark-surface" value="rate">Rate (sat/vB)</option>
+                    <option className="bg-spark-surface" value="networkRecommended">Network + leeway</option>
+                  </select>
+                  <div className="flex-1">
+                    <FormInput
+                      id="deposit-fee-default"
+                      type="number"
+                      min={0}
+                      value={feeValue}
+                      onChange={(e) => setFeeValue(e.target.value)}
+                      placeholder={feeType === 'fixed' ? 'sats' : 'sat/vB'}
+                    />
+                  </div>
+                </div>
+              </FormGroup>
+            </div>
+          )}
+
+          {/* Sync Settings */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Sync Settings</h3>
+              <FormGroup>
+                <label htmlFor="sync-interval" className="block text-sm text-spark-text-secondary mb-1">
+                  Sync interval (seconds)
+                </label>
+                <FormInput
+                  id="sync-interval"
+                  type="number"
+                  min={0}
+                  value={syncIntervalSecs}
+                  onChange={(e) => setSyncIntervalSecs(e.target.value)}
+                  placeholder="e.g. 30"
+                />
+              </FormGroup>
+            </div>
+          )}
+
+          {/* LNURL */}
+          {isDevMode && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">LNURL</h3>
+              <FormGroup>
+                <label htmlFor="lnurl-domain" className="block text-sm text-spark-text-secondary mb-1">
+                  Custom domain
+                </label>
+                <FormInput
+                  id="lnurl-domain"
+                  type="text"
+                  value={lnurlDomain}
+                  onChange={(e) => setLnurlDomain(e.target.value)}
+                  placeholder="example.com"
+                />
+              </FormGroup>
+            </div>
           )}
 
           {/* Version / Dev Mode Toggle */}

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -21,6 +21,14 @@ const PASSKEY_REGISTERED_KEY = 'passkeyRegistered';
 // platform refuses to register a duplicate even if PASSKEY_REGISTERED
 // was wiped (defense-in-depth: protects against localStorage clears).
 const KNOWN_CREDENTIALS_KEY = 'passkeyKnownCredentials';
+// Per-device timestamps. WebAuthn doesn't expose creation / last-use
+// dates, so we record them locally on each successful PRF ceremony.
+const PASSKEY_FIRST_SEEN_KEY = 'passkeyFirstSeenAt';
+const PASSKEY_LAST_SEEN_KEY = 'passkeyLastSeenAt';
+// Per-label last-used timestamps. Recorded each time a label is loaded
+// into the active wallet (initial connect or switchPasskeyLabel) so the
+// Labels page can surface a relative "last used" hint per row.
+const PASSKEY_LABEL_LAST_USED_PREFIX = 'passkeyLabelLastUsed:';
 
 let cachedPasskey: Passkey | null = null;
 
@@ -61,7 +69,62 @@ export async function createPasskey(): Promise<void> {
   const credentialId = await passkeyPrfProvider.createPasskey({ excludeCredentialIds });
   if (credentialId) addKnownCredentialIdLocal(credentialId);
   localStorage.setItem(PASSKEY_REGISTERED_KEY, '1');
+  markPasskeyUsed();
   logger.info(LogCategory.AUTH, 'Passkey created successfully');
+}
+
+/**
+ * Stamp first-seen (set once) and last-seen (always) for the passkey.
+ * Call after any successful PRF ceremony.
+ */
+export function markPasskeyUsed(): void {
+  const now = String(Date.now());
+  if (!localStorage.getItem(PASSKEY_FIRST_SEEN_KEY)) {
+    localStorage.setItem(PASSKEY_FIRST_SEEN_KEY, now);
+  }
+  localStorage.setItem(PASSKEY_LAST_SEEN_KEY, now);
+}
+
+export function getPasskeyMeta(): { firstSeenAt?: number; lastSeenAt?: number } {
+  const first = localStorage.getItem(PASSKEY_FIRST_SEEN_KEY);
+  const last = localStorage.getItem(PASSKEY_LAST_SEEN_KEY);
+  return {
+    firstSeenAt: first ? Number(first) : undefined,
+    lastSeenAt: last ? Number(last) : undefined,
+  };
+}
+
+/**
+ * Stamp last-used for a specific label. Called from the wallet hook
+ * whenever a label is brought online (initial connect or switch), so
+ * the Labels page can render a "last used" hint per row.
+ */
+export function markLabelUsed(label: string): void {
+  localStorage.setItem(`${PASSKEY_LABEL_LAST_USED_PREFIX}${label}`, String(Date.now()));
+}
+
+/**
+ * Read the last-used timestamp for a label. Returns undefined when the
+ * label has never been activated on this device.
+ */
+export function getLabelLastUsed(label: string): number | undefined {
+  const raw = localStorage.getItem(`${PASSKEY_LABEL_LAST_USED_PREFIX}${label}`);
+  if (raw === null) return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Wipe every per-label last-used entry. Used by the wipe / forget
+ * surfaces in PasskeyLocalStatePage and by the deletion-recovery flow
+ * when the passkey itself is being torn down.
+ */
+export function clearAllLabelLastUsed(): void {
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith(PASSKEY_LABEL_LAST_USED_PREFIX)) {
+      localStorage.removeItem(key);
+    }
+  }
 }
 
 /**
@@ -119,6 +182,9 @@ export async function clearPasskeyHistory(): Promise<void> {
   }
   localStorage.removeItem(PASSKEY_REGISTERED_KEY);
   localStorage.removeItem(KNOWN_CREDENTIALS_KEY);
+  localStorage.removeItem(PASSKEY_FIRST_SEEN_KEY);
+  localStorage.removeItem(PASSKEY_LAST_SEEN_KEY);
+  clearAllLabelLastUsed();
   invalidatePasskey();
 }
 
@@ -207,6 +273,7 @@ export async function getWallet(label?: string): Promise<Wallet> {
   try {
     const wallet = await passkey.getWallet(effectiveLabel);
     logger.info(LogCategory.AUTH, 'Passkey wallet derived successfully');
+    markPasskeyUsed();
     return wallet;
   } catch (e) {
     logger.error(LogCategory.AUTH, 'Failed to derive passkey wallet', {


### PR DESCRIPTION
Adds a dev-gated "Passkey" section in Settings that opens a hub page with three sub-pages:
- **Passkey** (status + first/last sign-in),
- **Labels** (list + add + one-tap switch via PRF),
- and **Local State** (forget / wipe).

`useBreezSdk` gains a `switchPasskeyLabel` action that disconnects, derives a new wallet via the passkey, and reconnects without bouncing through the home screen. PRF runs first so a cancelled prompt leaves the active wallet untouched.

`passkeyService` records first-seen / last-seen timestamps per device and per-label last-used timestamps so the management pages can display the metadata Google's Android passkey guidelines call for.

`CLAUDE.md` documents the new pages, screen wiring, and metadata keys.