### PR TITLE
revert(passkey): drop SDK Passkey instance cache

### DIFF
--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -1,10 +1,11 @@
 /**
  * Passkey Service.
  *
- * Wraps the Breez SDK's Passkey class. Holds a module-level singleton
- * so the SDK's internal Nostr-identity cache survives across calls
- * (otherwise `saveLabel`/`listLabels` would re-prompt for PRF each time).
- * Invalidate the singleton when the credential or relay config changes.
+ * Wraps the Breez SDK's Passkey class to provide
+ * passkey-based wallet creation and restoration functionality.
+ *
+ * Creates a fresh Passkey instance per operation so that no stale
+ * PRF session or cached state can survive between wizard steps.
  */
 
 import { Passkey, Wallet, NostrRelayConfig } from '@breeztech/breez-sdk-spark';
@@ -30,20 +31,16 @@ const PASSKEY_LAST_SEEN_KEY = 'passkeyLastSeenAt';
 // Labels page can surface a relative "last used" hint per row.
 const PASSKEY_LABEL_LAST_USED_PREFIX = 'passkeyLabelLastUsed:';
 
-let cachedPasskey: Passkey | null = null;
-
-function getPasskey(): Passkey {
-  if (cachedPasskey !== null) return cachedPasskey;
+/**
+ * Create a fresh Passkey instance.
+ * No caching: each call gets a clean instance with no stale state.
+ */
+function createPasskeyInstance(): Passkey {
   const breezApiKey = import.meta.env.VITE_BREEZ_API_KEY;
   const relayConfig: NostrRelayConfig | undefined = breezApiKey
     ? { breezApiKey }
     : undefined;
-  cachedPasskey = new Passkey(passkeyPrfProvider, relayConfig ?? null);
-  return cachedPasskey;
-}
-
-function invalidatePasskey(): void {
-  cachedPasskey = null;
+  return new Passkey(passkeyPrfProvider, relayConfig ?? null);
 }
 
 /**
@@ -185,7 +182,6 @@ export async function clearPasskeyHistory(): Promise<void> {
   localStorage.removeItem(PASSKEY_FIRST_SEEN_KEY);
   localStorage.removeItem(PASSKEY_LAST_SEEN_KEY);
   clearAllLabelLastUsed();
-  invalidatePasskey();
 }
 
 /**
@@ -198,7 +194,7 @@ export async function isPrfAvailable(): Promise<boolean> {
     return false;
   }
 
-  const passkey = getPasskey();
+  const passkey = createPasskeyInstance();
   return await passkey.isAvailable();
 }
 
@@ -226,7 +222,6 @@ export function setPasskeyMode(label?: string): void {
  */
 export function clearPasskeyMode(): void {
   localStorage.removeItem(PASSKEY_LABEL_KEY);
-  invalidatePasskey();
 }
 
 /**
@@ -243,7 +238,7 @@ export function hasPasskeyHistory(): boolean {
  */
 export async function listLabels(): Promise<string[]> {
   logger.info(LogCategory.AUTH, 'Listing labels from nostr relays');
-  const passkey = getPasskey();
+  const passkey = createPasskeyInstance();
   return await passkey.listLabels();
 }
 
@@ -252,7 +247,7 @@ export async function listLabels(): Promise<string[]> {
  */
 export async function saveLabel(label: string): Promise<void> {
   logger.info(LogCategory.AUTH, 'Saving label to nostr relays');
-  const passkey = getPasskey();
+  const passkey = createPasskeyInstance();
   await passkey.storeLabel(label);
 }
 
@@ -269,7 +264,7 @@ export async function getWallet(label?: string): Promise<Wallet> {
 
   logger.info(LogCategory.AUTH, 'Deriving wallet via passkey');
 
-  const passkey = getPasskey();
+  const passkey = createPasskeyInstance();
   try {
     const wallet = await passkey.getWallet(effectiveLabel);
     logger.info(LogCategory.AUTH, 'Passkey wallet derived successfully');


### PR DESCRIPTION
## Summary
- Reverts the SDK `Passkey` instance cache introduced in [fa35d39](https://github.com/breez/glow-web/commit/fa35d3951a271a8b980bdc72bb3427520cd5ee9d) (part of [#194](https://github.com/breez/glow-web/pull/194)).
- Restores the original `createPasskeyInstance()` factory: each call constructs a fresh SDK `Passkey` with no shared state.
- Removes `invalidatePasskey()` calls from `clearPasskeyHistory` and `clearPasskeyMode` along with the cache-related docstrings.

The singleton was meant to preserve the SDK's internal `nostr_keys: OnceCell` across `saveLabel`/`listLabels` within a session. In practice it adds complexity without saving prompts on the path that matters (`saveLabel` is the first Nostr op, cache is empty), and the dual-salt PRF work in Tier 2 is the proper fix.

## Test plan
- [ ] `npm run dev`, walk new-user create flow, confirm passkey create + first label save still work
- [ ] Sign-in flow on a device with an existing passkey: `listLabels` + `getWallet` complete successfully
- [ ] `clearPasskeyHistory` (deletion-recovery) and `clearPasskeyMode` (logout) leave no stale references