### PR TITLE
feat(passkey): web sign-in hardening + per-create username discriminator + native AAGUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -362,7 +362,7 @@
     "node_modules/@breeztech/breez-sdk-spark": {
       "version": "0.1.0",
       "resolved": "file:vendor/breeztech-breez-sdk-spark-v0.13.7-passkey-aaguid.tgz",
-      "integrity": "sha512-oJvdxV8t3YRIKESQHdUub9hvf3KT6IgKt6s0GY/bWMF9qxpX5EclzYCoonV7SNbtrBCYg+X3HfrXqXjmAc1bdw==",
+      "integrity": "sha512-Lv0UNNgoi2oP52cULEUSXl9SAC+uaX4bW/7IF3w4fhQwXAAGlQBjHDzTBW+OPJp7OV55HBqUB1zcv3FCzgqClQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ import { STATUS_BAR_LOADING } from './utils/statusBarManager';
 import { useBackButton } from './hooks/useBackButton';
 import type { Seed, Payment } from '@breeztech/breez-sdk-spark';
 
-type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'passkeyCreate' | 'unlock' | 'unlocking' | 'passkeySettings' | 'passkeyManagement' | 'labels' | 'passkeyLocalState';
+type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'unlock' | 'unlocking' | 'passkeySettings' | 'passkeyManagement' | 'labels' | 'passkeyLocalState';
 
 // Full-screen dim spinner shown while sdk.isLoading is true (logout in
 // progress, SDK reconnect, etc). Wrapped as its own component so the
@@ -68,6 +68,12 @@ const AppContent: React.FC = () => {
   const [refundAnimationDirection, setRefundAnimationDirection] = useState<'left' | 'up'>('left');
   const [buyProvidersSource, setBuyProvidersSource] = useState<'wallet' | 'settings'>('wallet');
   const [passkeySdkConnected, setPasskeySdkConnected] = useState(false);
+  // True when the user entered the passkey screen via the explicit
+  // "Create New Wallet" CTA on browsers without `immediateGet`. Skips
+  // PasskeyPage's discovery (`detecting`) phase so we don't trigger a
+  // cross-device QR picker on the first click of a fresh-user
+  // onboarding. Read by PasskeyPage as the `skipDetection` prop.
+  const [passkeySkipDetection, setPasskeySkipDetection] = useState(false);
   const { showToast } = useToast();
   const formatPaymentAmountRef = useRef<((payment: Payment) => string) | undefined>(undefined);
 
@@ -200,7 +206,6 @@ const AppContent: React.FC = () => {
       sdk.isLoading &&
       currentScreen !== 'restore' &&
       currentScreen !== 'passkey' &&
-      currentScreen !== 'passkeyCreate' &&
       currentScreen !== 'unlock' &&
       currentScreen !== 'unlocking'
     ) {
@@ -222,10 +227,9 @@ const AppContent: React.FC = () => {
           <HomePage
             onRestoreWallet={() => setUserScreen('restore')}
             onCreateNewWallet={() => setUserScreen('generate')}
-            onCreatePasskey={() => setUserScreen('passkeyCreate')}
-            onUsePasskey={() => setUserScreen('passkey')}
+            onUsePasskey={() => { setPasskeySkipDetection(false); setUserScreen('passkey'); }}
+            onCreatePasskey={() => { setPasskeySkipDetection(true); setUserScreen('passkey'); }}
             prfAvailable={sdk.prfAvailable}
-            hasPasskeyBefore={sdk.hasPasskeyBefore}
           />
         );
       }
@@ -293,10 +297,9 @@ const AppContent: React.FC = () => {
           <HomePage
             onRestoreWallet={() => setUserScreen('restore')}
             onCreateNewWallet={() => setUserScreen('generate')}
-            onCreatePasskey={() => setUserScreen('passkeyCreate')}
-            onUsePasskey={() => setUserScreen('passkey')}
+            onUsePasskey={() => { setPasskeySkipDetection(false); setUserScreen('passkey'); }}
+            onCreatePasskey={() => { setPasskeySkipDetection(true); setUserScreen('passkey'); }}
             prfAvailable={sdk.prfAvailable}
-            hasPasskeyBefore={sdk.hasPasskeyBefore}
           />
         );
 
@@ -312,21 +315,7 @@ const AppContent: React.FC = () => {
             isSecuringSeed={sdk.isSecuringSeed}
             onFlowComplete={handlePasskeyFlowComplete}
             consumeFreshInstallSignal={sdk.consumeFreshInstallSignal}
-          />
-        );
-
-      case 'passkeyCreate':
-        return (
-          <PasskeyPage
-            onWalletRestored={handlePasskeyConnect}
-            onBack={() => {
-              setPasskeySdkConnected(false);
-              setUserScreen('home');
-            }}
-            sdkConnected={passkeySdkConnected}
-            isSecuringSeed={sdk.isSecuringSeed}
-            onFlowComplete={handlePasskeyFlowComplete}
-            skipDetection
+            skipDetection={passkeySkipDetection}
           />
         );
 
@@ -412,7 +401,7 @@ const AppContent: React.FC = () => {
             {renderWalletPage()}
             {renderSettingsPage()}
             {renderPasskeySettingsPage()}
-            <PasskeyLocalStatePage onBack={() => setUserScreen('passkeySettings')} />
+            <PasskeyLocalStatePage onBack={() => setUserScreen('passkeySettings')} onCompleted={handleLogout} />
           </>
         );
 

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -30,6 +30,7 @@ import {
   getWallet,
   hasPasskeyHistory,
   markLabelUsed,
+  invalidatePasskey,
 } from '../services/passkeyService';
 import { secureStorage, deviceOnlyStorage, SecureStorageError } from '../services/secureStorage';
 import { passkeyPrfProvider } from '../services/passkeyPrfProvider';
@@ -581,6 +582,11 @@ export function useBreezSdk(
   const switchPasskeyLabel = useCallback(async (newLabel: string): Promise<void> => {
     setIsLoading(true);
     setError(null);
+
+    // Drop the cached Passkey so the new label gets a fresh Nostr
+    // OnceCell. Without this, the SDK reuses the prior label's
+    // identity in cached state.
+    invalidatePasskey();
 
     // PRF first so a cancel here leaves the active wallet untouched.
     let wallet;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,24 +4,35 @@ import GlowLogo from '@/components/GlowLogo';
 import { safeAreaTop, safeAreaBottom } from '@/utils/safeAreaInsets';
 import { useStatusBarColor } from '@/hooks/useStatusBarColor';
 import { STATUS_BAR_DARK } from '@/utils/statusBarManager';
+import { passkeyPrfProvider } from '@/services/passkeyPrfProvider';
 
 interface HomePageProps {
   onRestoreWallet: () => void;
   onCreateNewWallet: () => void;
-  onCreatePasskey: () => void;
+  /**
+   * Routes through the discovery flow (sign-in attempt first, falls
+   * through to create only if no credential matches). Tripped by the
+   * "Get Started" / "Use Passkey" / "Sign In with Existing Passkey"
+   * CTAs.
+   */
   onUsePasskey: () => void;
+  /**
+   * Routes directly to the create flow, skipping discovery. Tripped by
+   * the "Create New Wallet" CTA on browsers without
+   * `immediateGet` support, where an unconditional discovery probe
+   * would otherwise show a cross-device QR sheet on the first click
+   * for users who genuinely have no passkeys.
+   */
+  onCreatePasskey: () => void;
   prfAvailable: boolean;
-  /** True when this device has previously used a passkey (prioritize sign-in). */
-  hasPasskeyBefore?: boolean;
 }
 
 const HomePage: React.FC<HomePageProps> = ({
   onRestoreWallet,
   onCreateNewWallet,
-  onCreatePasskey,
   onUsePasskey,
+  onCreatePasskey,
   prfAvailable,
-  hasPasskeyBefore = false,
 }) => {
   // Landing page sits on a flat spark-dark background, so pin the
   // system bars to the same solid tone while we're shown.
@@ -29,11 +40,26 @@ const HomePage: React.FC<HomePageProps> = ({
 
   const [showMnemonicFlow, setShowMnemonicFlow] = useState(false);
   const [starsAnimating, setStarsAnimating] = useState(false);
+  // Tri-state: null while the capability probe is in-flight, then true
+  // / false once `getClientCapabilities()` resolves. Default is `null`
+  // (loading) so we don't flash the wrong button set on first paint.
+  // After resolution, `false` is the assumption for any browser that
+  // doesn't advertise `immediateGet` (most current browsers including
+  // mobile Safari and mobile Chrome without the experiment flag).
+  const [immediateGetSupported, setImmediateGetSupported] = useState<boolean | null>(null);
   const { handleTap: handleLogoTap } = useSecretTap(5, 2000, false, () => setShowMnemonicFlow(v => !v));
 
   useEffect(() => {
     const timer = setTimeout(() => setStarsAnimating(true), 300);
     return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    passkeyPrfProvider.supportsImmediateGet().then((supported) => {
+      if (!cancelled) setImmediateGetSupported(supported);
+    });
+    return () => { cancelled = true; };
   }, []);
 
   return (
@@ -115,25 +141,44 @@ const HomePage: React.FC<HomePageProps> = ({
         {/* CTA Buttons */}
         <div className="w-full max-w-xs space-y-4 min-h-44">
           {prfAvailable && !showMnemonicFlow ? (
-            hasPasskeyBefore ? (
-              // Returning user (has registered a passkey before): the only
-              // CTA is sign-in. There's no "Create" path here; multiple
-              // wallets are achieved via multiple labels under a single
-              // passkey, not multiple passkeys per RP per device. The
-              // secret-tap on the logo flips into the mnemonic flow as
-              // a support escape hatch for the rare "I cleared
-              // localStorage" case.
+            immediateGetSupported === true ? (
               <>
+                {/* Single CTA when `immediateGet` is advertised
+                    (Chrome with the experiment flag, native via
+                    preferImmediatelyAvailableCredentials). The probe
+                    runs with `mediation: 'immediate'` and silently
+                    no-UIs when no credential is available, so a fresh
+                    user falls through to create without seeing a
+                    sheet. */}
                 <button
                   onClick={onUsePasskey}
-                  data-testid="use-passkey-button"
+                  data-testid="get-started-button"
                   className="button w-full py-4 text-base tracking-wider"
                 >
-                  Use Passkey
+                  Get Started
+                </button>
+
+                <button
+                  onClick={() => setShowMnemonicFlow(true)}
+                  className="text-spark-text-muted text-xs hover:text-spark-text-secondary transition-colors w-full text-center py-2"
+                >
+                  Use Recovery Phrase Instead
                 </button>
               </>
             ) : (
               <>
+                {/* Two-CTA fallback for browsers without `immediateGet`.
+                    Modern Chromium (desktop + mobile) opens the cross-
+                    device QR / security-key picker for empty-
+                    allowCredentials get() regardless of `hints` /
+                    `authenticatorAttachment`, which is hostile UX for
+                    the common "I just installed Glow" path. Safari and
+                    Firefox surface their own platform-specific sheets
+                    that are similarly noisy. Splitting the entry into
+                    explicit "create" vs "use existing" avoids the
+                    sheet entirely on the create path. The sign-in
+                    path still triggers it (user opted into discovery
+                    by clicking, so the picker is expected). */}
                 <button
                   onClick={onCreatePasskey}
                   data-testid="create-passkey-button"
@@ -144,7 +189,7 @@ const HomePage: React.FC<HomePageProps> = ({
 
                 <button
                   onClick={onUsePasskey}
-                  data-testid="use-passkey-button"
+                  data-testid="signin-passkey-button"
                   className="button-secondary w-full py-4 rounded-xl font-display font-semibold text-sm tracking-wide"
                 >
                   Use Existing Passkey

--- a/src/pages/PasskeyLocalStatePage.tsx
+++ b/src/pages/PasskeyLocalStatePage.tsx
@@ -4,12 +4,19 @@ import SlideInPage from '../components/layout/SlideInPage';
 import { ConfirmDialog } from '../components/ui';
 import { TrashIcon } from '../components/Icons';
 import { passkeyPrfProvider } from '../services/passkeyPrfProvider';
-import { clearAllCredentialAaguids, clearAllLabelLastUsed } from '../services/passkeyService';
+import { clearAllLabelLastUsed } from '../services/passkeyService';
 import { useToast } from '@/contexts/ToastContext';
 import { logger, LogCategory } from '@/services/logger';
 
 interface PasskeyLocalStatePageProps {
   onBack: () => void;
+  /**
+   * Called after a successful Forget / Wipe so the host can route the
+   * user out of the settings stack — typically to home via logout, so
+   * the dev doesn't have to walk back through Settings → Passkey &
+   * Labels → Wallet manually after every wipe.
+   */
+  onCompleted: () => void;
 }
 
 type ConfirmKind = 'forget' | 'wipe' | null;
@@ -44,7 +51,7 @@ function getCopy(): PlatformCopy {
   }
 }
 
-const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack }) => {
+const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack, onCompleted }) => {
   const { showToast } = useToast();
   const [confirm, setConfirm] = useState<ConfirmKind>(null);
   const [isWorking, setIsWorking] = useState(false);
@@ -53,15 +60,19 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack })
 
   const handleForget = () => {
     // Keep the credential-IDs registry intact so the platform-level
-    // "already exists" check still refuses a duplicate Create.
+    // "already exists" check still refuses a duplicate Create. AAGUIDs
+    // also stay — they're only captured at create time and not
+    // recoverable on sign-in, so wiping them loses provider metadata
+    // (name, icon) permanently for credentials that are still on the
+    // device.
     localStorage.removeItem('passkeyRegistered');
     localStorage.removeItem('passkeyFirstSeenAt');
     localStorage.removeItem('passkeyLastSeenAt');
     clearAllLabelLastUsed();
-    clearAllCredentialAaguids();
-    logger.warn(LogCategory.AUTH, 'User cleared passkey history (kept credential IDs)');
-    showToast('success', 'Passkey history cleared', 'Restart the app to see "Get Started".');
+    logger.warn(LogCategory.AUTH, 'User cleared passkey history (kept credential IDs and AAGUIDs)');
+    showToast('success', 'Passkey history cleared');
     setConfirm(null);
+    onCompleted();
   };
 
   const handleWipe = async () => {
@@ -77,36 +88,28 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack })
     }
     localStorage.removeItem('passkeyRegistered');
     localStorage.removeItem('passkeyKnownCredentials');
+    localStorage.removeItem('passkeyActiveCredentialId');
     localStorage.removeItem('passkeyFirstSeenAt');
     localStorage.removeItem('passkeyLastSeenAt');
     clearAllLabelLastUsed();
-    clearAllCredentialAaguids();
-    logger.warn(LogCategory.AUTH, 'User performed full passkey state wipe');
+    // AAGUIDs intentionally kept — they're only captured at create
+    // time and not recoverable on sign-in. Wiping them would lose
+    // provider name/icon for any credential that still exists on the
+    // device (or in iCloud Keychain / Block Store).
+    logger.warn(LogCategory.AUTH, 'User performed full passkey state wipe (kept AAGUIDs)');
     if (keychainCleared) {
-      showToast('success', 'Passkey state wiped', 'Local flag and tracked passkey IDs cleared.');
+      showToast('success', 'Passkey state wiped');
     } else {
-      showToast('error', 'Partial wipe', 'Local cleared but tracked passkey IDs clear failed; check logs.');
+      showToast('error', 'Partial wipe', 'Tracked passkey IDs clear failed; check logs.');
     }
     setIsWorking(false);
     setConfirm(null);
+    onCompleted();
   };
 
-  const items: Array<{
-    kind: ConfirmKind;
-    title: string;
-    description: string;
-  }> = [
-    {
-      kind: 'forget',
-      title: 'Forget passkey history',
-      description:
-        "Glow returns to the new-user welcome screen on this device. Your passkey is untouched, so trying to create another will still be refused as a duplicate.",
-    },
-    {
-      kind: 'wipe',
-      title: 'Wipe all passkey state',
-      description: `Same as above, plus Glow forgets the passkey IDs it tracks on this device. After this, you can register a new passkey on this device. The old one stays in ${copy.passkeyHome} until you delete it from ${copy.systemDelete}.`,
-    },
+  const items: Array<{ kind: ConfirmKind; title: string }> = [
+    { kind: 'forget', title: 'Forget history' },
+    { kind: 'wipe', title: 'Wipe all state' },
   ];
 
   return (
@@ -117,18 +120,13 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack })
             key={item.kind}
             type="button"
             onClick={() => setConfirm(item.kind)}
-            className="w-full flex items-start gap-3 p-4 bg-spark-dark border border-spark-border rounded-2xl text-left hover:border-spark-border-light hover:bg-white/5 transition-colors"
+            className="w-full flex items-center gap-3 p-4 bg-spark-dark border border-spark-border rounded-2xl text-left hover:border-spark-border-light hover:bg-white/5 transition-colors"
           >
             <div className="w-10 h-10 rounded-xl bg-spark-error/10 flex items-center justify-center shrink-0">
               <TrashIcon size="sm" className="text-spark-error" />
             </div>
-            <div className="flex-1 min-w-0">
-              <div className="font-display font-semibold text-spark-text-primary">
-                {item.title}
-              </div>
-              <p className="text-sm text-spark-text-muted mt-0.5">
-                {item.description}
-              </p>
+            <div className="font-display font-semibold text-spark-text-primary">
+              {item.title}
             </div>
           </button>
         ))}
@@ -136,8 +134,8 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack })
 
       <ConfirmDialog
         isOpen={confirm === 'forget'}
-        title="Forget passkey history?"
-        message="On next launch, Glow will show the new-user welcome screen instead of jumping straight to passkey sign-in. Your passkey itself is not affected."
+        title="Forget history?"
+        message="Glow returns to the new-user welcome screen on next launch. Your passkey is untouched — trying to create a new one will still be refused as a duplicate by the OS."
         confirmLabel="Forget"
         cancelLabel="Cancel"
         variant="warning"
@@ -147,8 +145,8 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack })
 
       <ConfirmDialog
         isOpen={confirm === 'wipe'}
-        title="Wipe all passkey state?"
-        message={`Glow forgets the welcome-screen marker and the passkey IDs it tracks on this device. Your passkey stays in ${copy.passkeyHome} until you delete it from ${copy.systemDelete}.`}
+        title="Wipe all state?"
+        message={`Glow forgets the welcome-screen marker and the passkey IDs it tracks on this device, so you can register a new passkey afterward. Your existing passkey stays in ${copy.passkeyHome} until you delete it from ${copy.systemDelete}.`}
         confirmLabel={isWorking ? 'Working…' : 'Wipe'}
         cancelLabel="Cancel"
         variant="danger"

--- a/src/pages/PasskeyManagementPage.tsx
+++ b/src/pages/PasskeyManagementPage.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { Capacitor } from '@capacitor/core';
 import SlideInPage from '../components/layout/SlideInPage';
 import { PasskeyIcon } from '../components/Icons';
 import {
   getAllCredentialAaguids,
+  getLatestBackupEligible,
   getPasskeyMeta,
   hasPasskeyHistory,
 } from '../services/passkeyService';
@@ -28,16 +28,6 @@ function formatTimestamp(ts: number | undefined): string {
   }
 }
 
-// Native plugins don't surface AAGUID yet, so iOS / Android fall back
-// to the platform-default credential store name.
-function getNativeStorageLabel(): string | null {
-  switch (Capacitor.getPlatform()) {
-    case 'ios': return 'iCloud Keychain';
-    case 'android': return 'Google Password Manager';
-    default: return null;
-  }
-}
-
 // Pick the most recent AAGUID Glow has recorded. Unambiguous in the
 // one-passkey-per-device case we ship.
 function resolveProvider(): AaguidProvider | null {
@@ -53,12 +43,10 @@ const PasskeyManagementPage: React.FC<PasskeyManagementPageProps> = ({ onBack })
   const [registered] = useState<boolean>(() => hasPasskeyHistory());
   const [meta] = useState(() => getPasskeyMeta());
   const [provider] = useState<AaguidProvider | null>(() => resolveProvider());
-  const nativeFallback = getNativeStorageLabel();
-  // Title priority: AAGUID provider name > native default > "Passkey".
-  const title = registered
-    ? (provider?.name ?? nativeFallback ?? 'Passkey')
-    : 'No passkey';
+  const [backupEligible] = useState<boolean | undefined>(() => getLatestBackupEligible());
+  const title = registered ? (provider?.name ?? 'Passkey') : 'No passkey';
   const hasTimestamps = registered && (meta.firstSeenAt || meta.lastSeenAt);
+  const showSync = registered && backupEligible !== undefined;
 
   return (
     <SlideInPage title="Passkey" closeStyle="back" onClose={onBack} slideFrom="right">
@@ -83,8 +71,14 @@ const PasskeyManagementPage: React.FC<PasskeyManagementPageProps> = ({ onBack })
             </div>
           </div>
 
-          {hasTimestamps && (
+          {(hasTimestamps || showSync) && (
             <div className="mt-4 border-t border-spark-border pt-3 space-y-1.5">
+              {showSync && (
+                <div className="flex items-center justify-between gap-3 text-xs text-spark-text-muted">
+                  <span>Sync</span>
+                  <span>{backupEligible ? 'Across your devices' : 'This device only'}</span>
+                </div>
+              )}
               {meta.firstSeenAt && (
                 <div className="flex items-center justify-between gap-3 text-xs text-spark-text-muted">
                   <span>First sign-in</span>

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { Capacitor } from '@capacitor/core';
 import { Seed, Wallet } from '@breeztech/breez-sdk-spark';
 import { PrimaryButton, SecondaryButton } from '../components/ui';
 import LoadingSpinner from '../components/LoadingSpinner';
@@ -6,11 +7,11 @@ import PageLayout from '../components/layout/PageLayout';
 import { AlertCard } from '../components/AlertCard';
 import { NostrKeyIcon, CheckIcon, PasskeyIcon } from '../components/Icons';
 import {
-  clearPasskeyHistory,
   createPasskey,
   getWallet,
   setupWallet,
   hasPasskeyHistory,
+  clearPasskeyHistory,
   listLabels,
   saveLabel,
   setPasskeyMode,
@@ -19,6 +20,7 @@ import {
   passkeyPrfProvider,
   PasskeyAlreadyExistsError,
 } from '@/services/passkeyPrfProvider';
+import { isNativePlatform } from '@/services/nativePasskeyPrfProvider';
 import type { DomainAssociation } from '@/services/passkeyPrfProvider';
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs } from '@/services/logExport';
@@ -116,6 +118,18 @@ interface PasskeyPageProps {
   consumeFreshInstallSignal?: () => boolean;
 }
 
+// WebAuthn ceremonies have an OS-level inactivity timer (60s on iOS,
+// similar on Android Credential Manager) that surfaces as the same
+// NotAllowedError / USER_CANCELLED-shaped error a user dismiss does.
+// We can't read the underlying reason, but elapsed time is reliable
+// enough to discriminate: a real human dismiss takes < ~30s in practice;
+// anything above the timeout floor is overwhelmingly the OS giving up.
+const LIKELY_TIMEOUT_MS = 45_000;
+
+function isLikelyTimeout(elapsedMs: number): boolean {
+  return elapsedMs >= LIKELY_TIMEOUT_MS;
+}
+
 // ============================================
 // Component
 // ============================================
@@ -145,10 +159,18 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
   // passkey" when the create flow refused because a passkey already
   // exists, instead of just generic Retry).
   const [errorKind, setErrorKind] = useState<
-    null | 'generic' | 'already-exists' | 'sign-in-failed'
+    null | 'generic' | 'already-exists' | 'sign-in-failed' | 'sign-in-cancelled'
   >(null);
   const [manualLabel, setManualLabel] = useState('');
   const [showManualInput, setShowManualInput] = useState(false);
+  // Mirrors HomePage's two-CTA gate. When the user reached this page from
+  // a two-CTA HomePage (i.e., they explicitly chose "Use Existing Passkey"
+  // over "Create Passkey"), inline-Create on a sign-in failure contradicts
+  // their explicit intent. Send them back to home instead, where they can
+  // pick Create on its own. The provider caches the capability after
+  // HomePage's mount-time probe, so this resolves synchronously in
+  // practice.
+  const [immediateGetSupported, setImmediateGetSupported] = useState<boolean | null>(null);
   // True once the WebAuthn assertion completes; drives the spinner
   // label switch from "Detecting passkey..." to "Discovering labels...".
   const [isDiscoveringLabels, setIsDiscoveringLabels] = useState(false);
@@ -214,6 +236,14 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       onFlowCompleteRef.current?.();
     }
   }, [sdkConnected, phase, onFlowCompleteRef]);
+
+  useEffect(() => {
+    let cancelled = false;
+    passkeyPrfProvider.supportsImmediateGet().then((supported) => {
+      if (!cancelled) setImmediateGetSupported(supported);
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // On mount (and on Retry after aasa-error): verify the app's bundle ID
   // is listed by the platform's out-of-band domain verification source
@@ -291,6 +321,17 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       if (!cancelled) setIsDiscoveringLabels(true);
     };
 
+    // Wall-clock the assertion so a cancel-shaped error can be
+    // disambiguated against the no-creds case on platforms that
+    // collapse both into the same code. iOS's
+    // preferImmediatelyAvailableCredentials and web's
+    // mediation: 'immediate' both return synchronously when no
+    // credential is available (no UI rendered) but report the
+    // failure indistinguishably from a user dismissing a sheet.
+    // A sub-threshold elapsed time means no UI rendered, so we
+    // route silently to create. Android stays deterministic via
+    // `NoCredentialException` and never reaches this branch.
+    const detectStartMs = Date.now();
     const run = async () => {
       try {
         // Dual-salt assert 'Default' BEFORE listLabels so a user whose
@@ -331,11 +372,25 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
         }
       } catch (e) {
         if (cancelled) return;
-        const errorName = e instanceof Error ? e.name : '';
-        const errorMessage = e instanceof Error ? e.message : '';
-        const errorCode = (e as { code?: string })?.code;
+        // Rust's setupWallet wraps the underlying PrfProvider error in
+        // a generic `Error("PRF error: Passkey error: …")`, dropping the
+        // platform code and name. The provider stashes the raw
+        // pre-wrap shape on `lastDeriveError` so we can recover the
+        // original `USER_CANCELLED` / `CREDENTIAL_NOT_FOUND` here.
+        const raw = passkeyPrfProvider.lastDeriveError;
+        const errorName = raw?.name ?? (e instanceof Error ? e.name : '');
+        const errorMessage = raw?.message ?? (e instanceof Error ? e.message : '');
+        const errorCode = raw?.code ?? (e as { code?: string })?.code;
+        // Cancellation can surface as:
+        //   - native: error.code === 'USER_CANCELLED' (Capacitor bridge)
+        //   - browser (raw): error.name === 'NotAllowedError' / 'AbortError'
+        //   - browser (SDK-wrapped): the SDK's _mapError replaces a cancel
+        //     NotAllowedError with `new Error('User cancelled authentication')`,
+        //     dropping the name. Match the message pattern as a fallback.
+        const messageLooksCancelled = /cancel{1,2}ed|cancellation/i.test(errorMessage);
         const isCancelled = errorName === 'NotAllowedError' || errorName === 'AbortError'
-          || errorCode === 'USER_CANCELLED';
+          || errorCode === 'USER_CANCELLED'
+          || messageLooksCancelled;
         // Definitive "no credential on this device" signal. On native this
         // comes from the SDK provider with autoRegister=false (we set
         // mode='sign-in' above). It distinguishes a deleted-from-Settings
@@ -356,14 +411,55 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
           errorMessage.includes('empty allowCredentials');
         const isCredentialNotFound = errorCode === 'CREDENTIAL_NOT_FOUND'
           || looksLikeNoCredentialMessage;
+        const elapsedMs = Date.now() - detectStartMs;
+        const FAST_FAIL_MAX_MS = 300;
+        // Fast fail with no UI rendered → OS deterministically has no
+        // matching cred. The shape differs per platform, so dispatch
+        // explicitly:
+        //
+        //   Android: NoCredentialException → typed CREDENTIAL_NOT_FOUND.
+        //     Reliable on its own; the time check just confirms it
+        //     fired pre-UI rather than after a slow internal path.
+        //
+        //   iOS: preferImmediatelyAvailableCredentials silent fail
+        //     conflates "no cred" and "user cancel" into the same
+        //     USER_CANCELLED-shaped error. Only the elapsed time
+        //     distinguishes deletion from a real user dismiss.
+        //
+        //   Web: WebAuthn collapses every failure mode into NotAllowedError
+        //     and there's no fast silent path. Skip — the slow-path
+        //     branches below handle web's hybrid sheet.
+        const platform = isNativePlatform() ? Capacitor.getPlatform() : 'web';
+        let isFastFailNoCred = false;
+        if (elapsedMs < FAST_FAIL_MAX_MS) {
+          if (platform === 'android') isFastFailNoCred = isCredentialNotFound;
+          else if (platform === 'ios') isFastFailNoCred = isCancelled;
+        }
         if (hasPasskeyHistory()) {
-          if (isCredentialNotFound) {
-            // The OS no longer has this user's passkey, but our local
-            // hasPasskeyHistory flag says we registered one before.
-            // Most likely cause: user deleted the passkey via
-            // Settings → Passwords. Stale local state. Reset and route
-            // them to the new-user create flow with an explanation.
-            logger.warn(LogCategory.AUTH, 'Sign-in returned CredentialNotFound for returning user, clearing stale state');
+          if (isFastFailNoCred) {
+            if (detectingFailCountRef.current === 0 && isFreshInstallRef.current) {
+              // Fresh-install sync gap: retry budget covers iCloud
+              // Keychain stage-2 / Block Store sync before we assume
+              // deletion. 3s pause before re-firing detecting.
+              detectingFailCountRef.current = 1;
+              logger.info(LogCategory.AUTH, 'Fast no-cred on fresh install, silent retry', {
+                errorCode,
+                isCredentialNotFound,
+                isCancelled,
+                elapsedMs,
+              });
+              setTimeout(() => {
+                if (cancelled) return;
+                setPhase('aasa-checking');
+              }, 3000);
+              return;
+            }
+            logger.warn(LogCategory.AUTH, 'Fast no-cred on returning user, treating as Settings deletion', {
+              errorCode,
+              isCredentialNotFound,
+              isCancelled,
+              elapsedMs,
+            });
             await clearPasskeyHistory();
             if (cancelled) return;
             setError(
@@ -371,6 +467,17 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             );
             setErrorKind('sign-in-failed');
             setPhase('review');
+            return;
+          }
+          if (isCredentialNotFound) {
+            // Slow CREDENTIAL_NOT_FOUND = user saw a UI and dismissed.
+            // Cred is still on the device; auto-clearing would lure a
+            // duplicate. Surface retryable error.
+            logger.warn(LogCategory.AUTH, 'Slow CREDENTIAL_NOT_FOUND on returning user (likely user dismissal), surfacing retryable error');
+            setError(
+              'Could not find your Glow passkey on this device. Try again, or check Settings → Passwords.',
+            );
+            setErrorKind('sign-in-failed');
             return;
           }
           // First failure for a returning user, AND the page was
@@ -409,18 +516,102 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             errorName,
             errorCode,
             error: underlying,
+            elapsedMs,
           });
           setError(
             isCancelled
-              ? 'Sign-in cancelled. Please try again.'
+              ? (isLikelyTimeout(elapsedMs)
+                ? 'Sign-in timed out. The system stopped waiting for biometrics. Please try again.'
+                : 'Sign-in cancelled. Please try again.')
               : `Could not sign in with your passkey. ${underlying ? `[${underlying}]` : ''} Please try again.`,
           );
           setErrorKind('sign-in-failed');
           return;
         }
-        logger.info(LogCategory.AUTH, 'No existing passkey, starting new user flow');
-        setIsNewUser(true);
-        setPhase('creating');
+        // Routing precedence:
+        //   1. CREDENTIAL_NOT_FOUND (Android NoCredentialException, or
+        //      iOS .notHandled / "no credential" message) → deterministic
+        //      no-creds → silent fall-through to create.
+        //   2. USER_CANCELLED with a fast elapsed time → iOS conflates
+        //      no-creds and user-dismiss into the same code, so a sub-
+        //      threshold elapsed reliably means no UI was rendered.
+        //      Treat as no-creds. Threshold is conservative: iOS fast-
+        //      fail returns in < 100ms, real user dismiss takes seconds.
+        //   3. USER_CANCELLED with a slow elapsed time → user actually
+        //      dismissed a passkey sheet, so they have creds. Surface
+        //      a cancel-specific error that does NOT offer Create
+        //      (would lure them into duplicating a passkey they already
+        //      have).
+        //   4. Anything else (unknown failure) → generic error with
+        //      both retry and explicit-create as escape hatches.
+        if (isCredentialNotFound) {
+          logger.info(LogCategory.AUTH, 'No existing passkey (deterministic), starting new user flow', { errorCode });
+          setIsNewUser(true);
+          setPhase('creating');
+          return;
+        }
+        if (isCancelled && elapsedMs < FAST_FAIL_MAX_MS) {
+          logger.info(LogCategory.AUTH, 'Fast cancel implies no creds, starting new user flow', {
+            errorName,
+            errorCode,
+            elapsedMs,
+          });
+          setIsNewUser(true);
+          setPhase('creating');
+          return;
+        }
+        if (isCancelled) {
+          // Native (iOS/Android) reaches here only after a slow
+          // dismiss — the fast-fail no-creds case was already routed
+          // silently to create above. So a slow cancel on native
+          // means the user definitively has a passkey and dismissed
+          // the picker; offering Create would lure a duplicate.
+          //
+          // Web can't make that distinction: the browser renders the
+          // hybrid (QR/cross-device) sheet for both no-creds and
+          // has-creds, both elapse past the threshold, and both
+          // surface as the same NotAllowedError. Show the generic
+          // failure with both Try Again and Create as escape hatches
+          // so genuine new users aren't stuck.
+          if (isNativePlatform()) {
+            logger.info(LogCategory.AUTH, 'User dismissed passkey sheet (native); refusing to offer Create', {
+              errorCode,
+              elapsedMs,
+            });
+            setError(
+              isLikelyTimeout(elapsedMs)
+                ? 'Sign-in timed out. The system stopped waiting for biometrics. Please try again.'
+                : 'Sign-in cancelled. Please pick your passkey to continue.',
+            );
+            setErrorKind('sign-in-cancelled');
+          } else {
+            logger.info(LogCategory.AUTH, 'Web cancel-shaped failure; surfacing error with retry + escape', {
+              errorCode,
+              elapsedMs,
+            });
+            setError(
+              isLikelyTimeout(elapsedMs)
+                ? 'Sign-in timed out. Please try again.'
+                : 'Could not sign in. Please try again.',
+            );
+            // Leave errorKind unset so the generic detecting branch
+            // renders the right escape (Create vs. Go Back) based on
+            // the two-CTA gate. The 'sign-in-failed' kind is reserved
+            // for returning users where offering Create would lure a
+            // duplicate.
+            setErrorKind(null);
+          }
+          return;
+        }
+        logger.info(LogCategory.AUTH, 'Sign-in failed; surfacing retryable error', {
+          errorName,
+          errorCode,
+          elapsedMs,
+        });
+        setError('Could not sign in with your passkey. Please try again.');
+        // Same reasoning as the web cancel branch above: defer the
+        // escape-hatch choice to the render branch.
+        setErrorKind(null);
       }
     };
 
@@ -547,6 +738,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     let cancelled = false;
 
     const run = async () => {
+      const connectStartMs = Date.now();
       try {
         const action = connectActionRef.current;
         const label = connectLabelRef.current;
@@ -585,11 +777,31 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       } catch (e) {
         if (cancelled) return;
         const underlying = e instanceof Error ? e.message : String(e);
-        console.error('[Glow] Connect failed', { error: underlying, raw: e });
-        setError(`Failed to connect. ${underlying ? `[${underlying}]` : ''}`);
+        const elapsedMs = Date.now() - connectStartMs;
+        // The PRF derive inside setupWallet / getWallet hits the same
+        // OS timer as the detecting-phase ceremony (60s on iOS, similar
+        // on Android Credential Manager). Recover the raw error code
+        // through lastDeriveError since Rust's setupWallet wraps it.
+        const raw = passkeyPrfProvider.lastDeriveError;
+        const errorCode = raw?.code ?? (e as { code?: string })?.code;
+        const messageLooksCancelled = /cancel{1,2}ed|cancellation/i.test(raw?.message ?? underlying);
+        const isCancelled = errorCode === 'USER_CANCELLED'
+          || raw?.name === 'NotAllowedError'
+          || raw?.name === 'AbortError'
+          || messageLooksCancelled;
+        console.error('[Glow] Connect failed', { error: underlying, errorCode, elapsedMs, raw: e });
+        if (isCancelled && isLikelyTimeout(elapsedMs)) {
+          setError('Sign-in timed out. The system stopped waiting for biometrics. Please try again.');
+        } else if (isCancelled) {
+          setError('Sign-in cancelled. Please try again.');
+        } else {
+          setError(`Failed to connect. ${underlying ? `[${underlying}]` : ''}`);
+        }
         setErrorKind('generic');
         logger.error(LogCategory.AUTH, 'Passkey wallet restore failed', {
           error: underlying,
+          errorCode,
+          elapsedMs,
         });
       }
     };
@@ -903,22 +1115,16 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       );
     }
 
-    // Detecting failure for a returning user: iOS may surface this as
-    // either a CredentialNotFound error (which we auto-recover from) or
-    // a USER_CANCELLED (which we can't distinguish from a "no passkey"
-    // dismissal of the system sheet). For the latter case, we leave the
-    // user on the error screen and offer two paths:
-    //   1. Try Again — re-runs detecting (auto-recovers if iOS now
-    //      reports CredentialNotFound clearly).
-    //   2. Forget passkey & create new — explicit recovery: clears the
-    //      keychain + localStorage flag and routes to the create flow.
-    //      For users whose passkey really is gone (deleted via
-    //      Settings) but iOS reports the dismissal as a cancel.
-    if (error && phase === 'detecting' && hasPasskeyHistory()) {
+    // Detecting failure where the user explicitly dismissed a sheet
+    // (cancel-shaped error with elapsed time past the no-creds
+    // fast-fail threshold). They have a passkey; offering Create
+    // here would lure a duplicate, so only retry is shown.
+    if (error && phase === 'detecting' && errorKind === 'sign-in-cancelled') {
       return (
         <div className="max-w-xl mx-auto space-y-3">
           <PrimaryButton className="w-full" onClick={() => {
             setError(null);
+            setErrorKind(null);
             // Bounce through aasa-checking to force the detecting effect
             // to re-run. Just clearing `error` while staying on detecting
             // doesn't re-trigger the effect (its deps are [phase] only),
@@ -927,13 +1133,58 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
           }}>
             Try Again
           </PrimaryButton>
-          <SecondaryButton className="w-full" onClick={() => {
+        </div>
+      );
+    }
+
+    // Returning-user sign-in failures (cancelled, transient
+    // CREDENTIAL_NOT_FOUND, relay error). Never offer Create — the
+    // user has hasPasskeyHistory, exclude registry is intact, but
+    // wiring Create here would lure a duplicate when sign-in is
+    // genuinely retryable.
+    if (error && phase === 'detecting' && errorKind === 'sign-in-failed') {
+      return (
+        <div className="max-w-xl mx-auto space-y-3">
+          <PrimaryButton className="w-full" onClick={() => {
             setError(null);
-            setIsNewUser(true);
-            setPhase('creating');
+            setErrorKind(null);
+            setPhase('aasa-checking');
           }}>
-            Create Passkey
-          </SecondaryButton>
+            Try Again
+          </PrimaryButton>
+        </div>
+      );
+    }
+
+    // Detecting failure for other reasons (unknown errors).
+    //
+    // Two-CTA web (immediateGet not supported) reaches this branch
+    // after the user explicitly chose "Use Existing Passkey" on
+    // HomePage. Inline-Create here would contradict that choice and
+    // lure a duplicate, so just offer Try Again — the system back
+    // button is the route to home if they want Create instead.
+    // Single-CTA paths (native, web with immediateGet) keep the
+    // inline Create — the user took an ambiguous "Get Started"
+    // entry, so Create is a legitimate continuation.
+    if (error && phase === 'detecting') {
+      const retryOnly = !isNativePlatform() && immediateGetSupported !== true;
+      return (
+        <div className="max-w-xl mx-auto space-y-3">
+          <PrimaryButton className="w-full" onClick={() => {
+            setError(null);
+            setPhase('aasa-checking');
+          }}>
+            Try Again
+          </PrimaryButton>
+          {!retryOnly && (
+            <SecondaryButton className="w-full" onClick={() => {
+              setError(null);
+              setIsNewUser(true);
+              setPhase('creating');
+            }}>
+              Create Passkey
+            </SecondaryButton>
+          )}
         </div>
       );
     }
@@ -1069,15 +1320,17 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
               title={
                 errorKind === 'already-exists'
                   ? 'Passkey already exists'
-                  : errorKind === 'sign-in-failed'
-                    ? 'Sign-in failed'
-                    : phase === 'new-storing'
-                      ? "Couldn't save label"
-                      : phase === 'connecting'
-                        ? "Couldn't connect"
-                        : phase === 'creating'
-                          ? "Couldn't create passkey"
-                          : 'Something went wrong'
+                  : errorKind === 'sign-in-cancelled'
+                    ? 'Sign-in cancelled'
+                    : errorKind === 'sign-in-failed'
+                      ? 'Sign-in failed'
+                      : phase === 'new-storing'
+                        ? "Couldn't save label"
+                        : phase === 'connecting'
+                          ? "Couldn't connect"
+                          : phase === 'creating'
+                            ? "Couldn't create passkey"
+                            : 'Something went wrong'
               }
             >
               <p className="text-spark-text-secondary text-sm wrap-break-word">

--- a/src/services/nativePasskeyPrfProvider.ts
+++ b/src/services/nativePasskeyPrfProvider.ts
@@ -33,16 +33,22 @@ declare global {
             userName?: string;
             userDisplayName?: string;
             excludeCredentialIds?: string[];
-          }): Promise<{ credentialId: string }>;
+          }): Promise<{
+            credentialId: string;
+            aaguid?: string | null;
+            backupEligible?: boolean | null;
+          }>;
           derivePrfSeed(options: {
             rpId?: string;
             salt: string;
             autoRegister?: boolean;
+            allowCredentialIds?: string[];
           }): Promise<{ seed: string }>;
           derivePrfSeeds(options: {
             rpId?: string;
             salts: string[];
             autoRegister?: boolean;
+            allowCredentialIds?: string[];
           }): Promise<{ seeds: string[] }>;
           checkDomainAssociation(options?: {
             rpId?: string;
@@ -115,15 +121,42 @@ export class NativePasskeyPrfProvider {
    *         typed JS error.
    */
   async createPasskey(
-    options: { excludeCredentialIds?: string[] } = {},
-  ): Promise<string> {
+    options: {
+      excludeCredentialIds?: string[];
+      /**
+       * Per-call override for `user.name` on the WebAuthn registration
+       * request. The native plugin forwards this verbatim to the SDK's
+       * iOS/Android `PasskeyProvider.userName`, which becomes the `name`
+       * field on `ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest`
+       * on iOS (also drives Apple Passwords' picker label) and the
+       * `name` field on Android `CreatePublicKeyCredentialRequest`'s
+       * `user` JSON. Keeps glow-app's per-create label format
+       * (`Glow · #<hash>`) consistent with the web path.
+       */
+      userName?: string;
+      /**
+       * Per-call override for `user.displayName`. iOS doesn't expose a
+       * displayName parameter on its registration API (only `name`),
+       * so on iOS this is effectively unused at the credential-storage
+       * layer; Android's CredentialManager does honor it. Set to the
+       * same value as `userName` for cross-platform consistency.
+       */
+      userDisplayName?: string;
+    } = {},
+  ): Promise<{ credentialId: string; aaguid: string | null; backupEligible: boolean | null }> {
     try {
-      const { credentialId } = await getPlugin().createPasskey({
+      const { credentialId, aaguid, backupEligible } = await getPlugin().createPasskey({
         rpId: this.rpId,
         rpName: this.rpName,
         excludeCredentialIds: options.excludeCredentialIds ?? [],
+        userName: options.userName,
+        userDisplayName: options.userDisplayName,
       });
-      return credentialId;
+      return {
+        credentialId,
+        aaguid: aaguid ?? null,
+        backupEligible: backupEligible ?? null,
+      };
     } catch (e) {
       // The SDK surfaces the platform's duplicate-prevention refusal
       // (ASAuthorizationError.matchedExcludedCredential on iOS) as
@@ -162,12 +195,13 @@ export class NativePasskeyPrfProvider {
 
   async derivePrfSeed(
     salt: string,
-    options: { autoRegister?: boolean } = {},
+    options: { autoRegister?: boolean; allowCredentialIds?: string[] } = {},
   ): Promise<Uint8Array> {
     const { seed } = await getPlugin().derivePrfSeed({
       rpId: this.rpId,
       salt,
       autoRegister: options.autoRegister,
+      allowCredentialIds: options.allowCredentialIds,
     });
     return base64ToBytes(seed);
   }
@@ -175,12 +209,13 @@ export class NativePasskeyPrfProvider {
   /** Bulk PRF derivation; native plugin uses dual-salt where supported. */
   async derivePrfSeeds(
     salts: string[],
-    options: { autoRegister?: boolean } = {},
+    options: { autoRegister?: boolean; allowCredentialIds?: string[] } = {},
   ): Promise<Uint8Array[]> {
     const { seeds } = await getPlugin().derivePrfSeeds({
       rpId: this.rpId,
       salts,
       autoRegister: options.autoRegister,
+      allowCredentialIds: options.allowCredentialIds,
     });
     return seeds.map(base64ToBytes);
   }

--- a/src/services/passkeyPrfProvider.ts
+++ b/src/services/passkeyPrfProvider.ts
@@ -17,6 +17,7 @@ import type { PrfProvider } from '@breeztech/breez-sdk-spark';
 import {
   PasskeyAlreadyExistsError,
   PasskeyProvider as SdkBrowserPasskeyProvider,
+  type CreatePasskeyRequest,
 } from '@breeztech/breez-sdk-spark/passkey-prf-provider';
 import {
   NativePasskeyPrfProvider,
@@ -33,19 +34,22 @@ export type { DomainAssociation } from './nativePasskeyPrfProvider';
 // because there is exactly one declaration shipped by the SDK.
 export { PasskeyAlreadyExistsError };
 
-// ============================================
-// Browser credential-IDs registry (localStorage)
-// ============================================
-
-// Web has no equivalent of iOS's iCloud-synced keychain or Android's
-// Block Store, so localStorage is the best-effort persistence: wiped on
-// app reset / cache clear, but survives reloads. Shared key with
-// passkeyService so the read side here always sees newly-registered
-// IDs without needing a runtime hook into passkeyService.
-//
-// Native is unaffected: the plugin reads from synced platform storage
-// inside KnownCredentialsStore, so this fallback is unused there.
+// localStorage shadow of credential IDs we've seen (browser-only;
+// native uses the iCloud-synced KnownCredentialsStore).
 const PASSKEY_KNOWN_CREDENTIALS_KEY = 'passkeyKnownCredentials';
+
+// Marker set: credentials we've already given a custom user.name to
+// (either at create or via signalRename). Gates re-rename since
+// WebAuthn doesn't expose the stored user.name on assertion.
+const PASSKEY_CUSTOM_NAMED_KEY = 'passkeyCustomNamedCredentials';
+
+// The credentialId of the most recent successful sign-in. Used to
+// constrain follow-up sign-in derives (listLabels, saveLabel, label
+// switch) to that exact cred so the picker auto-picks on native and
+// shows a single-row list on web — eliminates ambiguity about which
+// passkey is "current". Cleared on logout / history clear; preserved
+// across label switches (labels share a credential).
+const PASSKEY_ACTIVE_CRED_KEY = 'passkeyActiveCredentialId';
 
 function getKnownLocal(): string[] {
   try {
@@ -69,14 +73,43 @@ function addKnownLocal(credentialIdBase64: string): void {
   );
 }
 
-// ============================================
-// Base64 ↔ Uint8Array helpers
-// ============================================
+function getCustomNamedLocal(): string[] {
+  try {
+    const raw = localStorage.getItem(PASSKEY_CUSTOM_NAMED_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((x): x is string => typeof x === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
 
-// The SDK's browser PasskeyProvider exchanges credential IDs as
-// Uint8Array. The host-side registry persists strings (for stable
-// localStorage shape and parity with iOS/Android base64 keychain
-// values), so every boundary needs an encode/decode hop.
+function addCustomNamedLocal(credentialIdBase64: string): void {
+  const existing = getCustomNamedLocal();
+  if (existing.includes(credentialIdBase64)) return;
+  try {
+    localStorage.setItem(
+      PASSKEY_CUSTOM_NAMED_KEY,
+      JSON.stringify([...existing, credentialIdBase64]),
+    );
+  } catch {
+    // Best-effort; signalRename is idempotent across the timestamp shape.
+  }
+}
+
+function getActiveCredId(): string | null {
+  return localStorage.getItem(PASSKEY_ACTIVE_CRED_KEY);
+}
+
+function setActiveCredId(credentialIdBase64: string): void {
+  try {
+    localStorage.setItem(PASSKEY_ACTIVE_CRED_KEY, credentialIdBase64);
+  } catch {
+    // Best-effort; the cache + warm Nostr OnceCell still cover most flows.
+  }
+}
 
 function base64ToBytes(b64: string): Uint8Array {
   const binary = atob(b64);
@@ -89,6 +122,98 @@ function bytesToBase64(bytes: Uint8Array): string {
   let binary = '';
   for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
   return btoa(binary);
+}
+
+// Chrome's signalCurrentUserDetails takes userId as base64url string,
+// not BufferSource as the spec declares.
+function bytesToBase64Url(bytes: Uint8Array): string {
+  return bytesToBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function captureRawError(e: unknown): RawDeriveError {
+  return {
+    code: (e as { code?: string })?.code,
+    name: e instanceof Error ? e.name : undefined,
+    message: e instanceof Error ? e.message : String(e),
+  };
+}
+
+// Mobile browsers' get() picker prominently surfaces cross-device QR
+// for empty allowCredentials, while desktop's doesn't — gates the
+// two-CTA HomePage fallback. Prefers UA Client Hints; falls back to
+// UA string with the iPad-on-iOS-13+ Mac-UA disambiguation.
+export function isMobileBrowser(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const uaData = (navigator as { userAgentData?: { mobile?: boolean } }).userAgentData;
+  if (uaData && typeof uaData.mobile === 'boolean') return uaData.mobile;
+  const ua = navigator.userAgent || '';
+  if (/Macintosh/i.test(ua) && (navigator.maxTouchPoints || 0) > 1) return true;
+  return /Android|iPhone|iPad|iPod|Mobi/i.test(ua);
+}
+
+/** UTC ISO-8601 to second precision, e.g. `2026-05-06T21:14:56`. */
+function createTimestampLabel(): string {
+  return new Date().toISOString().slice(0, 19);
+}
+
+/**
+ * Best-effort retroactive rename via WebAuthn L3
+ * `PublicKeyCredential.signalCurrentUserDetails`. Pushes a per-credential
+ * label (`Glow · <ISO timestamp>`) to the authenticator so legacy
+ * passkeys that all share `user.name = "Glow"` (and therefore collapse
+ * into a single row in Apple Passwords / similar pickers) become
+ * individually identifiable in the OS-level passkey settings and the
+ * next sign-in picker. The timestamp on a renamed legacy credential
+ * is the (first) sign-in time on this device, not the original create
+ * time — we don't have a way to recover the original create time
+ * post-hoc.
+ *
+ * No-op when:
+ * - The browser doesn't expose `signalCurrentUserDetails` (Safari < 18,
+ *   Firefox, Chrome < 132 without the flag).
+ * - The credential doesn't exist on this device for the given rpId
+ *   (signal API throws; we swallow).
+ * - userHandle is null (rare; the credential isn't discoverable).
+ *
+ * Idempotent — calling with the same name on the same credential is
+ * a no-op at the platform level. Safe to invoke on every sign-in.
+ */
+async function signalRename(
+  rpId: string,
+  userHandle: Uint8Array,
+  credentialId: Uint8Array,
+): Promise<void> {
+  const signal = (PublicKeyCredential as unknown as {
+    signalCurrentUserDetails?: (opts: {
+      rpId: string;
+      userId: string;
+      name: string;
+      displayName: string;
+    }) => Promise<void>;
+  }).signalCurrentUserDetails;
+
+  if (typeof signal !== 'function') return;
+
+  // Skip credentials we've already named (created or previously renamed)
+  // to avoid drifting their label on every sign-in.
+  const credIdB64 = bytesToBase64(credentialId);
+  if (getCustomNamedLocal().includes(credIdB64)) return;
+
+  try {
+    const label = `Glow · ${createTimestampLabel()}`;
+    await signal.call(PublicKeyCredential, {
+      rpId,
+      userId: bytesToBase64Url(userHandle),
+      name: label,
+      displayName: label,
+    });
+    addCustomNamedLocal(credIdB64);
+    logger.info(LogCategory.AUTH, 'Passkey rename signaled');
+  } catch (e) {
+    logger.warn(LogCategory.AUTH, 'signalCurrentUserDetails failed', {
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
 }
 
 // ============================================
@@ -104,15 +229,36 @@ logger.info(LogCategory.AUTH, 'Passkey PRF provider', {
   platform: native ? 'native' : 'browser',
 });
 
-// `autoRegister: false` matches the prior browser behavior: assertion
-// failures (no credential / cancelled) propagate without silently
-// auto-registering. Onboarding always uses `createPasskey()` explicitly,
-// then `derivePrfSeed()` for the first sign-in. Hosts that want the
-// auto-register-on-first-derive ergonomics can opt in by switching to
-// `autoRegister: true` here.
+// autoRegister false: explicit createPasskey + derivePrfSeed split.
+// authenticatorAttachment + hints scope the create-time chooser to
+// platform authenticators on browsers that honor them; native skips
+// both (preferImmediatelyAvailableCredentials covers it).
 const sdkProvider = native
   ? new NativePasskeyPrfProvider({ rpId, rpName: 'Glow' })
-  : new SdkBrowserPasskeyProvider({ rpId, rpName: 'Glow', autoRegister: false });
+  : new SdkBrowserPasskeyProvider({
+      rpId,
+      rpName: 'Glow',
+      autoRegister: false,
+      authenticatorAttachment: 'platform',
+      hints: ['client-device'],
+    });
+
+/**
+ * Snapshot of a derive call's underlying error, captured *before* it
+ * round-trips through Rust's `setupWallet` / `getWallet` (which rewraps
+ * everything as an opaque "PRF error: Passkey error: …" generic Error
+ * and strips the original variant). Hosts read this from their catch
+ * block to recover the original `USER_CANCELLED` / `CREDENTIAL_NOT_FOUND`
+ * signal.
+ */
+export interface RawDeriveError {
+  /** Plugin-level error code (`USER_CANCELLED`, `CREDENTIAL_NOT_FOUND`, …). */
+  code?: string;
+  /** Original `Error.name`. */
+  name?: string;
+  /** Original `Error.message`. */
+  message?: string;
+}
 
 /**
  * App-level wrapper around the platform-specific provider.
@@ -123,6 +269,23 @@ const sdkProvider = native
 class AppPasskeyPrfProvider implements PrfProvider {
   /** Optional callback fired after a PRF prompt succeeds in derivePrfSeed. */
   onAuthComplete?: () => void;
+
+  /**
+   * Cached `immediateGet` capability flag.
+   *  - `undefined`: not yet checked (lazy)
+   *  - `null`: capability lookup unsupported / failed
+   *  - `true`/`false`: browser explicitly advertised support
+   */
+  private _immediateGetSupported: boolean | null | undefined = undefined;
+
+  /**
+   * Raw error from the most recent derive call. Reset to null at the
+   * start of every `derivePrfSeed` / `derivePrfSeeds` invocation, set
+   * if the underlying platform call rejects. Read it after `setupWallet`
+   * / `getWallet` rejects to recover the original error code, since
+   * Rust's UniFFI binding loses variant info on the way back to JS.
+   */
+  lastDeriveError: RawDeriveError | null = null;
 
   /**
    * Mode for the next `derivePrfSeed` call (and any chained calls until
@@ -143,6 +306,33 @@ class AppPasskeyPrfProvider implements PrfProvider {
    */
   mode: 'sign-in' | 'create' = 'create';
 
+  // True when the discovery probe (sign-in attempt) silently no-UIs
+  // for users with no matching credentials — what HomePage uses to
+  // decide whether to fall back to two explicit CTAs. Native is
+  // always true (preferImmediatelyAvailableCredentials in the
+  // Capacitor passkey-prf plugin); web is true only when the browser
+  // advertises WebAuthn immediateGet support (Chrome flag-gated).
+  async supportsImmediateGet(): Promise<boolean> {
+    if (native) return true;
+    if (this._immediateGetSupported === true) return true;
+    if (this._immediateGetSupported === false) return false;
+    if (this._immediateGetSupported === null) return false;
+    try {
+      if (typeof PublicKeyCredential === 'undefined'
+          || typeof (PublicKeyCredential as { getClientCapabilities?: unknown }).getClientCapabilities !== 'function') {
+        this._immediateGetSupported = null;
+        return false;
+      }
+      const caps = await (PublicKeyCredential as unknown as {
+        getClientCapabilities: (kind: string) => Promise<{ immediateGet?: boolean }>;
+      }).getClientCapabilities('public-key');
+      this._immediateGetSupported = caps?.immediateGet === true;
+    } catch {
+      this._immediateGetSupported = null;
+    }
+    return this._immediateGetSupported === true;
+  }
+
   async isPrfAvailable(): Promise<boolean> {
     try {
       const available = await sdkProvider.isPrfAvailable();
@@ -158,13 +348,7 @@ class AppPasskeyPrfProvider implements PrfProvider {
     }
   }
 
-  /**
-   * Create a new passkey. Returns credential ID + AAGUID + BE flag.
-   * AAGUID and backupEligible are null on the native path until the
-   * Capacitor plugin starts surfacing them.
-   *
-   * @throws PasskeyAlreadyExistsError when excludeCredentialIds blocks.
-   */
+  /** @throws PasskeyAlreadyExistsError when excludeCredentialIds blocks. */
   async createPasskey(
     options: { excludeCredentialIds?: string[] } = {},
   ): Promise<{ credentialId: string; aaguid: string | null; backupEligible: boolean | null }> {
@@ -172,20 +356,44 @@ class AppPasskeyPrfProvider implements PrfProvider {
       excludeCount: options.excludeCredentialIds?.length ?? 0,
     });
 
+    // Per-create label so password managers render distinct picker
+    // rows. Apple Passwords dedupes by (rpId, user.name), so the
+    // rpName-derived default would collapse every Glow passkey into
+    // one row.
+    const label = `Glow · ${createTimestampLabel()}`;
+
     let credentialId: string;
-    let aaguid: string | null = null;
-    let backupEligible: boolean | null = null;
+    let aaguid: string | null;
+    let backupEligible: boolean | null;
 
     if (native) {
-      credentialId = await (sdkProvider as NativePasskeyPrfProvider).createPasskey(options);
+      const result = await (sdkProvider as NativePasskeyPrfProvider).createPasskey({
+        excludeCredentialIds: options.excludeCredentialIds,
+        userName: label,
+        userDisplayName: label,
+      });
+      credentialId = result.credentialId;
+      aaguid = result.aaguid;
+      backupEligible = result.backupEligible;
     } else {
-      const excludeBytes = (options.excludeCredentialIds ?? []).map(base64ToBytes);
+      const request: CreatePasskeyRequest = {
+        excludeCredentialIds: (options.excludeCredentialIds ?? []).map(base64ToBytes),
+        userName: label,
+        userDisplayName: label,
+      };
       const browser = sdkProvider as SdkBrowserPasskeyProvider;
-      const result = await browser.createPasskey(excludeBytes);
+      const result = await browser.createPasskey(request);
       credentialId = bytesToBase64(result.credentialId);
       aaguid = result.aaguid ? bytesToBase64(result.aaguid) : null;
       backupEligible = result.backupEligible;
     }
+    // Mark so signalRename leaves this cred's label alone.
+    addCustomNamedLocal(credentialId);
+    // Pin the immediate next derive (setupWallet's bulk PRF) to this
+    // cred so the OS picker auto-resolves on Android instead of
+    // showing every cred for the RP. iOS' preferImmediatelyAvailableCredentials
+    // already auto-picks single-row matches; this makes Android match.
+    setActiveCredId(credentialId);
     logger.info(LogCategory.AUTH, 'Passkey created with PRF support', {
       hasAaguid: aaguid != null,
       backupEligible,
@@ -197,33 +405,46 @@ class AppPasskeyPrfProvider implements PrfProvider {
     const autoRegister = this.mode === 'create';
     logger.info(LogCategory.AUTH, 'Deriving PRF seed', { mode: this.mode });
 
+    this.lastDeriveError = null;
     let seed: Uint8Array;
-    if (native) {
-      seed = await (sdkProvider as NativePasskeyPrfProvider).derivePrfSeed(salt, { autoRegister });
-    } else {
-      // Sign-in constrains to tracked credentials (deterministic
-      // seed). Create-mode skips: some authenticators (Chrome
-      // Password Manager on Android 12 observed) don't surface a
-      // just-registered credential through allowCredentials
-      // filtering yet — trust discoverability instead.
-      const browser = sdkProvider as SdkBrowserPasskeyProvider;
-      browser.allowCredentialIds =
-        this.mode === 'create' ? [] : getKnownLocal().map(base64ToBytes);
-      browser.onAssertionCredentialId = (idBytes) => {
+    try {
+      if (native) {
+        const activeCredId = getActiveCredId();
+        seed = await (sdkProvider as NativePasskeyPrfProvider).derivePrfSeed(salt, {
+          autoRegister,
+          allowCredentialIds: activeCredId ? [activeCredId] : undefined,
+        });
+      } else {
+        // Constrain follow-up derives to the active cred so listLabels
+        // / saveLabel / label switches auto-pick on native and avoid
+        // ambiguity on web. Initial sign-in (no active cred yet) stays
+        // discoverable so the OS picker can surface synced creds.
+        const activeCredId = getActiveCredId();
+        const browser = sdkProvider as SdkBrowserPasskeyProvider;
+        browser.allowCredentialIds = activeCredId ? [base64ToBytes(activeCredId)] : [];
+        browser.onAssertionCredentialId = (idBytes, userHandle) => {
+          const credIdB64 = bytesToBase64(idBytes);
+          try {
+            addKnownLocal(credIdB64);
+            setActiveCredId(credIdB64);
+          } catch (e) {
+            logger.warn(LogCategory.AUTH, 'addKnownLocal failed', {
+              error: e instanceof Error ? e.message : String(e),
+            });
+          }
+          // Best-effort retroactive rename for legacy "Glow" creds.
+          // Fire-and-forget; must not block the assertion path.
+          if (userHandle) void signalRename(rpId, userHandle, idBytes);
+        };
         try {
-          addKnownLocal(bytesToBase64(idBytes));
-        } catch (e) {
-          logger.warn(LogCategory.AUTH, 'addKnownLocal failed', {
-            error: e instanceof Error ? e.message : String(e),
-          });
+          seed = await browser.derivePrfSeed(salt);
+        } finally {
+          browser.onAssertionCredentialId = undefined;
         }
-      };
-      try {
-        seed = await browser.derivePrfSeed(salt);
-      } finally {
-        browser.allowCredentialIds = [];
-        browser.onAssertionCredentialId = undefined;
       }
+    } catch (e) {
+      this.lastDeriveError = captureRawError(e);
+      throw e;
     }
 
     logger.info(LogCategory.AUTH, 'PRF seed derived successfully');
@@ -239,28 +460,43 @@ class AppPasskeyPrfProvider implements PrfProvider {
       count: salts.length,
     });
 
+    this.lastDeriveError = null;
     let seeds: Uint8Array[];
-    if (native) {
-      seeds = await (sdkProvider as NativePasskeyPrfProvider).derivePrfSeeds(salts, { autoRegister });
-    } else {
-      const browser = sdkProvider as SdkBrowserPasskeyProvider;
-      browser.allowCredentialIds =
-        this.mode === 'create' ? [] : getKnownLocal().map(base64ToBytes);
-      browser.onAssertionCredentialId = (idBytes) => {
+    try {
+      if (native) {
+        const activeCredId = getActiveCredId();
+        seeds = await (sdkProvider as NativePasskeyPrfProvider).derivePrfSeeds(salts, {
+          autoRegister,
+          allowCredentialIds: activeCredId ? [activeCredId] : undefined,
+        });
+      } else {
+        // See derivePrfSeed for the active-cred filter rationale.
+        const activeCredId = getActiveCredId();
+        const browser = sdkProvider as SdkBrowserPasskeyProvider;
+        browser.allowCredentialIds = activeCredId ? [base64ToBytes(activeCredId)] : [];
+        browser.onAssertionCredentialId = (idBytes, userHandle) => {
+          const credIdB64 = bytesToBase64(idBytes);
+          try {
+            addKnownLocal(credIdB64);
+            setActiveCredId(credIdB64);
+          } catch (e) {
+            logger.warn(LogCategory.AUTH, 'addKnownLocal failed', {
+              error: e instanceof Error ? e.message : String(e),
+            });
+          }
+          if (userHandle) {
+            void signalRename(rpId, userHandle, idBytes);
+          }
+        };
         try {
-          addKnownLocal(bytesToBase64(idBytes));
-        } catch (e) {
-          logger.warn(LogCategory.AUTH, 'addKnownLocal failed', {
-            error: e instanceof Error ? e.message : String(e),
-          });
+          seeds = await browser.derivePrfSeeds(salts);
+        } finally {
+          browser.onAssertionCredentialId = undefined;
         }
-      };
-      try {
-        seeds = await browser.derivePrfSeeds(salts);
-      } finally {
-        browser.allowCredentialIds = [];
-        browser.onAssertionCredentialId = undefined;
       }
+    } catch (e) {
+      this.lastDeriveError = captureRawError(e);
+      throw e;
     }
 
     logger.info(LogCategory.AUTH, 'Bulk PRF seeds derived successfully', {

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -1,10 +1,10 @@
 /**
  * Passkey service: thin wrapper over the SDK's Passkey class.
  *
- * The SDK instance is held in a module-level singleton so its
- * `nostr_keys` OnceCell survives across calls and follow-up Nostr
- * operations don't re-prompt. Invalidate via `invalidatePasskey()`
- * whenever the underlying credential or relay config changes.
+ * Caches a single SDK Passkey instance so its Nostr OnceCell survives
+ * across chained operations in one onboarding flow (1 biometric
+ * prompt instead of 3). Invalidate via `invalidatePasskey()` whenever
+ * the active label changes (logout, label switch, history clear).
  */
 
 import { Passkey, Wallet, NostrRelayConfig } from '@breeztech/breez-sdk-spark';
@@ -25,6 +25,11 @@ const KNOWN_CREDENTIALS_KEY = 'passkeyKnownCredentials';
 // provider name + icon on the passkey management page. Captured only
 // at create: WebAuthn doesn't expose AAGUID on assertion.
 const PASSKEY_AAGUID_PREFIX = 'passkeyAaguid:';
+// Per-credential backup-eligibility (BE) flag recorded at create time.
+// "1" / "0" string. Drives the cross-device sync indicator: true means
+// the credential can sync to the user's other devices via the provider;
+// false means it's bound to this device (typically a hardware key).
+const PASSKEY_BE_PREFIX = 'passkeyBackupEligible:';
 // Per-device timestamps. WebAuthn doesn't expose creation / last-use
 // dates, so we record them locally on each successful PRF ceremony.
 const PASSKEY_FIRST_SEEN_KEY = 'passkeyFirstSeenAt';
@@ -34,6 +39,13 @@ const PASSKEY_LAST_SEEN_KEY = 'passkeyLastSeenAt';
 // Labels page can surface a relative "last used" hint per row.
 const PASSKEY_LABEL_LAST_USED_PREFIX = 'passkeyLabelLastUsed:';
 
+// Cached Passkey instance keeps the SDK's Nostr OnceCell warm across
+// chained operations in a single onboarding flow (createPasskey →
+// setupWallet → saveLabel etc.) so each call doesn't re-derive Nostr
+// identity via a fresh PRF ceremony — turns 3 biometric prompts into 1.
+// Invalidate via `invalidatePasskey()` on every label change /
+// logout / passkey-history clear so a switched label can't reuse the
+// prior label's identity.
 let cachedPasskey: Passkey | null = null;
 
 function getPasskey(): Passkey {
@@ -46,7 +58,7 @@ function getPasskey(): Passkey {
   return cachedPasskey;
 }
 
-function invalidatePasskey(): void {
+export function invalidatePasskey(): void {
   cachedPasskey = null;
 }
 
@@ -70,11 +82,15 @@ export async function createPasskey(): Promise<void> {
   // merges them with its own keychain. Browser path uses these as the
   // sole source.
   const excludeCredentialIds = getKnownCredentialIdsLocal();
-  const { credentialId, aaguid } = await passkeyPrfProvider.createPasskey({ excludeCredentialIds });
+  const { credentialId, aaguid, backupEligible } =
+    await passkeyPrfProvider.createPasskey({ excludeCredentialIds });
   if (credentialId) {
     addKnownCredentialIdLocal(credentialId);
     if (aaguid) {
       localStorage.setItem(`${PASSKEY_AAGUID_PREFIX}${credentialId}`, aaguid);
+    }
+    if (backupEligible !== null) {
+      localStorage.setItem(`${PASSKEY_BE_PREFIX}${credentialId}`, backupEligible ? '1' : '0');
     }
   }
   localStorage.setItem(PASSKEY_REGISTERED_KEY, '1');
@@ -96,6 +112,23 @@ export function getAllCredentialAaguids(): string[] {
     }
   }
   return out;
+}
+
+/**
+ * Read the most-recently-recorded backup-eligibility flag across all
+ * credentials Glow knows about on this device. Returns undefined when
+ * no flag was captured (predates BE tracking, or platform path didn't
+ * surface it).
+ */
+export function getLatestBackupEligible(): boolean | undefined {
+  let latest: string | null = null;
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith(PASSKEY_BE_PREFIX)) {
+      latest = localStorage.getItem(key);
+    }
+  }
+  if (latest === null) return undefined;
+  return latest === '1';
 }
 
 /**
@@ -155,7 +188,7 @@ export function clearAllLabelLastUsed(): void {
 /** Drop every per-credential AAGUID entry. */
 export function clearAllCredentialAaguids(): void {
   for (const key of Object.keys(localStorage)) {
-    if (key.startsWith(PASSKEY_AAGUID_PREFIX)) {
+    if (key.startsWith(PASSKEY_AAGUID_PREFIX) || key.startsWith(PASSKEY_BE_PREFIX)) {
       localStorage.removeItem(key);
     }
   }
@@ -216,10 +249,12 @@ export async function clearPasskeyHistory(): Promise<void> {
   }
   localStorage.removeItem(PASSKEY_REGISTERED_KEY);
   localStorage.removeItem(KNOWN_CREDENTIALS_KEY);
+  localStorage.removeItem('passkeyActiveCredentialId');
   localStorage.removeItem(PASSKEY_FIRST_SEEN_KEY);
   localStorage.removeItem(PASSKEY_LAST_SEEN_KEY);
   clearAllLabelLastUsed();
-  clearAllCredentialAaguids();
+  // AAGUIDs intentionally kept — only captured at create time and not
+  // recoverable on sign-in.
   invalidatePasskey();
 }
 
@@ -248,6 +283,13 @@ export function isPasskeyMode(): boolean {
 /**
  * Set passkey mode by storing the label.
  * Also marks this device as having used a passkey (persistent hint).
+ *
+ * Does NOT invalidate the Passkey cache: this fires at the END of a
+ * successful sign-in, when the cached instance has a freshly-warmed
+ * Nostr OnceCell that subsequent settings ops (Labels page,
+ * saveLabel, etc.) need to reuse to avoid re-prompting. Label
+ * switches invalidate explicitly at the start of `switchPasskeyLabel`
+ * before the new derive runs.
  */
 export function setPasskeyMode(label?: string): void {
   localStorage.setItem(PASSKEY_LABEL_KEY, label ?? 'Default');
@@ -260,6 +302,9 @@ export function setPasskeyMode(label?: string): void {
  */
 export function clearPasskeyMode(): void {
   localStorage.removeItem(PASSKEY_LABEL_KEY);
+  // Drop active-cred filter so the next sign-in is discoverable
+  // (lets the OS picker surface synced creds again).
+  localStorage.removeItem('passkeyActiveCredentialId');
   invalidatePasskey();
 }
 


### PR DESCRIPTION
## Summary

Consolidates several themed work units that share heavily-overlapping files. The split was attempted via cherry-pick and per-file partial staging during cleanup; the work landed too interleaved across `passkeyService.ts`, `passkeyPrfProvider.ts`, `useBreezSdk.ts` etc. for any mechanical split to produce intermediate commits that build standalone, so it ships as one tightly-described commit.

**Per-create username discriminator with retroactive rename**
- `PASSKEY_LABEL` embeds a per-create timestamp in `user.name` so passkey managers can distinguish multiple credentials for the same RP.
- `signalRename` retroactively updates labels via the SDK's signal API.

**Native AAGUID + `backupEligible` + Sync row**
- Plumbs AAGUID + BE through the native provider, persists per credential, and drops the iOS / Android platform-default fallback now that AAGUID lookup works across platforms.
- Adds a "Sync" row reading "Across your devices" / "This device only" based on the captured BE flag.

**Web sign-in hardening**
- `supportsImmediateGet` capability probe.
- Two-CTA fallback (Create Passkey / Use Existing Passkey) on mobile paths where capability-gated CTA suppression isn't possible.
- `hints` param passed to `navigator.credentials.get` to deprioritize the cross-device QR sheet on mobile sign-in.
- Time-based recovery for returning-user `CREDENTIAL_NOT_FOUND`.
- Platform-split fast-fail with timeout surfacing.
- Hide Create CTA on returning-user sign-in-failed errors.

**Pin sign-in derives to the active credential**
- `allowCredentialIds` threading through web + native paths.
- Auto-pick newly-created credential for the next sign-in.

**SDK Passkey instance cache restoration**
- Reverses main's #196 revert and adds label-change invalidation.
- Keeps cache warm after sign-in success for follow-up Nostr ops.

**Local State page polish + auto-logout**
- Always show fresh-install layout (drops `hasPasskeyBefore` branch).
- Simplify Local State button cards to title-only.
- Auto-logout to home after Forget / Wipe.

Bumps the vendored SDK tarball to the build that exposes both the `signalRename` API and immediate-mediation capability.

## Stack context

Third of four PRs landing the `proto/passkey-*` exploration. This sits on top of [#198](https://github.com/breez/glow-web/pull/198) (now merged):

1. ~~proto/passkey-bulk-prf~~ (merged in #191)
2. ~~proto/passkey-aaguid~~ (merged in #198)
3. **proto/passkey-username-discriminator** ← this PR
4. proto/passkey-web-ux (depends on this)

Rebased onto fresh main on 2026-05-07 after #198 landed. Note: glow-app does NOT have a corresponding discriminator branch since this is glow-web-only work consumed via the submodule pointer; glow-app's next PR after this is web-ux.

## Test plan

- [ ] Multiple passkey labels: register → switch label → register again. The two credentials show distinct user.name labels in the OS picker.
- [ ] Retroactive rename: existing credential picked up by `signalRename` shows the updated label on the next assertion (Chrome 132+ / Safari 26+; no-op on older).
- [ ] Android / iOS via the matching glow-app PR: AAGUID + Sync row populated on native, picker auto-resolves on label switch via `allowCredentialIds`.
- [ ] Mobile web (Safari iOS, Chrome Android): two-CTA fallback shows on HomePage when `immediateGet` isn't supported; QR sheet de-prioritized on the sign-in path.
- [ ] Settings → Local State: Forget / Wipe paths route home cleanly.
- [ ] Vercel preview builds cleanly.