### PR TITLE
fix(passkey): disable signalRename on iOS + recover Android dup refusal

### DIFF
--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -762,8 +762,21 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
         // dedicated "passkey already exists" state with a clear
         // "Use Passkey" CTA so the next biometric prompt is one the
         // user explicitly opted into.
-        if (e instanceof PasskeyAlreadyExistsError) {
-          logger.info(LogCategory.AUTH, 'Create flow detected existing passkey, surfacing already-exists state');
+        const errMsg = e instanceof Error ? e.message : String(e);
+        // Android Chrome's Credential Manager swallows InvalidStateError
+        // into "An unknown error occurred while talking to the credential
+        // manager", so the SDK never sees a typed DOMException to map to
+        // PasskeyAlreadyExistsError. Heuristic-recover when we know the
+        // device has registered creds.
+        const knownCreds = localStorage.getItem('passkeyKnownCredentials');
+        const hasKnownCreds = !!knownCreds && knownCreds !== '[]';
+        const looksLikeAndroidDupRefusal = !isNativePlatform()
+          && /credential manager/i.test(errMsg)
+          && hasKnownCreds;
+        if (e instanceof PasskeyAlreadyExistsError || looksLikeAndroidDupRefusal) {
+          logger.info(LogCategory.AUTH, 'Create flow detected existing passkey, surfacing already-exists state', {
+            heuristic: !(e instanceof PasskeyAlreadyExistsError),
+          });
           // Restore the persistent flag so HomePage and the rest of
           // the app treat this as a returning-user session.
           localStorage.setItem('passkeyRegistered', '1');
@@ -782,16 +795,15 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
         // whether they cancelled, the entitlement is wrong, the AASA
         // CDN is stale, the existing keychain blocked them, etc.
         const code = (e as { code?: string })?.code;
-        const msg = e instanceof Error ? e.message : String(e);
         setError(
           code
-            ? `Failed to create passkey [${code}]: ${msg}`
-            : `Failed to create passkey: ${msg}`,
+            ? `Failed to create passkey [${code}]: ${errMsg}`
+            : `Failed to create passkey: ${errMsg}`,
         );
         setErrorKind('generic');
         logger.error(LogCategory.AUTH, 'Passkey creation failed', {
           errorCode: code,
-          error: msg,
+          error: errMsg,
         });
       }
     };

--- a/src/services/passkeyPrfProvider.ts
+++ b/src/services/passkeyPrfProvider.ts
@@ -174,6 +174,21 @@ export function isMobileBrowser(): boolean {
   return /Android|iPhone|iPad|iPod|Mobi/i.test(ua);
 }
 
+// All iOS browsers share WebKit, where signalCurrentUserDetails has been
+// observed to (a) fire spurious "Passkey Updated" notifications on
+// Apple Passwords and (b) cause GPM (via the AutoFill credential
+// provider extension) to materialize a duplicate credential instead of
+// updating in place. Until WebKit / iOS fix these, signalRename skips
+// iOS entirely.
+function isIos(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  if (/iPhone|iPad|iPod/i.test(ua)) return true;
+  // iPadOS 13+ reports a Mac UA but exposes touch points.
+  if (/Macintosh/i.test(ua) && (navigator.maxTouchPoints || 0) > 1) return true;
+  return false;
+}
+
 /** Local-time, second precision, ASCII-only, e.g. `May 6, 2026 21:14:56`. */
 function createTimestampLabel(): string {
   const d = new Date();
@@ -216,6 +231,7 @@ async function signalRename(
   }).signalCurrentUserDetails;
 
   if (typeof signal !== 'function') return;
+  if (isIos()) return;
 
   const credIdB64 = bytesToBase64(credentialId);
   let label = getCredentialUserName(credIdB64);


### PR DESCRIPTION
## Summary
- **iOS**: skip `signalRename` entirely. WebKit's `signalCurrentUserDetails` (a) spams "Passkey Updated" notifications on Apple Passwords on every sign-in even when the requested name matches the stored one, and (b) causes GPM (via the iOS AutoFill credential-provider extension) to materialize a duplicate credential instead of updating in place. Users can rename via Apple Passwords / GPM directly.
- **Android**: heuristic-recover from the Credential Manager's swallowed `InvalidStateError`. Chrome on Android surfaces "An unknown error occurred while talking to the credential manager" instead of a typed `DOMException`, so the SDK can't throw `PasskeyAlreadyExistsError`. When the create catch sees that error message and `passkeyKnownCredentials` is non-empty, route to the same already-exists UI iOS Chrome already gets.

## Test plan
- [x] iOS Safari + GPM: sign in with an existing GPM cred. No new credential gets created.
- [x] iOS Chrome + Apple Passwords: sign in. No "Passkey Updated" notification fires on repeat sign-ins.
- [x] Android Chrome with at least one existing Glow passkey: tap "Create Passkey". UI shows "You already have a Glow passkey on this device. Use it to sign in." with a "Use Passkey" CTA, instead of the generic credential-manager error.
- [x] Native iOS app: rename behavior unchanged (path doesn't go through web `signalRename`).