### PR TITLE
fix(send): Send All uses stale Stable Balance after toggle

### DIFF
--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -216,7 +216,9 @@ const AmountStep: React.FC<AmountStepProps> = ({
           {showSendAll && (
             <button
               onClick={() => {
-                if (hasTokenBalance && tokenBalanceDisplay) {
+                if (!isTokenMode && balanceSats !== undefined) {
+                  setLocalAmount(String(balanceSats));
+                } else if (hasTokenBalance && tokenBalanceDisplay) {
                   // Token send-all: switch to token mode + show token balance
                   if (!isTokenMode) setIsTokenMode(true);
                   setLocalAmount(tokenBalanceDisplay);

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -320,7 +320,9 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
             || (sendAllAmount !== null && sendAllAmount >= minSats)) && (
             <button
               onClick={() => {
-                if (hasTokenBalance && tokenBalanceDisplay) {
+                if (!isTokenMode && sendAllAmount !== null) {
+                  setAmountInput(String(sendAllAmount));
+                } else if (hasTokenBalance && tokenBalanceDisplay) {
                   if (!isTokenMode) setIsTokenMode(true);
                   setAmountInput(tokenBalanceDisplay);
                 } else if (sendAllBtcInTokenDisplay !== null) {


### PR DESCRIPTION
After disabling Stable Balance, the send dialog flips back to sats display immediately, but the SDK still reports a non-zero USDB balance until the conversion settles. In that brief window, tapping Send All loaded the USDB value into the input instead of the sats balance, which then read as an invalid number of sats. 

Send All now fills the input using whichever unit it's currently showing.

## Test plan

- [x] After disabling Stable Balance, tap Send All on a Lightning send and on an LNURL pay. Input should fill with the sats balance.