### PR TITLE
fix(contacts): search field UI and a11y

### DIFF
--- a/src/features/send/components/ContactsSubView.tsx
+++ b/src/features/send/components/ContactsSubView.tsx
@@ -3,7 +3,7 @@ import type { Contact } from '@breeztech/breez-sdk-spark';
 import { useContactsContext } from '../../../contexts/ContactsContext';
 import { isValidLightningAddress, searchContacts } from '../../../hooks/useContacts';
 import { FormInput, FormError, PrimaryButton, ConfirmDialog } from '../../../components/ui';
-import { BackIcon, PlusIcon, EditPencilIcon, TrashIcon, ContactsIcon, SearchIcon } from '../../../components/Icons';
+import { BackIcon, PlusIcon, EditPencilIcon, TrashIcon, ContactsIcon, SearchIcon, CloseIcon } from '../../../components/Icons';
 import { useWallet } from '../../../contexts/WalletContext';
 import { dismissKeyboard } from '../../../utils/keyboard';
 
@@ -132,10 +132,11 @@ const ContactsSubView: React.FC<ContactsSubViewProps> = ({ onSelect, onBack }) =
 
         {/* Search */}
         <div className="relative mb-3">
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-spark-text-muted pointer-events-none">
-            <SearchIcon />
-          </div>
+          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-spark-text-muted pointer-events-none" />
           <input
+            id="contacts-search"
+            name="contacts-search"
+            aria-label="Search contacts"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             onKeyDown={async (e) => {
@@ -150,15 +151,25 @@ const ContactsSubView: React.FC<ContactsSubViewProps> = ({ onSelect, onBack }) =
               }
             }}
             enterKeyHint="search"
-            type="search"
+            type="text"
             inputMode="search"
             autoCapitalize="none"
             autoCorrect="off"
             autoComplete="off"
             spellCheck={false}
             placeholder="Search contacts..."
-            className="w-full bg-spark-dark border border-spark-border rounded-xl pl-9 pr-4 py-2.5 text-sm text-spark-text-primary placeholder-spark-text-muted focus:border-spark-primary focus:ring-0 transition-all"
+            className="w-full bg-spark-dark border border-spark-border rounded-xl pl-9 pr-9 py-2.5 text-sm text-spark-text-primary placeholder-spark-text-muted focus:border-spark-primary focus:ring-0 transition-all"
           />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery('')}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-spark-text-muted hover:text-spark-text-primary transition-colors"
+            >
+              <CloseIcon size="sm" />
+            </button>
+          )}
         </div>
 
         {/* Contact list */}

--- a/src/index.css
+++ b/src/index.css
@@ -484,29 +484,31 @@ h6 {
    FORM ELEMENTS
    ============================================ */
 
-textarea,
-input,
-select {
-  font-family: 'DM Sans', system-ui, sans-serif;
-  background: var(--spark-dark);
-  color: var(--spark-text-primary);
-  border: 1px solid var(--spark-border);
-  border-radius: 12px;
-  padding: 14px 16px;
-  transition: all 0.2s ease;
-}
+@layer base {
+  textarea,
+  input,
+  select {
+    font-family: 'DM Sans', system-ui, sans-serif;
+    background: var(--spark-dark);
+    color: var(--spark-text-primary);
+    border: 1px solid var(--spark-border);
+    border-radius: 12px;
+    padding: 14px 16px;
+    transition: all 0.2s ease;
+  }
 
-textarea:focus,
-input:focus,
-select:focus {
-  outline: none;
-  border-color: var(--spark-primary);
-  box-shadow: 0 0 0 3px var(--glow-primary);
-}
+  textarea:focus,
+  input:focus,
+  select:focus {
+    outline: none;
+    border-color: var(--spark-primary);
+    box-shadow: 0 0 0 3px var(--glow-primary);
+  }
 
-input::placeholder,
-textarea::placeholder {
-  color: var(--spark-text-muted);
+  input::placeholder,
+  textarea::placeholder {
+    color: var(--spark-text-muted);
+  }
 }
 
 /* Custom select styling */


### PR DESCRIPTION
The contacts search field had a few small issues: the magnifier icon overlapped the placeholder text, the browser-default clear button looked out of place, and the input was missing accessibility attributes for form fields.

The icon now sits cleanly to the left of the input, a styled clear button appears when there's text, and the field exposes the right metadata for accessibility checks.