### PR TITLE
fix(send): prevent double-counting conversion fee in stable balance checks

### DIFF
--- a/src/features/send/hooks/useBalanceValidation.ts
+++ b/src/features/send/hooks/useBalanceValidation.ts
@@ -92,8 +92,7 @@ export function useBalanceValidation(
     conversionEstimate,
   }) => {
     if (confirmTokenMode && conversionEstimate && tokenBalance !== undefined) {
-      const required = conversionEstimate.amountIn + conversionEstimate.fee;
-      return required > tokenBalance;
+      return conversionEstimate.amountIn > tokenBalance;
     }
 
     const available = maxAvailableSats();


### PR DESCRIPTION
This PR fixes an issue where the conversion fee was counted twice during balance checks.

### Test plan
- [ ] **Stable balance active, token balance > 0**: open send (Lightning + LNURL), tap Send All → Confirm step shows the converted sats total and Send is enabled
- [ ] Send completes successfully and the full token balance is consumed
- [ ] Non-send-all token send with insufficient funds still surfaces "Insufficient funds" (e.g. type a value > token balance + BTC change)