### PR TITLE
fix(buy): native Browser.open + dismiss sheet before provider redirects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,18 @@
 
 Glow is a Bitcoin/Lightning wallet web app built with React + TypeScript + Vite, using the Breez Spark SDK (WASM).
 
+## Comment Style
+
+Same standard as spark-sdk's CLAUDE.md "Comment Style" section, condensed for this repo. Applies to any new or modified comment, JSDoc, commit message, or PR description.
+
+0. **No em-dashes or en-dashes** anywhere (code, comments, commits, PRs). Use a colon for an aside, a period between independent clauses, comma + conjunction for contrast, parentheses for a parenthetical, "to" for ranges (`3 to 5 lines`).
+1. **Cut what the code already says.** Default to no comment. Add one only for a non-obvious WHY: a hidden constraint, a workaround, a subtle invariant, surprising behavior. When a signature changes, audit nearby JSDoc for params/fields that no longer exist.
+2. **Compact what stays.** Target 3 to 5 lines. Longer means it wants to be a linked doc, not an inline essay. No multi-paragraph docstrings.
+3. **Calibrate to the reader.** Internal `//` comments: why the code is shaped this way, for whoever maintains the file. Commit messages and PR bodies: what changed and why, not what the code looks like.
+4. **Don't leak internal-looking specifics.** No production identifiers, stack-trace excerpts, or one-off debugging breadcrumbs in committed comments.
+5. **Strip narrative; keep implementation facts.** No development history ("we used to..."), no PR-credit ("added for #1234"). State workarounds as present-tense facts: "Uses `bar()`: `foo()` deadlocks on the main thread." Pointers to active context are fine (an open upstream bug, a spec section, the issue a defense exists for, e.g. `(#213)`). Decision history belongs in the commit message.
+6. **Frame what something IS,** not what happens downstream and not what lives elsewhere. Don't restate the type; document what `undefined`/absence means at the domain level.
+
 ## Key Paths (Hardcoded)
 
 Assume these repos are checked out locally:

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -87,12 +87,9 @@ export interface BottomSheetContainerProps {
   /** Whether to show a backdrop overlay */
   showBackdrop?: boolean;
   /**
-   * Fires once the close (leave) transition of both the backdrop and the
-   * panel has fully finished. Caveat: the transition is driven by the
-   * browser's rAF pipeline, which is paused while the page is hidden, so
-   * this never fires for a close dispatched in a background tab. Callers
-   * that need to act "after close" must bound their wait with a timeout
-   * (see closeAndWaitForLeave in BuyBitcoinDialog).
+   * Fires once the backdrop and panel leave transitions finish. Never
+   * fires while the page is hidden (rAF is paused), so any wait on it
+   * must be bounded by a timeout.
    */
   afterLeave?: () => void;
 }
@@ -188,17 +185,11 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
     };
   }, []);
 
-  // Self-heal a frozen leave transition. If the page is hidden the moment
-  // a close is dispatched (a buy flow pre-opened a tab during the tap, or
-  // navigated this tab right after closing), the leave animation never
-  // runs: rAF and CSS transition events are paused while hidden, so
-  // HeadlessUI never reaches the resting state where it sets the `hidden`
-  // attribute. The user then returns to a stuck backdrop with no sheet
-  // content (breez/glow-web#213). Detect exactly that state when the page
-  // becomes visible again (visibilitychange, bfcache pageshow, Capacitor
-  // resume) and remount the closed Transition via a key bump, which
-  // renders it hidden immediately. The predicate is only true in the
-  // pathological state, so the unmount={false} fast path is untouched.
+  // Self-heal a frozen leave: a close dispatched while the page is hidden
+  // never animates (rAF is paused), so HeadlessUI never sets the `hidden`
+  // attribute and the user returns to a stuck backdrop (#213). On return
+  // to visibility, remount the closed Transition via a key bump. The
+  // predicate only holds in that state, so unmount={false} is unaffected.
   const isOpenRef = useRef(isOpen);
   useEffect(() => {
     isOpenRef.current = isOpen;
@@ -421,9 +412,6 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
     // the browser skips layout + paint while closed, and re-opens
     // only pay browser layout/paint (no React mount).
     <Transition
-      // healKey only changes when the self-heal effect above catches a
-      // frozen leave; remounting snaps the sheet straight to its hidden
-      // resting state.
       key={healKey}
       show={isOpen}
       // `appear` animates on the very first mount when show is already

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, forwardRef, useState, useRef, useCallback, useEffect } from 'react';
 import { Transition, TransitionChild } from '@headlessui/react';
 import { Capacitor } from '@capacitor/core';
+import { App } from '@capacitor/app';
 import { Keyboard } from '@capacitor/keyboard';
 import type { PluginListenerHandle } from '@capacitor/core';
 import { useStatusBarColor } from '../../../hooks/useStatusBarColor';
@@ -85,6 +86,15 @@ export interface BottomSheetContainerProps {
   fullHeight?: boolean;
   /** Whether to show a backdrop overlay */
   showBackdrop?: boolean;
+  /**
+   * Fires once the close (leave) transition of both the backdrop and the
+   * panel has fully finished. Caveat: the transition is driven by the
+   * browser's rAF pipeline, which is paused while the page is hidden, so
+   * this never fires for a close dispatched in a background tab. Callers
+   * that need to act "after close" must bound their wait with a timeout
+   * (see closeAndWaitForLeave in BuyBitcoinDialog).
+   */
+  afterLeave?: () => void;
 }
 
 export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
@@ -96,6 +106,7 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   maxHeightVh = 100,
   fullHeight = false,
   showBackdrop = false,
+  afterLeave,
 }) => {
   // Current snap index: 0 = content, 1 = full. null = not yet measured.
   const [snapIndex, setSnapIndex] = useState(0);
@@ -174,6 +185,53 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       capHandles.forEach((h) => {
         void h.remove();
       });
+    };
+  }, []);
+
+  // Self-heal a frozen leave transition. If the page is hidden the moment
+  // a close is dispatched (a buy flow pre-opened a tab during the tap, or
+  // navigated this tab right after closing), the leave animation never
+  // runs: rAF and CSS transition events are paused while hidden, so
+  // HeadlessUI never reaches the resting state where it sets the `hidden`
+  // attribute. The user then returns to a stuck backdrop with no sheet
+  // content (breez/glow-web#213). Detect exactly that state when the page
+  // becomes visible again (visibilitychange, bfcache pageshow, Capacitor
+  // resume) and remount the closed Transition via a key bump, which
+  // renders it hidden immediately. The predicate is only true in the
+  // pathological state, so the unmount={false} fast path is untouched.
+  const isOpenRef = useRef(isOpen);
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+  const [healKey, setHealKey] = useState(0);
+  useEffect(() => {
+    const healIfStuck = () => {
+      if (isOpenRef.current) return;
+      const panel = wrapperRef.current;
+      if (panel && !panel.hidden) setHealKey((k) => k + 1);
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') healIfStuck();
+    };
+    const onPageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) healIfStuck();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('pageshow', onPageShow);
+
+    let cancelled = false;
+    let resumeHandle: PluginListenerHandle | undefined;
+    if (Capacitor.isNativePlatform()) {
+      void App.addListener('resume', healIfStuck).then((h) => {
+        if (cancelled) void h.remove();
+        else resumeHandle = h;
+      });
+    }
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('pageshow', onPageShow);
+      void resumeHandle?.remove();
     };
   }, []);
 
@@ -363,12 +421,17 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
     // the browser skips layout + paint while closed, and re-opens
     // only pay browser layout/paint (no React mount).
     <Transition
+      // healKey only changes when the self-heal effect above catches a
+      // frozen leave; remounting snaps the sheet straight to its hidden
+      // resting state.
+      key={healKey}
       show={isOpen}
       // `appear` animates on the very first mount when show is already
       // true. Needed so consumers that remount this component on each
       // open (via key) still get the enter animation.
       appear
       unmount={false}
+      afterLeave={afterLeave}
       as="div"
       className="absolute inset-x-0 top-0 z-50 overflow-hidden flex flex-col justify-end pointer-events-none"
       style={{ height: `${viewportHeight}px` }}

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   BottomSheetContainer,
   BottomSheetCard,
@@ -52,10 +52,21 @@ const cashAppHeaderIcon = (
   </div>
 );
 
+/**
+ * Upper bound on waiting for the sheet's 200ms leave transition before
+ * redirecting anyway. The afterLeave callback never fires while the page
+ * is hidden (rAF is paused), so the wait must not be unbounded or the
+ * user would be stranded on the pre-opened blank tab.
+ */
+const SHEET_LEAVE_WAIT_MS = 400;
+
 interface BuyBitcoinDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
+  onBuyBitcoin: (
+    provider: BuyBitcoinProvider,
+    closeAndWaitForLeave?: () => Promise<void>,
+  ) => Promise<void>;
   network?: Network;
 }
 
@@ -66,21 +77,58 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
   network,
 }) => {
   const { showToast } = useToast();
+
+  const pendingLeaveWaiters = useRef<Array<() => void>>([]);
+
+  const handleAfterLeave = useCallback(() => {
+    const waiters = pendingLeaveWaiters.current;
+    pendingLeaveWaiters.current = [];
+    waiters.forEach((resolve) => resolve());
+  }, []);
+
+  // Close the sheet, then wait for its leave transition so the page is
+  // never snapshotted (bfcache) or frozen mid-close when a buy flow
+  // navigates away (breez/glow-web#213). afterLeave is raced against a
+  // bounded timeout, and skipped entirely when the page is already hidden
+  // (a pre-opened blank tab is in the foreground): in those cases the
+  // animation cannot play at all and the stuck-close state is repaired by
+  // BottomSheetContainer's self-heal when the user returns.
+  const closeAndWaitForLeave = useCallback(() => {
+    onClose();
+    if (document.visibilityState === 'hidden') return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(settle, SHEET_LEAVE_WAIT_MS);
+      pendingLeaveWaiters.current.push(settle);
+    });
+  }, [onClose]);
+
+  const handleRedirectProvider = useCallback(
+    (provider: BuyBitcoinProvider) => onBuyBitcoin(provider, closeAndWaitForLeave),
+    [onBuyBitcoin, closeAndWaitForLeave],
+  );
+
   const buy = useBuyBitcoin({
     isOpen,
     network,
-    onSelectRedirectProvider: onBuyBitcoin,
-    onMobileRedirectComplete: onClose,
+    onSelectRedirectProvider: handleRedirectProvider,
+    closeAndWaitForLeave,
     onInvoicePaid: onClose,
   });
 
-  const handleSelect = async (provider: BuyBitcoinProvider) => {
-    await buy.selectProvider(provider);
-    if (provider === 'moonpay') onClose();
-  };
-
   return (
-    <BottomSheetContainer isOpen={isOpen} onClose={onClose} showBackdrop>
+    <BottomSheetContainer
+      isOpen={isOpen}
+      onClose={onClose}
+      showBackdrop
+      afterLeave={handleAfterLeave}
+    >
       <BottomSheetCard>
         {buy.step === 'select' && (
           <>
@@ -96,7 +144,7 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
                 return (
                   <button
                     key={provider}
-                    onClick={() => handleSelect(provider)}
+                    onClick={() => void buy.selectProvider(provider)}
                     disabled={buy.redirectingProvider !== null}
                     className="w-full flex items-center gap-4 p-4 rounded-2xl border border-spark-border hover:border-spark-primary/40 hover:bg-spark-primary/5 transition-all text-left disabled:opacity-50"
                   >

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -53,10 +53,8 @@ const cashAppHeaderIcon = (
 );
 
 /**
- * Upper bound on waiting for the sheet's 200ms leave transition before
- * redirecting anyway. The afterLeave callback never fires while the page
- * is hidden (rAF is paused), so the wait must not be unbounded or the
- * user would be stranded on the pre-opened blank tab.
+ * Upper bound on waiting for the sheet's 200ms leave transition:
+ * afterLeave never fires in a hidden page, so the wait must be bounded.
  */
 const SHEET_LEAVE_WAIT_MS = 400;
 
@@ -86,13 +84,10 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
     waiters.forEach((resolve) => resolve());
   }, []);
 
-  // Close the sheet, then wait for its leave transition so the page is
-  // never snapshotted (bfcache) or frozen mid-close when a buy flow
-  // navigates away (breez/glow-web#213). afterLeave is raced against a
-  // bounded timeout, and skipped entirely when the page is already hidden
-  // (a pre-opened blank tab is in the foreground): in those cases the
-  // animation cannot play at all and the stuck-close state is repaired by
-  // BottomSheetContainer's self-heal when the user returns.
+  // Close the sheet and wait out its leave transition so a buy redirect
+  // never navigates mid-close (#213). Races afterLeave against a timeout;
+  // skipped when the page is already hidden (pre-opened tab in front),
+  // where BottomSheetContainer's self-heal repairs the state on return.
   const closeAndWaitForLeave = useCallback(() => {
     onClose();
     if (document.visibilityState === 'hidden') return Promise.resolve();

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -29,8 +29,14 @@ export interface UseBuyBitcoinOptions {
   network?: Network;
   /** Called for providers that redirect externally (MoonPay). */
   onSelectRedirectProvider: (provider: BuyBitcoinProvider) => Promise<void>;
-  /** Called after a mobile Cash App redirect; the caller typically closes the dialog. */
-  onMobileRedirectComplete: () => void;
+  /**
+   * Closes the dialog and resolves once the sheet's leave transition has
+   * finished (bounded by a timeout; resolves immediately when the page is
+   * already hidden). The buy flow must not navigate away before this
+   * resolves: a page frozen or snapshotted mid-close restores as a stuck
+   * backdrop on return (breez/glow-web#213).
+   */
+  closeAndWaitForLeave: () => Promise<void>;
   /** Called when the displayed QR invoice is paid; the caller typically closes the dialog. */
   onInvoicePaid: () => void;
 }
@@ -67,7 +73,7 @@ export function useBuyBitcoin({
   isOpen,
   network,
   onSelectRedirectProvider,
-  onMobileRedirectComplete,
+  closeAndWaitForLeave,
   onInvoicePaid,
 }: UseBuyBitcoinOptions): UseBuyBitcoinReturn {
   const sdk = useWallet();
@@ -177,24 +183,29 @@ export function useBuyBitcoin({
     // window.location.href): that navigates the app's own WebView to
     // cash.app and gets stuck in a redirect loop when the user returns
     // (same bug as the MoonPay flow, see useBreezSdk.handleBuyBitcoin).
-    // Instead, defer until the SDK responds and hand the URL to
-    // @capacitor/browser (Chrome Custom Tabs / SFSafariViewController).
+    // Instead, the URL is handed to @capacitor/browser after the SDK
+    // responds (Chrome Custom Tabs / SFSafariViewController).
     const isNative = Capacitor.isNativePlatform();
     const mobileTab = isMobile && !isNative ? window.open('', '_blank') : null;
 
     try {
       const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats: amountSatsForSdk });
       setGeneratedAmountSats(amountSats);
-      if (isNative) {
-        await Browser.open({ url: response.url });
-        onMobileRedirectComplete();
-      } else if (isMobile) {
-        if (mobileTab) {
+      if (isNative || isMobile) {
+        // Order matters: fetch the URL with the sheet still open (spinner
+        // and inline errors keep working), then close the sheet and wait
+        // out its leave transition, then navigate (breez/glow-web#213).
+        // Only the synchronous window.open above needs the tap gesture;
+        // navigating an already-open tab handle and Browser.open have no
+        // user-activation deadline.
+        await closeAndWaitForLeave();
+        if (isNative) {
+          await Browser.open({ url: response.url });
+        } else if (mobileTab) {
           mobileTab.location.href = response.url;
         } else {
           window.location.href = response.url;
         }
-        onMobileRedirectComplete();
       } else {
         setCashAppUrl(response.url);
         setStep('qr');
@@ -206,7 +217,7 @@ export function useBuyBitcoin({
     } finally {
       setIsGenerating(false);
     }
-  }, [amountSats, isMobile, sdk, onMobileRedirectComplete]);
+  }, [amountSats, isMobile, sdk, closeAndWaitForLeave]);
 
   // Cash App URLs are `https://cash.app/launch/lightning/<bolt11>`. Extract the
   // invoice only while we're showing the QR so the bus subscription pauses

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -30,11 +30,9 @@ export interface UseBuyBitcoinOptions {
   /** Called for providers that redirect externally (MoonPay). */
   onSelectRedirectProvider: (provider: BuyBitcoinProvider) => Promise<void>;
   /**
-   * Closes the dialog and resolves once the sheet's leave transition has
-   * finished (bounded by a timeout; resolves immediately when the page is
-   * already hidden). The buy flow must not navigate away before this
-   * resolves: a page frozen or snapshotted mid-close restores as a stuck
-   * backdrop on return (breez/glow-web#213).
+   * Closes the dialog and resolves once the sheet's leave transition
+   * finishes (bounded). Navigating away earlier restores a stuck
+   * backdrop on return (#213).
    */
   closeAndWaitForLeave: () => Promise<void>;
   /** Called when the displayed QR invoice is paid; the caller typically closes the dialog. */
@@ -177,14 +175,10 @@ export function useBuyBitcoin({
     setError(null);
     setIsGenerating(true);
 
-    // On mobile web, pre-open a blank tab synchronously during the user
-    // gesture so browsers let us navigate it later without tripping popup
-    // blockers. On native hosts we must NOT do this (or fall back to
-    // window.location.href): that navigates the app's own WebView to
-    // cash.app and gets stuck in a redirect loop when the user returns
-    // (same bug as the MoonPay flow, see useBreezSdk.handleBuyBitcoin).
-    // Instead, the URL is handed to @capacitor/browser after the SDK
-    // responds (Chrome Custom Tabs / SFSafariViewController).
+    // Mobile web: pre-open a blank tab synchronously in the tap gesture so
+    // navigating it later doesn't trip popup blockers. Native must not do
+    // this (or fall back to window.location.href): navigating the WebView
+    // to cash.app strands the user, so the URL goes to Browser.open instead.
     const isNative = Capacitor.isNativePlatform();
     const mobileTab = isMobile && !isNative ? window.open('', '_blank') : null;
 
@@ -192,12 +186,9 @@ export function useBuyBitcoin({
       const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats: amountSatsForSdk });
       setGeneratedAmountSats(amountSats);
       if (isNative || isMobile) {
-        // Order matters: fetch the URL with the sheet still open (spinner
-        // and inline errors keep working), then close the sheet and wait
-        // out its leave transition, then navigate (breez/glow-web#213).
-        // Only the synchronous window.open above needs the tap gesture;
-        // navigating an already-open tab handle and Browser.open have no
-        // user-activation deadline.
+        // Close and wait out the sheet's leave transition before
+        // navigating (#213). Tab-handle navigation and Browser.open have
+        // no user-activation deadline, so deferring them is safe.
         await closeAndWaitForLeave();
         if (isNative) {
           await Browser.open({ url: response.url });

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -1,4 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { Browser } from '@capacitor/browser';
 import type { Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '../../../contexts/WalletContext';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -45,7 +47,6 @@ export interface UseBuyBitcoinReturn {
   isGenerating: boolean;
   error: string | null;
   validAmount: boolean;
-  isMobile: boolean;
   quickAmounts: number[];
   // Token mode
   isTokenMode: boolean;
@@ -170,14 +171,24 @@ export function useBuyBitcoin({
     setError(null);
     setIsGenerating(true);
 
-    // Pre-open a blank tab synchronously during the user gesture so mobile
-    // browsers let us navigate it later without tripping popup blockers.
-    const mobileTab = isMobile ? window.open('', '_blank') : null;
+    // On mobile web, pre-open a blank tab synchronously during the user
+    // gesture so browsers let us navigate it later without tripping popup
+    // blockers. On native hosts we must NOT do this (or fall back to
+    // window.location.href): that navigates the app's own WebView to
+    // cash.app and gets stuck in a redirect loop when the user returns
+    // (same bug as the MoonPay flow, see useBreezSdk.handleBuyBitcoin).
+    // Instead, defer until the SDK responds and hand the URL to
+    // @capacitor/browser (Chrome Custom Tabs / SFSafariViewController).
+    const isNative = Capacitor.isNativePlatform();
+    const mobileTab = isMobile && !isNative ? window.open('', '_blank') : null;
 
     try {
       const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats: amountSatsForSdk });
       setGeneratedAmountSats(amountSats);
-      if (isMobile) {
+      if (isNative) {
+        await Browser.open({ url: response.url });
+        onMobileRedirectComplete();
+      } else if (isMobile) {
         if (mobileTab) {
           mobileTab.location.href = response.url;
         } else {
@@ -237,7 +248,6 @@ export function useBuyBitcoin({
     isGenerating,
     error: displayedError,
     validAmount,
-    isMobile,
     quickAmounts,
     isTokenMode,
     isStableBalanceActive,

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -175,7 +175,10 @@ export interface BreezSdkActions {
   refreshWalletData: (showLoading?: boolean) => Promise<void>;
   fetchUnclaimedDeposits: () => Promise<void>;
   handleLogout: () => Promise<void>;
-  handleBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
+  handleBuyBitcoin: (
+    provider: BuyBitcoinProvider,
+    closeAndWaitForLeave?: () => Promise<void>,
+  ) => Promise<void>;
   clearError: () => void;
   dismissCelebration: () => void;
   subscribeToSdkEvents: (handler: SdkEventHandler) => SdkEventUnsubscribe;
@@ -826,7 +829,10 @@ export function useBreezSdk(
     }
   }, [connectWallet]);
 
-  const handleBuyBitcoin = useCallback(async (provider: BuyBitcoinProvider) => {
+  const handleBuyBitcoin = useCallback(async (
+    provider: BuyBitcoinProvider,
+    closeAndWaitForLeave?: () => Promise<void>,
+  ) => {
     if (!sdk) return;
     // CashApp requires an amount and is driven by the BuyBitcoinDialog amount step
     // (see useBuyBitcoin.generate), so this top-level handler only covers
@@ -847,6 +853,10 @@ export function useBreezSdk(
 
     try {
       const response = await sdk.buyBitcoin({ type: 'moonpay' });
+      // When invoked from the buy dialog, dismiss the sheet and let its
+      // leave transition finish before navigating, so the page is never
+      // frozen or bfcache-snapshotted mid-close (breez/glow-web#213).
+      await closeAndWaitForLeave?.();
       if (isNative) {
         await Browser.open({ url: response.url });
       } else if (newTab) {

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -853,9 +853,8 @@ export function useBreezSdk(
 
     try {
       const response = await sdk.buyBitcoin({ type: 'moonpay' });
-      // When invoked from the buy dialog, dismiss the sheet and let its
-      // leave transition finish before navigating, so the page is never
-      // frozen or bfcache-snapshotted mid-close (breez/glow-web#213).
+      // From the buy dialog: dismiss the sheet and let its leave
+      // transition finish before navigating (#213).
       await closeAndWaitForLeave?.();
       if (isNative) {
         await Browser.open({ url: response.url });

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -35,7 +35,10 @@ interface WalletPageProps {
   onOpenSettings: () => void;
   onOpenBackup: () => void;
   onOpenBuyProviders: () => void;
-  onBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
+  onBuyBitcoin: (
+    provider: BuyBitcoinProvider,
+    closeAndWaitForLeave?: () => Promise<void>,
+  ) => Promise<void>;
   network?: Network;
   onDepositChanged?: () => void;
 }


### PR DESCRIPTION
## Summary

Two fixes to the buy flows, one per commit.

### 1. Cash App on native: open via `@capacitor/browser`

`useBuyBitcoin.generate()` gated its redirect on UA-based `isMobile` (`isIOS || isAndroid`) and never checked `Capacitor.isNativePlatform()`. On the native app, `window.open('', '_blank')` returns `null` in the WebView, so the code fell back to `window.location.href = response.url`, navigating the app's own WebView to cash.app and reintroducing the stuck-redirect-loop bug the MoonPay path (`useBreezSdk.handleBuyBitcoin`) was already changed to avoid. `generate()` now branches on `Capacitor.isNativePlatform()` first and hands the URL to `Browser.open` (Chrome Custom Tabs / SFSafariViewController) after the SDK responds. Also drops the unused `isMobile` field from `UseBuyBitcoinReturn`.

### 2. Web sheet corruption on return (closes #213)

Returning to Glow after a provider redirect could restore a stuck backdrop with no sheet content: the page was navigated (or backgrounded) while the bottom sheet was mid-close, so the leave transition froze (rAF and CSS transition events pause in hidden pages) and HeadlessUI never reached the `hidden` resting state, which the bfcache snapshot then preserved.

**Sequencing fix.** Both buy flows now run fetch URL → close sheet → bounded wait for the leave transition → navigate. `BottomSheetContainer` gains an `afterLeave` prop (fires after backdrop and panel both finish), and `BuyBitcoinDialog` builds a `closeAndWaitForLeave()` primitive that races `afterLeave` against a 400ms timeout and short-circuits when the page is already hidden; it is threaded through `generate()` (Cash App) and `handleBuyBitcoin` (MoonPay, as an optional parameter so the single-provider quick-buy path without a sheet is unaffected). The wait is never gated on `afterLeave` alone: it cannot fire while the page is hidden, and an unbounded wait would strand the user on the pre-opened blank tab. Only the synchronous blank-tab `window.open` needs the tap gesture; navigating an existing tab handle and `Browser.open` have no user-activation deadline, so deferring just the navigation is popup-safe everywhere.

**Self-heal hardening.** The pre-opened-tab variants hide the page synchronously during the tap, before any close could animate, so no reordering helps there (and a delayed fresh `window.open` is not an option: iOS Safari blocks it after roughly 1s of accumulated delay, which the `sdk.buyBitcoin` RTT alone can exceed). `BottomSheetContainer` now detects the frozen-leave state (`isOpen === false` but the panel never got its `hidden` attribute) on `visibilitychange` to visible, `pageshow` with `persisted`, and Capacitor `resume`, and remounts the closed `Transition` via a key bump. The predicate is only true in the pathological state, so the `unmount={false}` first-open perf win is preserved. This also covers the invoice-paid auto-close while backgrounded. Residual risk is at worst a one-frame scrim flash before the handler drops the stale DOM.

**Behavior note.** If the MoonPay SDK call fails, the sheet now stays open under the error toast instead of closing, since the close only happens right before a successful redirect.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes on all touched files
- [ ] Native app: Cash App and MoonPay open in an in-app browser sheet; returning shows no stuck overlay
- [ ] Mobile web, popup allowed: blank tab pre-opens, sheet closes, tab navigates; returning to the Glow tab shows no stuck overlay (self-heal path)
- [ ] Mobile web, popup blocked: sheet visibly closes, then same-tab redirect; back-navigation restores a clean page (bfcache path)
- [ ] Desktop web: Cash App QR step unchanged; MoonPay opens in new tab
- [ ] Sheet open/close animations unchanged in normal use