### PR TITLE
fix: anchor bottom sheet to the visual viewport pan so it hugs the keyboard on mobile web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage/
 .claude/launch.json
 .claude/worktrees/
 .DS_Store
+.playwright-mcp/

--- a/src/components/ui/sheets/BottomSheet.test.tsx
+++ b/src/components/ui/sheets/BottomSheet.test.tsx
@@ -104,9 +104,20 @@ describe('BottomSheetContainer visual viewport tracking', () => {
     expect(wrapper.style.height).toBe('600px');
 
     act(() => {
-      vi.advanceTimersByTime(250);
+      vi.advanceTimersByTime(350);
     });
     expect(wrapper.style.height).toBe('900px');
+  });
+
+  it('applies small grows (keyboard layout swaps) without the hold', () => {
+    const { container } = renderSheet();
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    // Text keyboard up, then a swap to a slightly shorter layout.
+    setViewport(600);
+    setViewport(650);
+
+    expect(wrapper.style.height).toBe('650px');
   });
 
   it('pre-lifts on input focus before the keyboard opens, reverts if none arrives', () => {

--- a/src/components/ui/sheets/BottomSheet.test.tsx
+++ b/src/components/ui/sheets/BottomSheet.test.tsx
@@ -117,4 +117,34 @@ describe('BottomSheetContainer visual viewport tracking', () => {
     expect(wrapper.style.height).toBe('900px');
     expect(wrapper.style.top).toBe('0px');
   });
+
+  it('pre-lifts on input focus before the keyboard opens, reverts if none arrives', () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const { container, getByLabelText } = renderSheet();
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    // Seed the keyboard delta cache with one real keyboard cycle.
+    setViewport(600, 0);
+    setViewport(900, 0);
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(wrapper.style.height).toBe('900px');
+
+    // Focusing a sheet input from a non-input applies the cached
+    // shrink before any viewport event arrives, so the browser never
+    // needs to pan the page to reveal the caret.
+    act(() => {
+      getByLabelText('amount').dispatchEvent(
+        new FocusEvent('focusin', { bubbles: true }),
+      );
+    });
+    expect(wrapper.style.height).toBe('600px');
+
+    // No keyboard-sized shrink confirmed the pre-lift: revert.
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(wrapper.style.height).toBe('900px');
+  });
 });

--- a/src/components/ui/sheets/BottomSheet.test.tsx
+++ b/src/components/ui/sheets/BottomSheet.test.tsx
@@ -72,10 +72,14 @@ describe('BottomSheetContainer visual viewport tracking', () => {
 
   it('drops a transient grow when the keyboard re-claims space (focus switch)', () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    const { container } = renderSheet();
+    const { container, getByLabelText } = renderSheet();
     const wrapper = container.firstElementChild as HTMLElement;
 
-    // Keyboard opens on the first field.
+    // Keyboard opens on the first field; focus stays on an editable
+    // through the switch, which is what engages the grow hold.
+    act(() => {
+      getByLabelText('amount').focus();
+    });
     setViewport(600);
 
     // Focus moves to the next field: the browser reports a transient
@@ -94,11 +98,16 @@ describe('BottomSheetContainer visual viewport tracking', () => {
     expect(wrapper.style.height).toBe('580px');
   });
 
-  it('applies a real keyboard hide once the grow hold expires', () => {
+  it('applies a focus-retained keyboard hide once the grow hold expires', () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    const { container } = renderSheet();
+    const { container, getByLabelText } = renderSheet();
     const wrapper = container.firstElementChild as HTMLElement;
 
+    // iOS keyboard-dismiss chevron hides the keyboard but keeps the
+    // input focused: the grow is held, then applied.
+    act(() => {
+      getByLabelText('amount').focus();
+    });
     setViewport(600);
     setViewport(900);
     expect(wrapper.style.height).toBe('600px');
@@ -106,6 +115,25 @@ describe('BottomSheetContainer visual viewport tracking', () => {
     act(() => {
       vi.advanceTimersByTime(350);
     });
+    expect(wrapper.style.height).toBe('900px');
+  });
+
+  it('tracks a keyboard dismissal immediately once inputs are blurred', () => {
+    const { container, getByLabelText } = renderSheet();
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    act(() => {
+      getByLabelText('amount').focus();
+    });
+    setViewport(600);
+
+    // Submit/backdrop flows blur before the keyboard hides: the grow
+    // must apply without the hold so the sheet rides down with it.
+    act(() => {
+      getByLabelText('amount').blur();
+    });
+    setViewport(900);
+
     expect(wrapper.style.height).toBe('900px');
   });
 

--- a/src/components/ui/sheets/BottomSheet.test.tsx
+++ b/src/components/ui/sheets/BottomSheet.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { BottomSheetContainer, BottomSheetCard } from './BottomSheet';
+
+// Minimal stand-in for window.visualViewport: just enough surface for
+// the sheet's resize/scroll subscription and rect reads.
+class FakeVisualViewport extends EventTarget {
+  height = 900;
+  pageTop = 0;
+}
+
+let vv: FakeVisualViewport;
+
+beforeEach(() => {
+  vv = new FakeVisualViewport();
+  Object.defineProperty(window, 'visualViewport', {
+    value: vv,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'visualViewport', {
+    value: undefined,
+    configurable: true,
+  });
+});
+
+const renderSheet = () =>
+  render(
+    <BottomSheetContainer isOpen onClose={() => {}}>
+      <BottomSheetCard>
+        <input aria-label="amount" />
+      </BottomSheetCard>
+    </BottomSheetContainer>,
+  );
+
+describe('BottomSheetContainer visual viewport tracking', () => {
+  it('sizes and anchors the wrapper to the visual viewport rect', () => {
+    const { container } = renderSheet();
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    expect(wrapper.style.top).toBe('0px');
+    expect(wrapper.style.height).toBe('900px');
+  });
+
+  it('follows the visual viewport pan when the keyboard opens (#219)', () => {
+    const { container } = renderSheet();
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    // Keyboard opens: the viewport shrinks and the browser pans down
+    // to reveal a focused input near the bottom of the screen.
+    act(() => {
+      vv.height = 600;
+      vv.pageTop = 300;
+      vv.dispatchEvent(new Event('resize'));
+    });
+
+    expect(wrapper.style.top).toBe('300px');
+    expect(wrapper.style.height).toBe('600px');
+  });
+
+  it('re-anchors on visual viewport scroll without a resize', () => {
+    const { container } = renderSheet();
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    act(() => {
+      vv.pageTop = 120;
+      vv.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(wrapper.style.top).toBe('120px');
+  });
+});

--- a/src/components/ui/sheets/BottomSheet.test.tsx
+++ b/src/components/ui/sheets/BottomSheet.test.tsx
@@ -37,42 +37,37 @@ const renderSheet = () =>
   );
 
 /** Dispatch a viewport geometry change like a keyboard show/hide. */
-const setViewport = (height: number, pageTop: number, event: 'resize' | 'scroll' = 'resize') => {
+const setViewport = (height: number, event: 'resize' | 'scroll' = 'resize') => {
   act(() => {
     vv.height = height;
-    vv.pageTop = pageTop;
     vv.dispatchEvent(new Event(event));
   });
 };
 
 describe('BottomSheetContainer visual viewport tracking', () => {
-  it('sizes and anchors the wrapper to the visual viewport rect', () => {
+  it('sizes the wrapper to the visual viewport height', () => {
     const { container } = renderSheet();
     const wrapper = container.firstElementChild as HTMLElement;
 
-    expect(wrapper.style.top).toBe('0px');
     expect(wrapper.style.height).toBe('900px');
   });
 
-  it('follows the visual viewport pan when the keyboard opens (#219)', () => {
+  it('shrinks the wrapper when the keyboard opens (#219)', () => {
     const { container } = renderSheet();
     const wrapper = container.firstElementChild as HTMLElement;
 
-    // Keyboard opens: the viewport shrinks and the browser pans down
-    // to reveal a focused input near the bottom of the screen.
-    setViewport(600, 300);
+    setViewport(600);
 
-    expect(wrapper.style.top).toBe('300px');
     expect(wrapper.style.height).toBe('600px');
   });
 
-  it('re-anchors on visual viewport scroll without a resize', () => {
+  it('applies height changes that arrive via scroll events', () => {
     const { container } = renderSheet();
     const wrapper = container.firstElementChild as HTMLElement;
 
-    setViewport(900, 120, 'scroll');
+    setViewport(620, 'scroll');
 
-    expect(wrapper.style.top).toBe('120px');
+    expect(wrapper.style.height).toBe('620px');
   });
 
   it('drops a transient grow when the keyboard re-claims space (focus switch)', () => {
@@ -81,25 +76,22 @@ describe('BottomSheetContainer visual viewport tracking', () => {
     const wrapper = container.firstElementChild as HTMLElement;
 
     // Keyboard opens on the first field.
-    setViewport(600, 300);
+    setViewport(600);
 
     // Focus moves to the next field: the browser reports a transient
     // keyboard hide. The grow must not apply yet.
-    setViewport(900, 0);
+    setViewport(900);
     expect(wrapper.style.height).toBe('600px');
-    expect(wrapper.style.top).toBe('300px');
 
     // Keyboard re-shows (slightly different layout) before the hold
     // expires: tracked immediately, held grow cancelled.
-    setViewport(580, 320);
+    setViewport(580);
     expect(wrapper.style.height).toBe('580px');
-    expect(wrapper.style.top).toBe('320px');
 
     act(() => {
       vi.advanceTimersByTime(500);
     });
     expect(wrapper.style.height).toBe('580px');
-    expect(wrapper.style.top).toBe('320px');
   });
 
   it('applies a real keyboard hide once the grow hold expires', () => {
@@ -107,15 +99,14 @@ describe('BottomSheetContainer visual viewport tracking', () => {
     const { container } = renderSheet();
     const wrapper = container.firstElementChild as HTMLElement;
 
-    setViewport(600, 300);
-    setViewport(900, 0);
+    setViewport(600);
+    setViewport(900);
     expect(wrapper.style.height).toBe('600px');
 
     act(() => {
       vi.advanceTimersByTime(250);
     });
     expect(wrapper.style.height).toBe('900px');
-    expect(wrapper.style.top).toBe('0px');
   });
 
   it('pre-lifts on input focus before the keyboard opens, reverts if none arrives', () => {
@@ -124,8 +115,8 @@ describe('BottomSheetContainer visual viewport tracking', () => {
     const wrapper = container.firstElementChild as HTMLElement;
 
     // Seed the keyboard delta cache with one real keyboard cycle.
-    setViewport(600, 0);
-    setViewport(900, 0);
+    setViewport(600);
+    setViewport(900);
     act(() => {
       vi.advanceTimersByTime(700);
     });

--- a/src/components/ui/sheets/BottomSheet.test.tsx
+++ b/src/components/ui/sheets/BottomSheet.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, act } from '@testing-library/react';
 import { BottomSheetContainer, BottomSheetCard } from './BottomSheet';
 
@@ -20,6 +20,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   Object.defineProperty(window, 'visualViewport', {
     value: undefined,
     configurable: true,
@@ -34,6 +35,15 @@ const renderSheet = () =>
       </BottomSheetCard>
     </BottomSheetContainer>,
   );
+
+/** Dispatch a viewport geometry change like a keyboard show/hide. */
+const setViewport = (height: number, pageTop: number, event: 'resize' | 'scroll' = 'resize') => {
+  act(() => {
+    vv.height = height;
+    vv.pageTop = pageTop;
+    vv.dispatchEvent(new Event(event));
+  });
+};
 
 describe('BottomSheetContainer visual viewport tracking', () => {
   it('sizes and anchors the wrapper to the visual viewport rect', () => {
@@ -50,11 +60,7 @@ describe('BottomSheetContainer visual viewport tracking', () => {
 
     // Keyboard opens: the viewport shrinks and the browser pans down
     // to reveal a focused input near the bottom of the screen.
-    act(() => {
-      vv.height = 600;
-      vv.pageTop = 300;
-      vv.dispatchEvent(new Event('resize'));
-    });
+    setViewport(600, 300);
 
     expect(wrapper.style.top).toBe('300px');
     expect(wrapper.style.height).toBe('600px');
@@ -64,11 +70,51 @@ describe('BottomSheetContainer visual viewport tracking', () => {
     const { container } = renderSheet();
     const wrapper = container.firstElementChild as HTMLElement;
 
-    act(() => {
-      vv.pageTop = 120;
-      vv.dispatchEvent(new Event('scroll'));
-    });
+    setViewport(900, 120, 'scroll');
 
     expect(wrapper.style.top).toBe('120px');
+  });
+
+  it('drops a transient grow when the keyboard re-claims space (focus switch)', () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const { container } = renderSheet();
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    // Keyboard opens on the first field.
+    setViewport(600, 300);
+
+    // Focus moves to the next field: the browser reports a transient
+    // keyboard hide. The grow must not apply yet.
+    setViewport(900, 0);
+    expect(wrapper.style.height).toBe('600px');
+    expect(wrapper.style.top).toBe('300px');
+
+    // Keyboard re-shows (slightly different layout) before the hold
+    // expires: tracked immediately, held grow cancelled.
+    setViewport(580, 320);
+    expect(wrapper.style.height).toBe('580px');
+    expect(wrapper.style.top).toBe('320px');
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(wrapper.style.height).toBe('580px');
+    expect(wrapper.style.top).toBe('320px');
+  });
+
+  it('applies a real keyboard hide once the grow hold expires', () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const { container } = renderSheet();
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    setViewport(600, 300);
+    setViewport(900, 0);
+    expect(wrapper.style.height).toBe('600px');
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(wrapper.style.height).toBe('900px');
+    expect(wrapper.style.top).toBe('0px');
   });
 });

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -125,6 +125,14 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   const [viewportHeight, setViewportHeight] = useState<number>(() => {
     return window.visualViewport?.height ?? window.innerHeight;
   });
+  // Offset of the visual viewport from the document top. Mobile web
+  // browsers pan the visual viewport (pageTop > 0) to reveal a focused
+  // input the incoming keyboard would cover; the sheet must follow that
+  // pan or it floats above the keyboard by the pan amount (#219).
+  // Always 0 on native: adjustResize shrinks the WebView instead.
+  const [viewportTop, setViewportTop] = useState<number>(() => {
+    return window.visualViewport?.pageTop ?? 0;
+  });
 
   const dragging = useRef(false);
   const startY = useRef(0);
@@ -142,6 +150,7 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   useEffect(() => {
     const readViewport = () => {
       setViewportHeight(window.visualViewport?.height ?? window.innerHeight);
+      setViewportTop(window.visualViewport?.pageTop ?? 0);
     };
 
     const vv = window.visualViewport;
@@ -421,8 +430,8 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       unmount={false}
       afterLeave={afterLeave}
       as="div"
-      className="absolute inset-x-0 top-0 z-50 overflow-hidden flex flex-col justify-end pointer-events-none"
-      style={{ height: `${viewportHeight}px` }}
+      className="absolute inset-x-0 z-50 overflow-hidden flex flex-col justify-end pointer-events-none"
+      style={{ top: `${viewportTop}px`, height: `${viewportHeight}px` }}
     >
       {showBackdrop && (
         <TransitionChild

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -36,6 +36,21 @@ const maxWidthMap: Record<BottomSheetMaxWidth, string> = {
 const OVER_DRAG_RESISTANCE = 2.5;
 /** Velocity threshold (px) — snap toward the direction of the gesture */
 const SNAP_VELOCITY_THRESHOLD = 50;
+/**
+ * Hold (ms) before a viewport grow is applied on web. Moving focus
+ * between two sheet fields makes mobile browsers report a transient
+ * keyboard hide/show pair; applying the grow at once bounces the
+ * sheet down and back up on every field switch.
+ */
+const VIEWPORT_GROW_SETTLE_MS = 200;
+
+// Glide between viewport rects on web, where keyboard and pan changes
+// arrive as single step events and an instant jump reads as a teleport.
+// Native is exempt: adjustResize resizes the WebView in lockstep with
+// the keyboard and the sheet must track it without lag.
+const VIEWPORT_TRANSITION = Capacitor.isNativePlatform()
+  ? undefined
+  : 'top 200ms cubic-bezier(0.2, 0.0, 0, 1.0), height 200ms cubic-bezier(0.2, 0.0, 0, 1.0)';
 
 /** Find the nearest snap point, biased by drag direction */
 function resolveSnap(height: number, snapPoints: number[], dy: number): number {
@@ -148,9 +163,34 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   // WebViews where visualViewport.resize is delayed or coalesced
   // and fires before the WebView has finished re-laying out.
   useEffect(() => {
-    const readViewport = () => {
-      setViewportHeight(window.visualViewport?.height ?? window.innerHeight);
+    let appliedHeight = window.visualViewport?.height ?? window.innerHeight;
+    let growTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const apply = () => {
+      appliedHeight = window.visualViewport?.height ?? window.innerHeight;
+      setViewportHeight(appliedHeight);
       setViewportTop(window.visualViewport?.pageTop ?? 0);
+    };
+
+    // Shrinks and pan changes apply immediately so the sheet never
+    // sits behind the keyboard. Grows are held briefly on web (see
+    // VIEWPORT_GROW_SETTLE_MS) and dropped if the keyboard re-claims
+    // the space first. Native applies grows directly: adjustResize
+    // resizes the WebView once per keyboard event with no transient.
+    const readViewport = () => {
+      const nextHeight = window.visualViewport?.height ?? window.innerHeight;
+      if (!Capacitor.isNativePlatform() && nextHeight > appliedHeight) {
+        growTimer ??= setTimeout(() => {
+          growTimer = undefined;
+          apply();
+        }, VIEWPORT_GROW_SETTLE_MS);
+        return;
+      }
+      if (growTimer !== undefined) {
+        clearTimeout(growTimer);
+        growTimer = undefined;
+      }
+      apply();
     };
 
     const vv = window.visualViewport;
@@ -186,6 +226,7 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
 
     return () => {
       cancelled = true;
+      if (growTimer !== undefined) clearTimeout(growTimer);
       vv?.removeEventListener('resize', readViewport);
       vv?.removeEventListener('scroll', readViewport);
       capHandles.forEach((h) => {
@@ -431,7 +472,11 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       afterLeave={afterLeave}
       as="div"
       className="absolute inset-x-0 z-50 overflow-hidden flex flex-col justify-end pointer-events-none"
-      style={{ top: `${viewportTop}px`, height: `${viewportHeight}px` }}
+      style={{
+        top: `${viewportTop}px`,
+        height: `${viewportHeight}px`,
+        transition: VIEWPORT_TRANSITION,
+      }}
     >
       {showBackdrop && (
         <TransitionChild

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -44,13 +44,19 @@ const SNAP_VELOCITY_THRESHOLD = 50;
  */
 const VIEWPORT_GROW_SETTLE_MS = 200;
 
-// Glide between viewport rects on web, where keyboard and pan changes
-// arrive as single step events and an instant jump reads as a teleport.
-// Native is exempt: adjustResize resizes the WebView in lockstep with
-// the keyboard and the sheet must track it without lag.
-const VIEWPORT_TRANSITION = Capacitor.isNativePlatform()
-  ? undefined
-  : 'top 200ms cubic-bezier(0.2, 0.0, 0, 1.0), height 200ms cubic-bezier(0.2, 0.0, 0, 1.0)';
+// Glide between viewport rects: keyboard and pan changes arrive as
+// single step events (on native the WebView resize only reaches the
+// page near the end of the IME animation) and an instant jump reads
+// as a teleport.
+const VIEWPORT_TRANSITION =
+  'top 200ms cubic-bezier(0.2, 0.0, 0, 1.0), height 200ms cubic-bezier(0.2, 0.0, 0, 1.0)';
+
+// Viewport shrink the keyboard caused the last time it opened (native
+// only, survives sheet remounts). Lets keyboardWillShow pre-position
+// the sheet at the start of the IME animation instead of waiting for
+// the WebView resize, which lands near the animation's end and reads
+// as the sheet lagging the keyboard by its full travel.
+let lastNativeKeyboardDelta: number | undefined;
 
 /** Find the nearest snap point, biased by drag direction */
 function resolveSnap(height: number, snapPoints: number[], dy: number): number {
@@ -206,19 +212,58 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       // sample innerHeight / visualViewport.height.
       const delayedRead = () => requestAnimationFrame(readViewport);
 
-      void Keyboard.addListener('keyboardWillShow', delayedRead).then((h) => {
+      // willShow can fire again without a hide when the IME swaps
+      // layouts (numeric to text). Pre-positioning must only run from
+      // the keyboard-closed state or it would shrink an already-shrunk
+      // viewport; tracking keyboardUp also keeps the delta cache from
+      // being computed against a stale full height.
+      let keyboardUp = false;
+      let fullHeightAtWillShow: number | undefined;
+
+      const onWillShow = () => {
+        if (!keyboardUp) {
+          fullHeightAtWillShow =
+            window.visualViewport?.height ?? window.innerHeight;
+          if (lastNativeKeyboardDelta !== undefined) {
+            appliedHeight = fullHeightAtWillShow - lastNativeKeyboardDelta;
+            setViewportHeight(appliedHeight);
+          }
+        }
+        delayedRead();
+      };
+
+      const onDidShow = () => {
+        keyboardUp = true;
+        requestAnimationFrame(() => {
+          readViewport();
+          const settled = window.visualViewport?.height ?? window.innerHeight;
+          if (
+            fullHeightAtWillShow !== undefined &&
+            fullHeightAtWillShow > settled
+          ) {
+            lastNativeKeyboardDelta = fullHeightAtWillShow - settled;
+          }
+        });
+      };
+
+      const onHide = () => {
+        keyboardUp = false;
+        delayedRead();
+      };
+
+      void Keyboard.addListener('keyboardWillShow', onWillShow).then((h) => {
         if (cancelled) h.remove();
         else capHandles.push(h);
       });
-      void Keyboard.addListener('keyboardDidShow', delayedRead).then((h) => {
+      void Keyboard.addListener('keyboardDidShow', onDidShow).then((h) => {
         if (cancelled) h.remove();
         else capHandles.push(h);
       });
-      void Keyboard.addListener('keyboardWillHide', delayedRead).then((h) => {
+      void Keyboard.addListener('keyboardWillHide', onHide).then((h) => {
         if (cancelled) h.remove();
         else capHandles.push(h);
       });
-      void Keyboard.addListener('keyboardDidHide', delayedRead).then((h) => {
+      void Keyboard.addListener('keyboardDidHide', onHide).then((h) => {
         if (cancelled) h.remove();
         else capHandles.push(h);
       });

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -51,12 +51,17 @@ const VIEWPORT_GROW_SETTLE_MS = 200;
 const VIEWPORT_TRANSITION =
   'top 200ms cubic-bezier(0.2, 0.0, 0, 1.0), height 200ms cubic-bezier(0.2, 0.0, 0, 1.0)';
 
-// Viewport shrink the keyboard caused the last time it opened (native
-// only, survives sheet remounts). Lets keyboardWillShow pre-position
-// the sheet at the start of the IME animation instead of waiting for
-// the WebView resize, which lands near the animation's end and reads
-// as the sheet lagging the keyboard by its full travel.
-let lastNativeKeyboardDelta: number | undefined;
+// Viewport shrink the keyboard caused the last time it opened
+// (survives sheet remounts). Consumed by two pre-positioning paths:
+// native applies it at keyboardWillShow (the WebView resize only
+// lands near the end of the IME animation), web applies it on
+// focusin inside the sheet, before the keyboard opens, so the
+// browser never needs to pan the page to reveal the caret. The pan
+// is what makes the background page visibly jump on web (#219).
+let lastKeyboardDelta: number | undefined;
+
+/** Revert window (ms) for a web pre-lift that no keyboard confirmed. */
+const PRE_LIFT_REVERT_MS = 1000;
 
 /** Find the nearest snap point, biased by drag direction */
 function resolveSnap(height: number, snapPoints: number[], dy: number): number {
@@ -171,11 +176,39 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   useEffect(() => {
     let appliedHeight = window.visualViewport?.height ?? window.innerHeight;
     let growTimer: ReturnType<typeof setTimeout> | undefined;
+    // Full height captured at a web pre-lift, until a real keyboard
+    // shrink confirms it. Doubles as the "pre-lift pending" flag.
+    let preLiftBase: number | undefined;
+    let preLiftRevert: ReturnType<typeof setTimeout> | undefined;
+    let settleTimers: ReturnType<typeof setTimeout>[] = [];
 
     const apply = () => {
+      // Height before this keyboard appearance: the pre-lift already
+      // moved appliedHeight, so the cached delta must be measured
+      // against the full height captured when the pre-lift ran.
+      const reference = preLiftBase ?? appliedHeight;
       appliedHeight = window.visualViewport?.height ?? window.innerHeight;
       setViewportHeight(appliedHeight);
       setViewportTop(window.visualViewport?.pageTop ?? 0);
+
+      if (!Capacitor.isNativePlatform() && reference - appliedHeight > 150) {
+        // A keyboard-sized shrink landed: remember it for the next
+        // pre-lift, and re-read after the dust settles. iOS Safari
+        // can restore its focus pan without firing another resize or
+        // scroll event, which would otherwise leave the sheet
+        // floating on stale values.
+        lastKeyboardDelta = reference - appliedHeight;
+        preLiftBase = undefined;
+        if (preLiftRevert !== undefined) {
+          clearTimeout(preLiftRevert);
+          preLiftRevert = undefined;
+        }
+        settleTimers.forEach(clearTimeout);
+        settleTimers = [
+          setTimeout(() => readViewport(), 250),
+          setTimeout(() => readViewport(), 600),
+        ];
+      }
     };
 
     // Shrinks and pan changes apply immediately so the sheet never
@@ -198,6 +231,49 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       }
       apply();
     };
+
+    // Web counterpart of the native keyboardWillShow pre-positioning:
+    // when a sheet input takes focus from a non-input (keyboard still
+    // closed), apply the cached keyboard shrink before the keyboard
+    // opens. The caret is then already visible above the incoming
+    // keyboard, so the browser never pans the page and the content
+    // behind the sheet stays static. Reverted if no keyboard-sized
+    // shrink confirms within PRE_LIFT_REVERT_MS (hardware keyboards,
+    // desktop browsers).
+    const onFocusIn = (event: FocusEvent) => {
+      if (Capacitor.isNativePlatform()) return;
+      if (lastKeyboardDelta === undefined) return;
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      if (!wrapperRef.current?.contains(target)) return;
+      if (!target.matches('input, textarea, [contenteditable="true"]')) return;
+      const from = event.relatedTarget;
+      if (
+        from instanceof HTMLElement &&
+        from.matches('input, textarea, [contenteditable="true"]')
+      ) {
+        // Field switch: keyboard already up, sheet already lifted.
+        return;
+      }
+      const current = window.visualViewport?.height ?? window.innerHeight;
+      // Viewport already keyboard-shrunk relative to the layout
+      // viewport: pre-lifting again would double-shrink.
+      if (current < document.documentElement.clientHeight - 50) return;
+      const lifted = current - lastKeyboardDelta;
+      if (lifted <= 0) return;
+      preLiftBase = current;
+      appliedHeight = lifted;
+      setViewportHeight(lifted);
+      if (preLiftRevert !== undefined) clearTimeout(preLiftRevert);
+      preLiftRevert = setTimeout(() => {
+        preLiftRevert = undefined;
+        if (preLiftBase !== undefined) {
+          preLiftBase = undefined;
+          apply();
+        }
+      }, PRE_LIFT_REVERT_MS);
+    };
+    document.addEventListener('focusin', onFocusIn);
 
     const vv = window.visualViewport;
     vv?.addEventListener('resize', readViewport);
@@ -224,8 +300,8 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
         if (!keyboardUp) {
           fullHeightAtWillShow =
             window.visualViewport?.height ?? window.innerHeight;
-          if (lastNativeKeyboardDelta !== undefined) {
-            appliedHeight = fullHeightAtWillShow - lastNativeKeyboardDelta;
+          if (lastKeyboardDelta !== undefined) {
+            appliedHeight = fullHeightAtWillShow - lastKeyboardDelta;
             setViewportHeight(appliedHeight);
           }
         }
@@ -241,7 +317,7 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
             fullHeightAtWillShow !== undefined &&
             fullHeightAtWillShow > settled
           ) {
-            lastNativeKeyboardDelta = fullHeightAtWillShow - settled;
+            lastKeyboardDelta = fullHeightAtWillShow - settled;
           }
         });
       };
@@ -272,6 +348,9 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
     return () => {
       cancelled = true;
       if (growTimer !== undefined) clearTimeout(growTimer);
+      if (preLiftRevert !== undefined) clearTimeout(preLiftRevert);
+      settleTimers.forEach(clearTimeout);
+      document.removeEventListener('focusin', onFocusIn);
       vv?.removeEventListener('resize', readViewport);
       vv?.removeEventListener('scroll', readViewport);
       capHandles.forEach((h) => {
@@ -516,7 +595,11 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       unmount={false}
       afterLeave={afterLeave}
       as="div"
-      className="absolute inset-x-0 z-50 overflow-hidden flex flex-col justify-end pointer-events-none"
+      // No overflow-hidden: the keyboard bleed below must paint
+      // outside the wrapper, and the panel only ever animates
+      // downward out of it, into keyboard-covered or off-screen
+      // space (ancestors clip at the page bounds).
+      className="absolute inset-x-0 z-50 flex flex-col justify-end pointer-events-none"
       style={{
         top: `${viewportTop}px`,
         height: `${viewportHeight}px`,
@@ -599,6 +682,17 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
           return child;
         })}
       </TransitionChild>
+      {/* Card-surface bleed below the sheet footer. iOS Safari can
+          over-subtract the keyboard from visualViewport.height or
+          restore its focus pan without firing an event, exposing a
+          band of the page behind between the sheet and the keyboard.
+          The bleed paints sheet surface across that band; with an
+          accurate viewport it sits behind the keyboard or past the
+          page bounds, where ancestors clip it. */}
+      <div
+        aria-hidden
+        className={`absolute top-full inset-x-0 mx-auto w-full ${maxWidthClass} h-40 bg-spark-surface pointer-events-auto`}
+      />
     </Transition>
   );
 };

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -37,12 +37,16 @@ const OVER_DRAG_RESISTANCE = 2.5;
 /** Velocity threshold (px) — snap toward the direction of the gesture */
 const SNAP_VELOCITY_THRESHOLD = 50;
 /**
- * Hold (ms) before a keyboard-sized viewport grow is applied on web.
- * Moving focus between two sheet fields makes mobile browsers report
- * a transient keyboard hide/show pair; applying the grow at once
- * bounces the sheet down and back up on every field switch.
+ * Hold (ms) before a keyboard-sized viewport grow is applied on web,
+ * while focus is still on an editable element. Moving focus between
+ * two sheet fields makes mobile browsers report a transient keyboard
+ * hide/show pair; applying the grow at once bounces the sheet down
+ * and back up on every field switch. Real dismissals blur first, so
+ * they bypass the hold and the sheet rides down with the keyboard.
  */
 const VIEWPORT_GROW_SETTLE_MS = 300;
+
+const EDITABLE_SELECTOR = 'input, textarea, [contenteditable="true"]';
 /**
  * Grows at or below this (px) bypass the hold: keyboard layout swaps
  * (numeric to text) and suggestion-bar toggles resize the keyboard by
@@ -225,14 +229,17 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
     // sheet never sits behind the keyboard and keyboard layout swaps
     // track fluidly. Keyboard-sized grows are held briefly on web
     // (see VIEWPORT_GROW_SETTLE_MS) and dropped if the keyboard
-    // re-claims the space first. Native applies grows directly:
-    // adjustResize resizes the WebView once per keyboard event with
-    // no transient.
+    // re-claims the space first, but only while an editable element
+    // still has focus: a blurred grow is a real dismissal and must
+    // track the keyboard down without the hang. Native applies grows
+    // directly: adjustResize resizes the WebView once per keyboard
+    // event with no transient.
     const readViewport = () => {
       const nextHeight = window.visualViewport?.height ?? window.innerHeight;
       if (
         !Capacitor.isNativePlatform() &&
-        nextHeight - appliedHeight > VIEWPORT_SMALL_GROW_PX
+        nextHeight - appliedHeight > VIEWPORT_SMALL_GROW_PX &&
+        (document.activeElement?.matches(EDITABLE_SELECTOR) ?? false)
       ) {
         growTimer ??= setTimeout(() => {
           growTimer = undefined;
@@ -260,12 +267,9 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       const target = event.target;
       if (!(target instanceof HTMLElement)) return;
       if (!wrapperRef.current?.contains(target)) return;
-      if (!target.matches('input, textarea, [contenteditable="true"]')) return;
+      if (!target.matches(EDITABLE_SELECTOR)) return;
       const from = event.relatedTarget;
-      if (
-        from instanceof HTMLElement &&
-        from.matches('input, textarea, [contenteditable="true"]')
-      ) {
+      if (from instanceof HTMLElement && from.matches(EDITABLE_SELECTOR)) {
         // Field switch: keyboard already up, sheet already lifted.
         return;
       }
@@ -650,7 +654,12 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
           leave="transition-opacity ease-m3-emphasized-accelerate duration-200"
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
-          className="absolute inset-0 bg-black/60 pointer-events-auto z-0"
+          // min-h-[100lvh] keeps the scrim covering the whole screen
+          // while the wrapper is keyboard-shrunk; with inset-0 alone
+          // the region below the wrapper showed the raw page during
+          // keyboard transitions (the post-dismissal hang read as the
+          // sheet re-entering over a naked wallet).
+          className="absolute inset-0 min-h-[100lvh] bg-black/60 pointer-events-auto z-0"
           onClick={onClose}
         />
       )}

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -44,12 +44,20 @@ const SNAP_VELOCITY_THRESHOLD = 50;
  */
 const VIEWPORT_GROW_SETTLE_MS = 200;
 
-// Glide between viewport rects: keyboard and pan changes arrive as
-// single step events (on native the WebView resize only reaches the
-// page near the end of the IME animation) and an instant jump reads
-// as a teleport.
-const VIEWPORT_TRANSITION =
-  'top 200ms cubic-bezier(0.2, 0.0, 0, 1.0), height 200ms cubic-bezier(0.2, 0.0, 0, 1.0)';
+// Glide between viewport heights: keyboard changes arrive as single
+// step events (on native the WebView resize only reaches the page
+// near the end of the IME animation) and an instant jump reads as a
+// teleport.
+const VIEWPORT_TRANSITION = 'height 200ms cubic-bezier(0.2, 0.0, 0, 1.0)';
+
+/**
+ * First-focus keyboard estimate as a fraction of the viewport, used
+ * by the web pre-lift when no measured delta is cached yet. Slight
+ * overshoot is fine (the sheet floats briefly until the real shrink
+ * lands); undershoot risks a browser pan. 0.42 covers typical
+ * portrait keyboards with their suggestion bars.
+ */
+const KEYBOARD_ESTIMATE_FRACTION = 0.42;
 
 // Viewport shrink the keyboard caused the last time it opened
 // (survives sheet remounts). Consumed by two pre-positioning paths:
@@ -151,14 +159,10 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   const [viewportHeight, setViewportHeight] = useState<number>(() => {
     return window.visualViewport?.height ?? window.innerHeight;
   });
-  // Offset of the visual viewport from the document top. Mobile web
-  // browsers pan the visual viewport (pageTop > 0) to reveal a focused
-  // input the incoming keyboard would cover; the sheet must follow that
-  // pan or it floats above the keyboard by the pan amount (#219).
-  // Always 0 on native: adjustResize shrinks the WebView instead.
-  const [viewportTop, setViewportTop] = useState<number>(() => {
-    return window.visualViewport?.pageTop ?? 0;
-  });
+  // No pan tracking: browser focus panning is neutralized globally by
+  // webViewportManager's counter-translate on #root (web) and never
+  // happens under adjustResize (native), so anchoring at top 0 always
+  // lines the wrapper bottom up with the keyboard top.
 
   const dragging = useRef(false);
   const startY = useRef(0);
@@ -189,7 +193,6 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       const reference = preLiftBase ?? appliedHeight;
       appliedHeight = window.visualViewport?.height ?? window.innerHeight;
       setViewportHeight(appliedHeight);
-      setViewportTop(window.visualViewport?.pageTop ?? 0);
 
       if (!Capacitor.isNativePlatform() && reference - appliedHeight > 150) {
         // A keyboard-sized shrink landed: remember it for the next
@@ -242,7 +245,6 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
     // desktop browsers).
     const onFocusIn = (event: FocusEvent) => {
       if (Capacitor.isNativePlatform()) return;
-      if (lastKeyboardDelta === undefined) return;
       const target = event.target;
       if (!(target instanceof HTMLElement)) return;
       if (!wrapperRef.current?.contains(target)) return;
@@ -259,7 +261,18 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       // Viewport already keyboard-shrunk relative to the layout
       // viewport: pre-lifting again would double-shrink.
       if (current < document.documentElement.clientHeight - 50) return;
-      const lifted = current - lastKeyboardDelta;
+      // On the first focus of a session there is no measured delta
+      // yet; estimate one on touch devices so even that focus opens
+      // without a browser pan. Pointer-fine devices (desktop) skip
+      // the estimate: a soft keyboard is unlikely and the revert
+      // would bounce the sheet on every focus.
+      const delta =
+        lastKeyboardDelta ??
+        (window.matchMedia('(pointer: coarse)').matches
+          ? Math.round(current * KEYBOARD_ESTIMATE_FRACTION)
+          : undefined);
+      if (delta === undefined) return;
+      const lifted = current - delta;
       if (lifted <= 0) return;
       preLiftBase = current;
       appliedHeight = lifted;
@@ -595,13 +608,13 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       unmount={false}
       afterLeave={afterLeave}
       as="div"
-      // No overflow-hidden: the keyboard bleed below must paint
-      // outside the wrapper, and the panel only ever animates
-      // downward out of it, into keyboard-covered or off-screen
-      // space (ancestors clip at the page bounds).
-      className="absolute inset-x-0 z-50 flex flex-col justify-end pointer-events-none"
+      // No overflow-hidden: the card's keyboard skirt (index.css,
+      // html.keyboard-visible) must paint below the wrapper, and the
+      // panel only ever animates downward out of it, into
+      // keyboard-covered or off-screen space (ancestors clip at the
+      // page bounds).
+      className="absolute inset-x-0 top-0 z-50 flex flex-col justify-end pointer-events-none"
       style={{
-        top: `${viewportTop}px`,
         height: `${viewportHeight}px`,
         transition: VIEWPORT_TRANSITION,
       }}
@@ -682,17 +695,6 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
           return child;
         })}
       </TransitionChild>
-      {/* Card-surface bleed below the sheet footer. iOS Safari can
-          over-subtract the keyboard from visualViewport.height or
-          restore its focus pan without firing an event, exposing a
-          band of the page behind between the sheet and the keyboard.
-          The bleed paints sheet surface across that band; with an
-          accurate viewport it sits behind the keyboard or past the
-          page bounds, where ancestors clip it. */}
-      <div
-        aria-hidden
-        className={`absolute top-full inset-x-0 mx-auto w-full ${maxWidthClass} h-40 bg-spark-surface pointer-events-auto`}
-      />
     </Transition>
   );
 };

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -37,12 +37,19 @@ const OVER_DRAG_RESISTANCE = 2.5;
 /** Velocity threshold (px) — snap toward the direction of the gesture */
 const SNAP_VELOCITY_THRESHOLD = 50;
 /**
- * Hold (ms) before a viewport grow is applied on web. Moving focus
- * between two sheet fields makes mobile browsers report a transient
- * keyboard hide/show pair; applying the grow at once bounces the
- * sheet down and back up on every field switch.
+ * Hold (ms) before a keyboard-sized viewport grow is applied on web.
+ * Moving focus between two sheet fields makes mobile browsers report
+ * a transient keyboard hide/show pair; applying the grow at once
+ * bounces the sheet down and back up on every field switch.
  */
-const VIEWPORT_GROW_SETTLE_MS = 200;
+const VIEWPORT_GROW_SETTLE_MS = 300;
+/**
+ * Grows at or below this (px) bypass the hold: keyboard layout swaps
+ * (numeric to text) and suggestion-bar toggles resize the keyboard by
+ * less than this and should track fluidly, while real dismissals and
+ * switch transients always exceed it.
+ */
+const VIEWPORT_SMALL_GROW_PX = 150;
 
 // Glide between viewport heights: keyboard changes arrive as single
 // step events (on native the WebView resize only reaches the page
@@ -214,14 +221,19 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       }
     };
 
-    // Shrinks and pan changes apply immediately so the sheet never
-    // sits behind the keyboard. Grows are held briefly on web (see
-    // VIEWPORT_GROW_SETTLE_MS) and dropped if the keyboard re-claims
-    // the space first. Native applies grows directly: adjustResize
-    // resizes the WebView once per keyboard event with no transient.
+    // Shrinks, pan changes, and small grows apply immediately so the
+    // sheet never sits behind the keyboard and keyboard layout swaps
+    // track fluidly. Keyboard-sized grows are held briefly on web
+    // (see VIEWPORT_GROW_SETTLE_MS) and dropped if the keyboard
+    // re-claims the space first. Native applies grows directly:
+    // adjustResize resizes the WebView once per keyboard event with
+    // no transient.
     const readViewport = () => {
       const nextHeight = window.visualViewport?.height ?? window.innerHeight;
-      if (!Capacitor.isNativePlatform() && nextHeight > appliedHeight) {
+      if (
+        !Capacitor.isNativePlatform() &&
+        nextHeight - appliedHeight > VIEWPORT_SMALL_GROW_PX
+      ) {
         growTimer ??= setTimeout(() => {
           growTimer = undefined;
           apply();

--- a/src/features/receive/AmountPanel.tsx
+++ b/src/features/receive/AmountPanel.tsx
@@ -189,8 +189,11 @@ const AmountPanel: React.FC<AmountPanelProps> = ({
             </div>
           </div>
 
-          {/* Quick amount buttons */}
-          <div className="flex gap-2">
+          {/* Quick amount buttons. Hidden while the native keyboard is
+              up: this is the tallest sheet form, and with the row kept
+              the amount/description fields get pushed into inner
+              scrolling, which makes focus switches jump. */}
+          <div className="flex gap-2 hide-on-keyboard">
             {quickAmounts.map((quickAmount) => (
               <button
                 key={quickAmount}

--- a/src/features/receive/LightningAddressDisplay.tsx
+++ b/src/features/receive/LightningAddressDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import type { LightningAddressInfo } from '@breeztech/breez-sdk-spark';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import { SimpleAlert } from '../../components/AlertCard';
@@ -53,23 +53,6 @@ const EditingForm: React.FC<EditingFormProps> = ({
   onCancel,
   onSave,
 }) => {
-  const buttonsRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-
-  // Scroll buttons into view when keyboard opens
-  useEffect(() => {
-    const handleFocus = () => {
-      // Small delay to let keyboard animate
-      setTimeout(() => {
-        buttonsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-      }, 300);
-    };
-
-    const input = inputRef.current;
-    input?.addEventListener('focus', handleFocus);
-    return () => input?.removeEventListener('focus', handleFocus);
-  }, []);
-
   return (
     <div className="pt-2 space-y-5">
       {/* Header with icon */}
@@ -86,7 +69,6 @@ const EditingForm: React.FC<EditingFormProps> = ({
       <div className="space-y-4">
         <div className="flex items-center bg-spark-dark border border-spark-border rounded-xl overflow-hidden focus-within:border-spark-primary transition-all">
           <textarea
-            ref={inputRef}
             value={editValue}
             onChange={(e) => onEditValueChange(e.target.value.toLowerCase().replace(/[^a-z0-9\n]/g, '').replace(/\n/g, ''))}
             onKeyDown={async (e) => {
@@ -125,7 +107,7 @@ const EditingForm: React.FC<EditingFormProps> = ({
       </div>
 
       {/* Action buttons */}
-      <div ref={buttonsRef} className="flex gap-3 justify-center pt-2 pb-4">
+      <div className="flex gap-3 justify-center pt-2 pb-4">
         <SecondaryButton onClick={onCancel} className="flex-1">
           Cancel
         </SecondaryButton>

--- a/src/index.css
+++ b/src/index.css
@@ -205,6 +205,14 @@ body {
   flex-direction: column;
 }
 
+/* Collapse non-essential rows while the soft keyboard is up so tall
+   bottom-sheet forms fit above it without inner scrolling. Native
+   only: main.tsx toggles `keyboard-visible` on <html> from the
+   @capacitor/keyboard events; web never sets the class. */
+html.keyboard-visible .hide-on-keyboard {
+  display: none;
+}
+
 /* ============================================
    ATMOSPHERIC BACKGROUND
    ============================================ */

--- a/src/index.css
+++ b/src/index.css
@@ -206,9 +206,9 @@ body {
 }
 
 /* Collapse non-essential rows while the soft keyboard is up so tall
-   bottom-sheet forms fit above it without inner scrolling. Native
-   only: main.tsx toggles `keyboard-visible` on <html> from the
-   @capacitor/keyboard events; web never sets the class. */
+   bottom-sheet forms fit above it without inner scrolling. The
+   `keyboard-visible` class on <html> comes from main.tsx (native,
+   via @capacitor/keyboard) or webViewportManager (web). */
 html.keyboard-visible .hide-on-keyboard {
   display: none;
 }
@@ -793,6 +793,17 @@ video::-webkit-media-controls-panel {
   width: 100%;
   padding: 0.75em 1.5em 1em 1.5em;
   padding-bottom: calc(1em + env(safe-area-inset-bottom, 0px));
+}
+
+/* While the soft keyboard is up, extend the card 160px below its
+   footer; the negative margin cancels the layout shift so only the
+   painted box grows. Covers the band iOS Safari can expose between
+   the sheet and the keyboard when visualViewport.height
+   over-subtracts around the accessory bar. Being part of the card,
+   it always matches its surface and moves with it. */
+html.keyboard-visible .bottom-sheet-card {
+  padding-bottom: calc(1em + env(safe-area-inset-bottom, 0px) + 160px);
+  margin-bottom: -160px;
 }
 
 .bottom-sheet-card-bordered {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -55,7 +55,12 @@ if (Capacitor.isNativePlatform()) {
   // The `void` on each addListener suppresses the unhandled-promise
   // warning; we don't store the handle because main.tsx runs once at
   // startup and the listener lifetime is the app lifetime.
+  let keyboardHideClassTimer: ReturnType<typeof setTimeout> | null = null;
   void Keyboard.addListener('keyboardWillShow', (info) => {
+    if (keyboardHideClassTimer) {
+      clearTimeout(keyboardHideClassTimer);
+      keyboardHideClassTimer = null;
+    }
     document.documentElement.style.setProperty(
       '--keyboard-height',
       `${info.keyboardHeight}px`,
@@ -107,8 +112,14 @@ if (Capacitor.isNativePlatform()) {
     });
   });
   void Keyboard.addListener('keyboardWillHide', () => {
-    document.documentElement.style.setProperty('--keyboard-height', '0px');
-    document.documentElement.classList.remove('keyboard-visible');
+    // Hold the class through the transient hide/show pair fired when
+    // focus moves between two fields; dropping it at once flaps
+    // hide-on-keyboard rows and the card skirt mid-switch.
+    keyboardHideClassTimer = setTimeout(() => {
+      keyboardHideClassTimer = null;
+      document.documentElement.style.setProperty('--keyboard-height', '0px');
+      document.documentElement.classList.remove('keyboard-visible');
+    }, 250);
     logger.debug(LogCategory.UI, 'Keyboard will hide');
   });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { Keyboard } from '@capacitor/keyboard';
 import App from './App';
 import './index.css';
 import { logger, LogCategory } from '@/services/logger';
+import { initWebViewportManager } from '@/utils/webViewportManager';
 import initBreezSDK from '@breeztech/breez-sdk-spark';
 
 // Allow JSON.stringify to handle BigInt values (e.g. payment amounts/fees from SDK)
@@ -111,6 +112,11 @@ if (Capacitor.isNativePlatform()) {
     logger.debug(LogCategory.UI, 'Keyboard will hide');
   });
 }
+
+// On web the same keyboard signals (`keyboard-visible` class +
+// `--keyboard-height` var) come from the viewport manager, which also
+// pins the page against browser focus panning. No-op on native.
+initWebViewportManager();
 
 /**
  * Fades out and removes the initial splash screen, resolving once the

--- a/src/utils/webViewportManager.test.ts
+++ b/src/utils/webViewportManager.test.ts
@@ -10,6 +10,11 @@ let vv: FakeVisualViewport;
 let root: HTMLDivElement;
 let layoutHeight: number;
 
+/** Polls past the keyboard-off hysteresis (~18 frames). */
+const pollUntilSettled = () => {
+  for (let i = 0; i < 25; i++) pollWebViewport();
+};
+
 beforeEach(() => {
   layoutHeight = document.documentElement.clientHeight;
   vv = new FakeVisualViewport();
@@ -27,7 +32,7 @@ afterEach(() => {
   // Drain module state back to baseline so tests stay independent.
   vv.height = layoutHeight;
   vv.pageTop = 0;
-  pollWebViewport();
+  pollUntilSettled();
   root.remove();
   Object.defineProperty(window, 'visualViewport', {
     value: undefined,
@@ -55,9 +60,31 @@ describe('pollWebViewport', () => {
     expect(html.style.getPropertyValue('--keyboard-height')).toBe('320px');
 
     vv.height = layoutHeight;
-    pollWebViewport();
+    pollUntilSettled();
     expect(html.classList.contains('keyboard-visible')).toBe(false);
     expect(html.style.getPropertyValue('--keyboard-height')).toBe('0px');
+  });
+
+  it('holds the keyboard-visible class through a transient hide', () => {
+    const html = document.documentElement;
+
+    vv.height = layoutHeight - 320;
+    pollWebViewport();
+    expect(html.classList.contains('keyboard-visible')).toBe(true);
+
+    // Focus switch: the browser reports a momentary full-height
+    // viewport. A few frames must not drop the class.
+    vv.height = layoutHeight;
+    pollWebViewport();
+    pollWebViewport();
+    expect(html.classList.contains('keyboard-visible')).toBe(true);
+
+    // Keyboard re-shows with a different layout: class stays on and
+    // the published height updates.
+    vv.height = layoutHeight - 280;
+    pollWebViewport();
+    expect(html.classList.contains('keyboard-visible')).toBe(true);
+    expect(html.style.getPropertyValue('--keyboard-height')).toBe('280px');
   });
 
   it('reports activity while an editable element is focused', () => {

--- a/src/utils/webViewportManager.test.ts
+++ b/src/utils/webViewportManager.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { pollWebViewport } from './webViewportManager';
+
+class FakeVisualViewport extends EventTarget {
+  height = 0;
+  pageTop = 0;
+}
+
+let vv: FakeVisualViewport;
+let root: HTMLDivElement;
+let layoutHeight: number;
+
+beforeEach(() => {
+  layoutHeight = document.documentElement.clientHeight;
+  vv = new FakeVisualViewport();
+  vv.height = layoutHeight;
+  Object.defineProperty(window, 'visualViewport', {
+    value: vv,
+    configurable: true,
+  });
+  root = document.createElement('div');
+  root.id = 'root';
+  document.body.appendChild(root);
+});
+
+afterEach(() => {
+  // Drain module state back to baseline so tests stay independent.
+  vv.height = layoutHeight;
+  vv.pageTop = 0;
+  pollWebViewport();
+  root.remove();
+  Object.defineProperty(window, 'visualViewport', {
+    value: undefined,
+    configurable: true,
+  });
+});
+
+describe('pollWebViewport', () => {
+  it('counter-translates #root by the visual viewport pan', () => {
+    vv.pageTop = 280;
+    pollWebViewport();
+    expect(root.style.transform).toBe('translateY(280px)');
+
+    vv.pageTop = 0;
+    pollWebViewport();
+    expect(root.style.transform).toBe('');
+  });
+
+  it('mirrors the native keyboard signals on <html>', () => {
+    const html = document.documentElement;
+
+    vv.height = layoutHeight - 320;
+    pollWebViewport();
+    expect(html.classList.contains('keyboard-visible')).toBe(true);
+    expect(html.style.getPropertyValue('--keyboard-height')).toBe('320px');
+
+    vv.height = layoutHeight;
+    pollWebViewport();
+    expect(html.classList.contains('keyboard-visible')).toBe(false);
+    expect(html.style.getPropertyValue('--keyboard-height')).toBe('0px');
+  });
+
+  it('reports activity while an editable element is focused', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    expect(pollWebViewport()).toBe(true);
+
+    input.blur();
+    expect(pollWebViewport()).toBe(false);
+    input.remove();
+  });
+});

--- a/src/utils/webViewportManager.ts
+++ b/src/utils/webViewportManager.ts
@@ -20,6 +20,13 @@ import { Capacitor } from '@capacitor/core';
 const KEYBOARD_MIN_PX = 150;
 /** Idle frames (~1.5s) before the poll loop goes back to sleep. */
 const SLEEP_AFTER_IDLE_FRAMES = 90;
+/**
+ * Frames (~300ms) the keyboard must stay gone before the class drops.
+ * Moving focus between two fields fires a transient hide/show pair;
+ * dropping the class mid-switch flaps hide-on-keyboard rows and the
+ * card skirt on every switch.
+ */
+const KEYBOARD_OFF_FRAMES = 18;
 
 const EDITABLE_SELECTOR = 'input, textarea, [contenteditable="true"]';
 
@@ -27,6 +34,8 @@ let rafId: number | null = null;
 let idleFrames = 0;
 let appliedPageTop = 0;
 let keyboardVisible = false;
+let appliedKeyboardPx = 0;
+let keyboardOffFrames = 0;
 
 /**
  * One measure-and-apply step. Returns true while there is keyboard or
@@ -47,18 +56,27 @@ export function pollWebViewport(): boolean {
     }
   }
 
-  const kb = html.clientHeight - height > KEYBOARD_MIN_PX;
-  if (kb !== keyboardVisible) {
-    keyboardVisible = kb;
-    html.classList.toggle('keyboard-visible', kb);
-    html.style.setProperty(
-      '--keyboard-height',
-      kb ? `${Math.round(html.clientHeight - height)}px` : '0px',
-    );
+  const keyboardPx = Math.round(html.clientHeight - height);
+  if (keyboardPx > KEYBOARD_MIN_PX) {
+    keyboardOffFrames = 0;
+    if (!keyboardVisible || keyboardPx !== appliedKeyboardPx) {
+      keyboardVisible = true;
+      appliedKeyboardPx = keyboardPx;
+      html.classList.add('keyboard-visible');
+      html.style.setProperty('--keyboard-height', `${keyboardPx}px`);
+    }
+  } else if (keyboardVisible) {
+    keyboardOffFrames += 1;
+    if (keyboardOffFrames > KEYBOARD_OFF_FRAMES) {
+      keyboardVisible = false;
+      appliedKeyboardPx = 0;
+      html.classList.remove('keyboard-visible');
+      html.style.setProperty('--keyboard-height', '0px');
+    }
   }
 
   return (
-    kb ||
+    keyboardVisible ||
     pageTop !== 0 ||
     (document.activeElement?.matches(EDITABLE_SELECTOR) ?? false)
   );

--- a/src/utils/webViewportManager.ts
+++ b/src/utils/webViewportManager.ts
@@ -1,0 +1,99 @@
+import { Capacitor } from '@capacitor/core';
+
+/**
+ * Web counterpart of the native adjustResize keyboard model (#219).
+ *
+ * Mobile browsers overlay the soft keyboard and pan the visual
+ * viewport to reveal the caret, which visibly slides the whole page.
+ * iOS Safari also restores that pan without firing any resize or
+ * scroll event, so event-driven tracking always ends up stale.
+ *
+ * This manager pins the page instead: while an input is focused or
+ * the keyboard is up, an animation-frame poll counter-translates
+ * #root by visualViewport.pageTop, so content stays visually static
+ * no matter how the browser pans. It also mirrors the native
+ * keyboard signals from main.tsx on web: the `keyboard-visible`
+ * class and `--keyboard-height` var on <html>.
+ */
+
+/** Viewport shrink (px) below which we do not call it a keyboard. */
+const KEYBOARD_MIN_PX = 150;
+/** Idle frames (~1.5s) before the poll loop goes back to sleep. */
+const SLEEP_AFTER_IDLE_FRAMES = 90;
+
+const EDITABLE_SELECTOR = 'input, textarea, [contenteditable="true"]';
+
+let rafId: number | null = null;
+let idleFrames = 0;
+let appliedPageTop = 0;
+let keyboardVisible = false;
+
+/**
+ * One measure-and-apply step. Returns true while there is keyboard or
+ * pan activity that should keep the poll loop awake. Exported for
+ * tests; production calls it once per animation frame via the loop.
+ */
+export function pollWebViewport(): boolean {
+  const html = document.documentElement;
+  const height = window.visualViewport?.height ?? window.innerHeight;
+  const pageTop = window.visualViewport?.pageTop ?? 0;
+
+  if (pageTop !== appliedPageTop) {
+    appliedPageTop = pageTop;
+    const root = document.getElementById('root');
+    if (root) {
+      root.style.transform =
+        pageTop !== 0 ? `translateY(${pageTop}px)` : '';
+    }
+  }
+
+  const kb = html.clientHeight - height > KEYBOARD_MIN_PX;
+  if (kb !== keyboardVisible) {
+    keyboardVisible = kb;
+    html.classList.toggle('keyboard-visible', kb);
+    html.style.setProperty(
+      '--keyboard-height',
+      kb ? `${Math.round(html.clientHeight - height)}px` : '0px',
+    );
+  }
+
+  return (
+    kb ||
+    pageTop !== 0 ||
+    (document.activeElement?.matches(EDITABLE_SELECTOR) ?? false)
+  );
+}
+
+function loop(): void {
+  if (pollWebViewport()) {
+    idleFrames = 0;
+  } else {
+    idleFrames += 1;
+  }
+  if (idleFrames > SLEEP_AFTER_IDLE_FRAMES) {
+    rafId = null;
+    return;
+  }
+  rafId = requestAnimationFrame(loop);
+}
+
+function wake(): void {
+  idleFrames = 0;
+  if (rafId === null) {
+    rafId = requestAnimationFrame(loop);
+  }
+}
+
+/**
+ * Start the manager (web only; no-op on native, where adjustResize
+ * resizes the WebView and no panning exists). The listeners only wake
+ * the poll loop; all state changes flow through pollWebViewport so
+ * event-less changes are caught while the loop is awake.
+ */
+export function initWebViewportManager(): void {
+  if (Capacitor.isNativePlatform()) return;
+  document.addEventListener('focusin', wake);
+  window.visualViewport?.addEventListener('resize', wake);
+  window.visualViewport?.addEventListener('scroll', wake);
+  wake();
+}


### PR DESCRIPTION
Fixes #219

## What

When a text field inside a bottom sheet is focused on mobile web, the sheet ends up floating roughly a keyboard height above the keyboard, with the page behind the backdrop visible through the gap.

The wrapper was anchored to the container top (`top-0`) and only tracked `visualViewport.height`. On the web the keyboard does not shrink the layout viewport (100dvh stays full screen); the browser instead shrinks the visual viewport **and pans it down** (`visualViewport.pageTop > 0`) to reveal the focused input, which sits near the bottom of the screen at focus time. The sheet ignored that pan, so on screen it floated `pageTop` px (close to a full keyboard height) above the keyboard.

This PR tracks `visualViewport.pageTop` from the same resize/scroll listeners and anchors the wrapper at that offset, so the sheet bottom stays glued to the top of the keyboard no matter how far the browser pans.

## Investigation notes (relation to the glow-app keyboard fix)

The suspicion was that the glow-app Android keyboard fix (breez/glow-app#5: `adjustResize` + Keyboard plugin config + the two patch-package patches) leaked into the web build. It did not:

- All native pieces live in the glow-app repo, and the `@capacitor/keyboard` listeners in `BottomSheet.tsx` are gated behind `Capacitor.isNativePlatform()`. None of it runs on web.
- The `visualViewport`-driven sheet sizing itself predates the native work: it was added for the **web** in #103 to fix #71 ("Bottom sheet content not visible when typing"). Gating it off on web would reopen #71, so the fix here corrects the web anchoring instead of removing it.
- Native behavior is unchanged by this PR: under `adjustResize` the WebView itself shrinks, layout and visual viewports coincide, and `pageTop` is always 0. glow-app picks this up automatically on its next glow-web submodule bump; no glow-app change is needed.

## Testing

- New regression test (`BottomSheet.test.tsx`) with a fake `visualViewport`: wrapper follows pan + resize, and re-anchors on scroll-only changes.
- `npm run test` (44 tests), `npx tsc --noEmit`, and `npx eslint` on the touched files all pass.
