### PR TITLE
fix: stop onchain claims failing on iOS by keeping requests CORS-simple

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,15 @@ import App from './App';
 import './index.css';
 import { logger, LogCategory } from '@/services/logger';
 import { initWebViewportManager } from '@/utils/webViewportManager';
+import { installUserAgentStrippingFetch } from '@/utils/stripUserAgentFetch';
 import initBreezSDK from '@breeztech/breez-sdk-spark';
+
+// Strip the SDK's custom User-Agent from outgoing requests before the SDK
+// (or anything else) issues one. User-Agent is a forbidden fetch header
+// that some engines forward (WebKit/iOS, Firefox), tripping CORS
+// preflights on strict third-party hosts (blockstream, LNURL hosts). This
+// replaces the previous native HTTP routing (CapacitorHttp, now disabled).
+installUserAgentStrippingFetch();
 
 // Allow JSON.stringify to handle BigInt values (e.g. payment amounts/fees from SDK)
 (BigInt.prototype as unknown as { toJSON: () => string }).toJSON = function () {

--- a/src/utils/stripUserAgentFetch.ts
+++ b/src/utils/stripUserAgentFetch.ts
@@ -1,0 +1,54 @@
+const USER_AGENT = 'user-agent';
+
+/**
+ * Strip the SDK's custom User-Agent from outgoing fetch requests.
+ *
+ * The Breez Spark SDK's shared reqwest client sets a
+ * "breez-sdk-spark/<version>" User-Agent. User-Agent is a forbidden fetch
+ * header the browser owns: Chromium drops the author value, but Firefox
+ * forwards it (failing CORS preflights on strict hosts such as Flashnet)
+ * and WebKit/iOS forwards it (blockstream's onchain-claim preflight 404s).
+ * Removing it before the request leaves the WebView keeps every
+ * cross-origin request CORS-simple on all engines, so the SDK's chain and
+ * operator calls work over plain fetch with no native HTTP routing
+ * (CapacitorHttp) needed.
+ *
+ * Call once, before the SDK issues any request.
+ */
+export function installUserAgentStrippingFetch(): void {
+  const originalFetch = window.fetch.bind(window);
+
+  // Standalone Headers carry the unguarded "none" header guard, so they
+  // can both read a forwarded user-agent and be rebuilt without one. A
+  // request-guarded Headers would hide or keep it depending on the engine.
+  const withoutUserAgent = (
+    base: Headers | undefined,
+    overrides: HeadersInit | undefined,
+  ): Headers | null => {
+    const merged = new Headers(base ?? undefined);
+    if (overrides) {
+      new Headers(overrides).forEach((value, key) => merged.set(key, value));
+    }
+    if (!merged.has(USER_AGENT)) return null;
+    const clean = new Headers();
+    merged.forEach((value, key) => {
+      if (key.toLowerCase() !== USER_AGENT) clean.set(key, value);
+    });
+    return clean;
+  };
+
+  window.fetch = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const base = input instanceof Request ? input.headers : undefined;
+    const clean = withoutUserAgent(base, init?.headers);
+    if (!clean) return originalFetch(input, init);
+    // Reconstruct with cleaned headers. For a bare Request (the reqwest
+    // path) this preserves method / url / body and only swaps headers.
+    if (input instanceof Request && !init) {
+      return originalFetch(new Request(input, { headers: clean }));
+    }
+    return originalFetch(input, { ...init, headers: clean });
+  };
+}


### PR DESCRIPTION
## What

Removes a custom identification header that the SDK attaches to its outgoing network requests, before those requests leave the app.

## Why

On iOS (and Firefox) that header quietly upgrades an otherwise simple cross-origin request into a preflighted one. Some of the Bitcoin and Lightning service hosts Glow talks to reject that preflight, which surfaced as onchain deposits that could not be claimed. Stripping the header keeps every request simple across all browser engines, fixing the claim failure and any similar host that is strict about cross-origin headers.

This is the narrow, correct version of an earlier, broader workaround that routed all traffic through native networking. That approach also proxied the wallet's operator traffic, which did not round-trip faithfully and broke Lightning invoice and Bitcoin address generation on iOS. The matching app-side change that turns the old native routing off ships in the glow-app wrapper.

## Test plan (needs a real device)

- On iOS, claim an onchain deposit and confirm it succeeds.
- On iOS, confirm Lightning invoice and Bitcoin address generation still work.

Closes #228
