### PR TITLE
Handle BIP21 bitcoin: URIs in the send flow

### DIFF
--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -70,6 +70,13 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
     onClose();
   };
 
+  // Back to the input step from a step that surfaces a prepare/amount error;
+  // clear it so the stale message doesn't follow the user onto the input screen.
+  const backToInput = () => {
+    send.clearError();
+    send.setCurrentStep('input');
+  };
+
   const dialogTitle = send.currentStep === 'input'
     ? 'Send'
     : getPaymentMethodName(send.paymentInput);
@@ -156,7 +163,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                 tokenBalance={send.tokenBalance}
                 isLoading={send.isLoading}
                 error={send.error}
-                onBack={() => send.setCurrentStep('input')}
+                onBack={backToInput}
                 onNext={send.onAmountNext}
               />
             )}
@@ -234,7 +241,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     error={send.error}
                     isLoading={false}
                     disableConfirm
-                    onBack={() => send.setCurrentStep('input')}
+                    onBack={backToInput}
                     onConfirm={() => {}}
                   />
                 )}

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -174,7 +174,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     conversionEstimate={send.prepareResponse.conversionEstimate}
                     balanceSats={send.balanceSats}
                     tokenBalance={send.tokenBalance}
-                    onBack={() => send.setCurrentStep('amount')}
+                    onBack={() => send.setCurrentStep(send.amountFixed ? 'input' : 'amount')}
                     onSend={send.handleSend}
                   />
                 )}

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -94,10 +94,8 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
   // Prepare can fail before producing a response (e.g. insufficient funds on a
   // fixed-amount payment). With no response and no LNURL workflow to render, show
   // the error on the confirm step with the send action disabled, rather than a
-  // blank step. `amount` holds the attempted sats for the fixed-amount path.
-  const prepareFailed =
-    send.currentStep === 'workflow' && !send.prepareResponse && !lnurlPayDetails && !lnurlAuthDetails && !!send.error;
-  const attemptedAmountSats = /^\d+$/.test(send.amount) ? BigInt(send.amount) : null;
+  // blank step. Only read inside the workflow-step block below.
+  const prepareFailed = !send.prepareResponse && !lnurlPayDetails && !lnurlAuthDetails && !!send.error;
 
   return (
     <BottomSheetContainer isOpen={isOpen} onClose={handleClose} showBackdrop>
@@ -234,7 +232,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                 )}
                 {prepareFailed && (
                   <ConfirmStep
-                    amountSats={attemptedAmountSats}
+                    amountSats={/^\d+$/.test(send.amount) ? BigInt(send.amount) : null}
                     feesSat={null}
                     balanceSats={send.balanceSats}
                     tokenBalance={send.tokenBalance}

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -10,6 +10,7 @@ import SparkWorkflow from './workflows/SparkWorkflow';
 import LnurlWorkflow from './workflows/LnurlWorkflow';
 import LnurlAuthWorkflow from './workflows/LnurlAuthWorkflow';
 import AmountStep from './steps/AmountStep';
+import ConfirmStep from './steps/ConfirmStep';
 import ProcessingStep from './steps/ProcessingStep';
 import ResultStep from './steps/ResultStep';
 import ContactsSubView from './components/ContactsSubView';
@@ -82,6 +83,14 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
 
   const lnurlPayDetails = getLnurlPayRequestDetails(send.paymentInput);
   const lnurlAuthDetails = getLnurlAuthRequestDetails(send.paymentInput);
+
+  // Prepare can fail before producing a response (e.g. insufficient funds on a
+  // fixed-amount payment). With no response and no LNURL workflow to render, show
+  // the error on the confirm step with the send action disabled, rather than a
+  // blank step. `amount` holds the attempted sats for the fixed-amount path.
+  const prepareFailed =
+    send.currentStep === 'workflow' && !send.prepareResponse && !lnurlPayDetails && !lnurlAuthDetails && !!send.error;
+  const attemptedAmountSats = /^\d+$/.test(send.amount) ? BigInt(send.amount) : null;
 
   return (
     <BottomSheetContainer isOpen={isOpen} onClose={handleClose} showBackdrop>
@@ -214,6 +223,19 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     onAuth={async (requestData) => {
                       return await wallet.lnurlAuth(requestData);
                     }}
+                  />
+                )}
+                {prepareFailed && (
+                  <ConfirmStep
+                    amountSats={attemptedAmountSats}
+                    feesSat={null}
+                    balanceSats={send.balanceSats}
+                    tokenBalance={send.tokenBalance}
+                    error={send.error}
+                    isLoading={false}
+                    disableConfirm
+                    onBack={() => send.setCurrentStep('input')}
+                    onConfirm={() => {}}
                   />
                 )}
               </>

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -113,6 +113,13 @@ export function useSendPayment(): UseSendPaymentReturn {
 
     setIsLoading(true);
     setError(null);
+    // Re-evaluating a destination from scratch: drop the amount, fee choice, and
+    // prepare response from any previous attempt so a re-submitted input (e.g. the
+    // same URI with its amount removed) doesn't carry the old values forward.
+    setAmount('');
+    setFeesIncluded(false);
+    setAmountFixed(false);
+    setPrepareResponse(null);
 
     try {
       const parseResult = await wallet.parse(currentInput);

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -178,9 +178,11 @@ export function useSendPayment(): UseSendPaymentReturn {
       } else if (isPayableAmountType) {
         setAmountFixed(false);
         setCurrentStep('amount');
-      } else if (effective.type === 'lnurlPay' || effective.type === 'lightningAddress') {
-        setCurrentStep('workflow');
-      } else if (effective.type === 'lnurlAuth') {
+      } else if (
+        effective.type === 'lnurlPay' ||
+        effective.type === 'lightningAddress' ||
+        effective.type === 'lnurlAuth'
+      ) {
         setCurrentStep('workflow');
       } else {
         setError('Invalid payment destination');

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -23,6 +23,10 @@ export interface UseSendPaymentReturn {
   tokenBalance: bigint | undefined;
   feesIncluded: boolean;
   processingPhase: ProcessingPhase;
+  /** True when the destination carried its own amount (a BIP21 `amount` or a
+   *  bolt11's embedded amount), so the amount step was skipped. Lets the confirm
+   *  step send "back" to input instead of the amount step the user never saw. */
+  amountFixed: boolean;
   // Actions
   clearError: () => void;
   reset: () => void;
@@ -47,6 +51,7 @@ export function useSendPayment(): UseSendPaymentReturn {
   const [paymentResult, setPaymentResult] = useState<'success' | 'failure' | null>(null);
   const [feesIncluded, setFeesIncluded] = useState(false);
   const [processingPhase, setProcessingPhase] = useState<ProcessingPhase>('sending');
+  const [amountFixed, setAmountFixed] = useState(false);
 
   // Balance is read live from the wallet info context, which is auto-refreshed
   // by useBreezSdk on `synced`/`paymentSucceeded`/`claimedDeposits` events. We
@@ -66,6 +71,9 @@ export function useSendPayment(): UseSendPaymentReturn {
     feePolicy?: FeePolicy,
     tokenIdentifier?: string,
     conversionOptions?: ConversionOptions,
+    // Step to return to if prepare fails. Defaults to the amount step, but the
+    // fixed-amount path skips amount entry, so it falls back to input instead.
+    errorStep: SendStep = 'amount',
   ) => {
     if (amount <= 0n) {
       setError('Please enter a valid amount');
@@ -86,7 +94,7 @@ export function useSendPayment(): UseSendPaymentReturn {
     } catch (err) {
       logger.error(LogCategory.PAYMENT, 'Failed to prepare payment', { error: formatError(err) });
       setError(`Failed to prepare payment ${err instanceof Error ? err.message : 'Unknown error'}`);
-      setCurrentStep('amount');
+      setCurrentStep(errorStep);
     } finally {
       setIsLoading(false);
     }
@@ -104,20 +112,64 @@ export function useSendPayment(): UseSendPaymentReturn {
 
     try {
       const parseResult = await wallet.parse(currentInput);
-      const parsed: SendInput = { rawInput: currentInput.trim(), parsedInput: parseResult };
+
+      // Unwrap a BIP21 URI (bitcoin:<addr>?amount=&label=) to its underlying
+      // payment method. `paymentRequest` becomes the bare address/invoice sent to
+      // prepareSendPayment (the URI itself isn't a valid send request), while
+      // `rawInput` keeps the original text so the input field still shows it on
+      // back-navigation. The URI amount (sats) is used as the exact send amount.
+      let effective = parseResult;
+      let paymentRequest = currentInput;
+      let prefillAmountSat: number | undefined;
+      if (parseResult.type === 'bip21') {
+        const method = parseResult.paymentMethods.find(
+          (m) => m.type === 'bitcoinAddress' || m.type === 'sparkAddress' || m.type === 'bolt11Invoice',
+        );
+        if (!method) {
+          setError('Invalid payment destination');
+          setCurrentStep('input');
+          return;
+        }
+        effective = method;
+        if (method.type === 'bolt11Invoice') {
+          paymentRequest = method.invoice.bolt11;
+        } else if (method.type === 'bitcoinAddress' || method.type === 'sparkAddress') {
+          paymentRequest = method.address;
+        }
+        prefillAmountSat = parseResult.amountSat;
+      }
+
+      const parsed: SendInput = { rawInput: currentInput, paymentRequest, parsedInput: effective };
       setPaymentInput(parsed);
 
-      if (parseResult.type === 'bolt11Invoice' && parseResult.amountMsat && parseResult.amountMsat > 0) {
-        const sats = Math.floor(parseResult.amountMsat / 1000);
-        setAmount(String(sats));
-        await prepareSend(currentInput, BigInt(sats));
-      } else if (parseResult.type === 'bolt11Invoice') {
+      // A fixed amount is always denominated in sats and must be paid exactly: a
+      // bolt11 invoice's embedded amount, or a BIP21 `amount` parameter. Prepare
+      // directly with that sats amount and skip amount entry (the same flow used for
+      // amount-bearing bolt11 invoices). This also avoids the amount step's
+      // stable-balance token denomination, where a sats prefill would be read as a
+      // fiat value; the SDK applies any active stable-balance conversion to fund the
+      // exact sats output.
+      const invoiceSats =
+        effective.type === 'bolt11Invoice' && effective.amountMsat && effective.amountMsat > 0
+          ? Math.floor(effective.amountMsat / 1000)
+          : undefined;
+      const fixedSats =
+        invoiceSats ?? (prefillAmountSat && prefillAmountSat > 0 ? prefillAmountSat : undefined);
+      const isPayableAmountType =
+        effective.type === 'bolt11Invoice' ||
+        effective.type === 'bitcoinAddress' ||
+        effective.type === 'sparkAddress';
+
+      if (isPayableAmountType && fixedSats !== undefined) {
+        setAmountFixed(true);
+        setAmount(String(fixedSats));
+        await prepareSend(paymentRequest, BigInt(fixedSats), undefined, undefined, undefined, 'input');
+      } else if (isPayableAmountType) {
+        setAmountFixed(false);
         setCurrentStep('amount');
-      } else if (parseResult.type === 'bitcoinAddress' || parseResult.type === 'sparkAddress') {
-        setCurrentStep('amount');
-      } else if (parseResult.type === 'lnurlPay' || parseResult.type === 'lightningAddress') {
+      } else if (effective.type === 'lnurlPay' || effective.type === 'lightningAddress') {
         setCurrentStep('workflow');
-      } else if (parseResult.type === 'lnurlAuth') {
+      } else if (effective.type === 'lnurlAuth') {
         setCurrentStep('workflow');
       } else {
         setError('Invalid payment destination');
@@ -143,13 +195,13 @@ export function useSendPayment(): UseSendPaymentReturn {
     }
     setFeesIncluded(!!includeFees);
     await prepareSend(
-      paymentInput?.rawInput || '',
+      paymentInput?.paymentRequest || '',
       amount,
       includeFees ? 'feesIncluded' : undefined,
       tokenIdentifier,
       conversionOptions,
     );
-  }, [paymentInput?.rawInput, prepareSend]);
+  }, [paymentInput?.paymentRequest, prepareSend]);
 
   const handleSend = useCallback(async (options?: SendPaymentOptions) => {
     if (!prepareResponse) return;
@@ -263,6 +315,7 @@ export function useSendPayment(): UseSendPaymentReturn {
     setPaymentInput(null);
     setPaymentResult(null);
     setProcessingPhase('sending');
+    setAmountFixed(false);
   }, []);
 
   return {
@@ -277,6 +330,7 @@ export function useSendPayment(): UseSendPaymentReturn {
     tokenBalance,
     feesIncluded,
     processingPhase,
+    amountFixed,
     clearError: useCallback(() => setError(null), []),
     reset,
     processInput,

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -71,8 +71,9 @@ export function useSendPayment(): UseSendPaymentReturn {
     feePolicy?: FeePolicy,
     tokenIdentifier?: string,
     conversionOptions?: ConversionOptions,
-    // Step to return to if prepare fails. Defaults to the amount step, but the
-    // fixed-amount path skips amount entry, so it falls back to input instead.
+    // Step to return to if prepare fails. Defaults to the amount step; the
+    // fixed-amount path skips amount entry and passes 'workflow' so the error
+    // surfaces on the confirm step (with the send action disabled) instead.
     errorStep: SendStep = 'amount',
   ) => {
     if (amount <= 0n) {
@@ -94,6 +95,9 @@ export function useSendPayment(): UseSendPaymentReturn {
     } catch (err) {
       logger.error(LogCategory.PAYMENT, 'Failed to prepare payment', { error: formatError(err) });
       setError(`Failed to prepare payment ${err instanceof Error ? err.message : 'Unknown error'}`);
+      // Clear any stale response so the confirm step renders its prepare-failed
+      // fallback (error + disabled send) instead of an old success render.
+      setPrepareResponse(null);
       setCurrentStep(errorStep);
     } finally {
       setIsLoading(false);
@@ -163,7 +167,7 @@ export function useSendPayment(): UseSendPaymentReturn {
       if (isPayableAmountType && fixedSats !== undefined) {
         setAmountFixed(true);
         setAmount(String(fixedSats));
-        await prepareSend(paymentRequest, BigInt(fixedSats), undefined, undefined, undefined, 'input');
+        await prepareSend(paymentRequest, BigInt(fixedSats), undefined, undefined, undefined, 'workflow');
       } else if (isPayableAmountType) {
         setAmountFixed(false);
         setCurrentStep('amount');

--- a/src/features/send/steps/ConfirmStep.tsx
+++ b/src/features/send/steps/ConfirmStep.tsx
@@ -18,11 +18,14 @@ export interface ConfirmStepProps {
   tokenBalance?: bigint;
   error: string | null;
   isLoading: boolean;
+  /** Force the send action disabled regardless of the balance check, e.g. when
+   *  prepare failed and there is no response to send. */
+  disableConfirm?: boolean;
   onBack?: () => void;
   onConfirm: () => void;
 }
 
-const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncluded, conversionEstimate, balanceSats, tokenBalance, error, isLoading, onBack, onConfirm }) => {
+const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncluded, conversionEstimate, balanceSats, tokenBalance, error, isLoading, disableConfirm, onBack, onConfirm }) => {
   const stableBalance = useStableBalance();
   const isTokenMode = stableBalance.isActive && !!stableBalance.displayConfig && !!conversionEstimate;
   const balance = useBalanceValidation(isTokenMode, undefined, balanceSats, tokenBalance);
@@ -85,7 +88,7 @@ const ConfirmStep: React.FC<ConfirmStepProps> = ({ amountSats, feesSat, feesIncl
         )}
         <PrimaryButton
           onClick={onConfirm}
-          disabled={isLoading || insufficientBalance}
+          disabled={isLoading || insufficientBalance || disableConfirm}
           className={onBack ? 'flex-1' : 'w-full'}
         >
           {isLoading ? (

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -19,6 +19,11 @@ export interface FeeOptions {
 }
 
 export interface SendInput {
+  /** Exactly what the user pasted or scanned. Shown in the input field so it
+   *  survives back-navigation (e.g. a full `bitcoin:...?amount=&label=` URI). */
   rawInput: string;
+  /** The destination passed to prepareSendPayment. Same as rawInput for bare
+   *  inputs; for a BIP21 URI it's the unwrapped bare address/invoice. */
+  paymentRequest: string;
   parsedInput: InputType;
 }


### PR DESCRIPTION
Closes #233

`parse()` returns a `bip21` `InputType` for a `bitcoin:<addr>?amount=&label=` URI, but the send flow only handled the leaf types, so these URIs failed with "Invalid payment destination" before reaching `prepareSendPayment`.

## Changes
- `processInput` now unwraps a `bip21` result to its underlying payment method and sends the bare address/invoice to `prepareSendPayment` (the URI itself isn't a valid send request).
- `SendInput` gains a `paymentRequest` field (the bare destination); `rawInput` stays the original pasted/scanned text, so the input field still shows the full URI on back-navigation.
- A fixed amount (a BIP21 `amount` or a bolt11's embedded amount) skips amount entry and prepares directly with the exact sats. This avoids the amount step's stable-balance token denomination (where a sats value would be misread as fiat) and preserves the exact requested amount; the SDK applies any active stable-balance conversion to fund it.
- Back from confirm, and the prepare-failure fallback, return to the input step rather than the amount step the user never saw.

## Notes
- Self-contained: works with the current vendored SDK (verified the bare address reaches the on-chain prepare path); no SDK change required.
- `tsc` and `eslint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)