### PR TITLE
fix(buy): open Cash App on native via AppLauncher; drop sheet-close redirect delay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@breeztech/breez-sdk-spark": "file:vendor/breeztech-breez-sdk-spark-v0.1.0.tgz",
         "@capacitor/app": "^8.1.0",
+        "@capacitor/app-launcher": "^8.0.1",
         "@capacitor/browser": "^8.0.3",
         "@capacitor/core": "^8.3.0",
         "@capacitor/filesystem": "^8.1.2",
@@ -333,6 +334,15 @@
     },
     "node_modules/@capacitor/app": {
       "version": "8.1.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/app-launcher": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/app-launcher/-/app-launcher-8.0.1.tgz",
+      "integrity": "sha512-23D8zi74sn7kxvISix8qYwgqdxGJN+4NImcNGvHen98LB1zb4eZfkJvFvp7pwntxGw4OjIE7yuf4wbzZxQHpog==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@breeztech/breez-sdk-spark": "file:vendor/breeztech-breez-sdk-spark-v0.1.0.tgz",
     "@capacitor/app": "^8.1.0",
+    "@capacitor/app-launcher": "^8.0.1",
     "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.3.0",
     "@capacitor/filesystem": "^8.1.2",

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -111,12 +111,6 @@ export interface BottomSheetContainerProps {
   fullHeight?: boolean;
   /** Whether to show a backdrop overlay */
   showBackdrop?: boolean;
-  /**
-   * Fires once the close animation finishes (react-modal-sheet's
-   * onCloseEnd). Never fires while the page is hidden (animations are
-   * paused), so any wait on it must be bounded by a timeout.
-   */
-  afterLeave?: () => void;
 }
 
 export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
@@ -128,7 +122,6 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   maxHeightVh = 100,
   fullHeight = false,
   showBackdrop = false,
-  afterLeave,
 }) => {
   const sheetRef = useRef<SheetRef>(null);
   const [contentPx, setContentPx] = useState<number | null>(null);
@@ -396,7 +389,6 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       ref={sheetRef}
       isOpen={isOpen}
       onClose={dismiss}
-      onCloseEnd={afterLeave}
       onOpenEnd={() => {
         fullyOpen.current = true;
         // Settle the position in case the keyboard resized the WebView

--- a/src/features/buy/BuyBitcoinDialog.tsx
+++ b/src/features/buy/BuyBitcoinDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React from 'react';
 import {
   BottomSheetContainer,
   BottomSheetCard,
@@ -52,19 +52,10 @@ const cashAppHeaderIcon = (
   </div>
 );
 
-/**
- * Upper bound on waiting for the sheet's 200ms leave transition:
- * afterLeave never fires in a hidden page, so the wait must be bounded.
- */
-const SHEET_LEAVE_WAIT_MS = 400;
-
 interface BuyBitcoinDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onBuyBitcoin: (
-    provider: BuyBitcoinProvider,
-    closeAndWaitForLeave?: () => Promise<void>,
-  ) => Promise<void>;
+  onBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
   network?: Network;
 }
 
@@ -76,54 +67,21 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
 }) => {
   const { showToast } = useToast();
 
-  const pendingLeaveWaiters = useRef<Array<() => void>>([]);
-
-  const handleAfterLeave = useCallback(() => {
-    const waiters = pendingLeaveWaiters.current;
-    pendingLeaveWaiters.current = [];
-    waiters.forEach((resolve) => resolve());
-  }, []);
-
-  // Close the sheet and wait out its leave transition so a buy redirect
-  // never navigates mid-close (#213). Races afterLeave against a timeout;
-  // skipped when the page is already hidden (pre-opened tab in front),
-  // where BottomSheetContainer's self-heal repairs the state on return.
-  const closeAndWaitForLeave = useCallback(() => {
-    onClose();
-    if (document.visibilityState === 'hidden') return Promise.resolve();
-    return new Promise<void>((resolve) => {
-      let settled = false;
-      const settle = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve();
-      };
-      const timer = setTimeout(settle, SHEET_LEAVE_WAIT_MS);
-      pendingLeaveWaiters.current.push(settle);
-    });
-  }, [onClose]);
-
-  const handleRedirectProvider = useCallback(
-    (provider: BuyBitcoinProvider) => onBuyBitcoin(provider, closeAndWaitForLeave),
-    [onBuyBitcoin, closeAndWaitForLeave],
-  );
-
   const buy = useBuyBitcoin({
     isOpen,
     network,
-    onSelectRedirectProvider: handleRedirectProvider,
-    closeAndWaitForLeave,
+    onSelectRedirectProvider: onBuyBitcoin,
+    onMobileRedirectComplete: onClose,
     onInvoicePaid: onClose,
   });
 
+  const handleSelect = async (provider: BuyBitcoinProvider) => {
+    await buy.selectProvider(provider);
+    if (provider === 'moonpay') onClose();
+  };
+
   return (
-    <BottomSheetContainer
-      isOpen={isOpen}
-      onClose={onClose}
-      showBackdrop
-      afterLeave={handleAfterLeave}
-    >
+    <BottomSheetContainer isOpen={isOpen} onClose={onClose} showBackdrop>
       <BottomSheetCard>
         {buy.step === 'select' && (
           <>
@@ -139,7 +97,7 @@ const BuyBitcoinDialog: React.FC<BuyBitcoinDialogProps> = ({
                 return (
                   <button
                     key={provider}
-                    onClick={() => void buy.selectProvider(provider)}
+                    onClick={() => handleSelect(provider)}
                     disabled={buy.redirectingProvider !== null}
                     className="w-full flex items-center gap-4 p-4 rounded-2xl border border-spark-border hover:border-spark-primary/40 hover:bg-spark-primary/5 transition-all text-left disabled:opacity-50"
                   >

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Capacitor } from '@capacitor/core';
-import { Browser } from '@capacitor/browser';
+import { AppLauncher } from '@capacitor/app-launcher';
 import type { Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '../../../contexts/WalletContext';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -174,7 +174,7 @@ export function useBuyBitcoin({
     // Mobile web: pre-open a blank tab synchronously in the tap gesture so
     // navigating it later doesn't trip popup blockers. Native must not do
     // this (or fall back to window.location.href): navigating the WebView
-    // to cash.app strands the user, so the URL goes to Browser.open instead.
+    // to cash.app strands the user.
     const isNative = Capacitor.isNativePlatform();
     const mobileTab = isMobile && !isNative ? window.open('', '_blank') : null;
 
@@ -182,7 +182,12 @@ export function useBuyBitcoin({
       const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats: amountSatsForSdk });
       setGeneratedAmountSats(amountSats);
       if (isNative) {
-        await Browser.open({ url: response.url });
+        // AppLauncher bridges to UIApplication.open, the only iOS API that
+        // hands an https universal link (cash.app/launch/...) off to the
+        // Cash App app. Browser.open (SFSafariViewController) only loads the
+        // web page: iOS suppresses universal-link handoff on a programmatic
+        // in-app-browser load. Falls back to Safari if Cash App is absent.
+        await AppLauncher.openUrl({ url: response.url });
         onMobileRedirectComplete();
       } else if (isMobile) {
         // Navigate immediately: the cash.app universal link only bounces

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -29,12 +29,8 @@ export interface UseBuyBitcoinOptions {
   network?: Network;
   /** Called for providers that redirect externally (MoonPay). */
   onSelectRedirectProvider: (provider: BuyBitcoinProvider) => Promise<void>;
-  /**
-   * Closes the dialog and resolves once the sheet's leave transition
-   * finishes (bounded). Navigating away earlier restores a stuck
-   * backdrop on return (#213).
-   */
-  closeAndWaitForLeave: () => Promise<void>;
+  /** Called after a mobile/native Cash App redirect; the caller closes the dialog. */
+  onMobileRedirectComplete: () => void;
   /** Called when the displayed QR invoice is paid; the caller typically closes the dialog. */
   onInvoicePaid: () => void;
 }
@@ -71,7 +67,7 @@ export function useBuyBitcoin({
   isOpen,
   network,
   onSelectRedirectProvider,
-  closeAndWaitForLeave,
+  onMobileRedirectComplete,
   onInvoicePaid,
 }: UseBuyBitcoinOptions): UseBuyBitcoinReturn {
   const sdk = useWallet();
@@ -185,18 +181,20 @@ export function useBuyBitcoin({
     try {
       const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats: amountSatsForSdk });
       setGeneratedAmountSats(amountSats);
-      if (isNative || isMobile) {
-        // Close and wait out the sheet's leave transition before
-        // navigating (#213). Tab-handle navigation and Browser.open have
-        // no user-activation deadline, so deferring them is safe.
-        await closeAndWaitForLeave();
-        if (isNative) {
-          await Browser.open({ url: response.url });
-        } else if (mobileTab) {
+      if (isNative) {
+        await Browser.open({ url: response.url });
+        onMobileRedirectComplete();
+      } else if (isMobile) {
+        // Navigate immediately: the cash.app universal link only bounces
+        // to the app inside the tap's user-activation window, so any await
+        // before this (e.g. a sheet-close animation) drops it to the web
+        // page.
+        if (mobileTab) {
           mobileTab.location.href = response.url;
         } else {
           window.location.href = response.url;
         }
+        onMobileRedirectComplete();
       } else {
         setCashAppUrl(response.url);
         setStep('qr');
@@ -208,7 +206,7 @@ export function useBuyBitcoin({
     } finally {
       setIsGenerating(false);
     }
-  }, [amountSats, isMobile, sdk, closeAndWaitForLeave]);
+  }, [amountSats, isMobile, sdk, onMobileRedirectComplete]);
 
   // Cash App URLs are `https://cash.app/launch/lightning/<bolt11>`. Extract the
   // invoice only while we're showing the QR so the bus subscription pauses

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -175,10 +175,7 @@ export interface BreezSdkActions {
   refreshWalletData: (showLoading?: boolean) => Promise<void>;
   fetchUnclaimedDeposits: () => Promise<void>;
   handleLogout: () => Promise<void>;
-  handleBuyBitcoin: (
-    provider: BuyBitcoinProvider,
-    closeAndWaitForLeave?: () => Promise<void>,
-  ) => Promise<void>;
+  handleBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
   clearError: () => void;
   dismissCelebration: () => void;
   subscribeToSdkEvents: (handler: SdkEventHandler) => SdkEventUnsubscribe;
@@ -829,10 +826,7 @@ export function useBreezSdk(
     }
   }, [connectWallet]);
 
-  const handleBuyBitcoin = useCallback(async (
-    provider: BuyBitcoinProvider,
-    closeAndWaitForLeave?: () => Promise<void>,
-  ) => {
+  const handleBuyBitcoin = useCallback(async (provider: BuyBitcoinProvider) => {
     if (!sdk) return;
     // CashApp requires an amount and is driven by the BuyBitcoinDialog amount step
     // (see useBuyBitcoin.generate), so this top-level handler only covers
@@ -853,9 +847,6 @@ export function useBreezSdk(
 
     try {
       const response = await sdk.buyBitcoin({ type: 'moonpay' });
-      // From the buy dialog: dismiss the sheet and let its leave
-      // transition finish before navigating (#213).
-      await closeAndWaitForLeave?.();
       if (isNative) {
         await Browser.open({ url: response.url });
       } else if (newTab) {

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -35,10 +35,7 @@ interface WalletPageProps {
   onOpenSettings: () => void;
   onOpenBackup: () => void;
   onOpenBuyProviders: () => void;
-  onBuyBitcoin: (
-    provider: BuyBitcoinProvider,
-    closeAndWaitForLeave?: () => Promise<void>,
-  ) => Promise<void>;
+  onBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
   network?: Network;
   onDepositChanged?: () => void;
 }


### PR DESCRIPTION
## Summary

Fixes two distinct Cash App buy-redirect regressions, plus removes the now-redundant sheet-sequencing machinery.

### 1. Native iOS: Cash App opened the website, not the app (regression from [22315a3](https://github.com/breez/glow-web/commit/22315a34531abd0803efa8cfe6563be4185b119c))

`22315a3` switched the native Cash App open to `Browser.open` (SFSafariViewController). Per Apple's docs, **programmatically loading a universal link into SFSafariViewController/WKWebView does not hand off to the app**, it renders the web page. So `cash.app/launch/lightning/<invoice>` loaded the 'Download Cash App' page with the invoice context lost (no purchase prompt) instead of opening the Cash App app.

Fix: native now uses `@capacitor/app-launcher` (`AppLauncher.openUrl` → iOS `UIApplication.open`), the one API that hands an `https` universal link off to its associated app. Falls back to Safari if Cash App isn't installed. MoonPay keeps `Browser.open` (web checkout, not a universal link).

### 2. Mobile Safari: redirect delay dropped the universal link (regression from 87538ac)

`87538ac` added `await closeAndWaitForLeave()` (~400ms) before navigating. On iOS the cash.app universal link only bounces to the app inside the tap's user-activation window, so the delay dropped it to the web page. Reverted to navigating the pre-opened tab immediately after the SDK responds (the known-good `2348b80` baseline). Also removes the now-dead `afterLeave` prop on `BottomSheetContainer` (the react-modal-sheet migration unmounts on close, so #213's frozen-leave can't occur).

## Platform behavior

- **Native (Capacitor)**: `AppLauncher.openUrl` → app handoff.
- **Mobile web**: pre-open blank tab in the gesture, navigate immediately after the SDK call.
- **Desktop web**: QR step, unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on touched files
- [x] **`npx cap sync ios` + native rebuild** (required for the new plugin to load)
- [ ] Native iOS with Cash App installed: Buy → Cash App opens with the invoice + purchase prompt
- [ ] Native iOS without Cash App: falls back to Safari
- [x] Mobile Safari: redirect still opens Cash App
- [x] Desktop web: QR step unchanged; MoonPay opens in-app browser (native) / new tab (web)

Not device-verified yet (reasoned from Apple's universal-link docs). Worth confirming Cash App's AASA still maps `/launch/lightning/*`.