### PR TITLE
fix(home): stop iOS Safari clipping the login logo glow

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,12 @@ const HomePage: React.FC<HomePageProps> = ({
   }, []);
 
   return (
-    <div className="h-full w-full flex flex-col bg-spark-dark relative overflow-hidden">
+    <div className="h-full w-full flex flex-col bg-spark-dark relative">
+      {/* No `overflow-hidden` on this root: it makes iOS Safari clip the
+          logo's composited glow (drop-shadow filter + blurred halo +
+          box-shadow dots) to a rectangle. The background effects are
+          already clipped by their own inner wrapper, and html/body/#root
+          clip at the viewport, so the page still can't scroll. */}
       {/* Background layer - extends behind all safe areas. Uses
           spark-dark (matched by the system bars via STATUS_BAR_DARK
           and the native splash background) so the landing surface


### PR DESCRIPTION
## Problem

On the login/landing page, the Glow logo's glow effect was clipped to a hard rectangle (the logo's 144px box) on mobile **iOS Safari**. It rendered correctly on desktop browsers, headless WebKit, and headed WebKit on macOS, so it only reproduced on real mobile Safari.

## Root cause

The glow is composed of layers that iOS Safari promotes to GPU compositing layers: the `drop-shadow` filter on the logo `<img>` and the `box-shadow` twinkle dots, which sit *outside* the logo box by design (`overflow: visible`). The blurred, animated halo next to the logo ([HomePage.tsx](../blob/main/src/pages/HomePage.tsx)) forces the wrapper onto its own compositing layer, and iOS then clips composited descendants to that box bounds, **ignoring `overflow: visible`**. Desktop/Chromium/WebKit-on-macOS rasterize without that GPU path, which is why it was mobile-Safari-only and invisible to every local/automated engine.

Confirmed by on-device A/B testing: the clip only appears with the blurred halo present, and disappears when the bleeding children are given their own GPU layers.

## Fix

Put the bleeding pieces on their own GPU layers with `translateZ(0)` so iOS gives each an independent, unclipped backing store:

- the logo `<img>` via an inline `transform: translateZ(0)`
- the twinkle dots via `translateZ(0)` added to the `twinkle-settle` keyframes (an inline transform would fight the scale animation, so it goes in the keyframes)

Two files, no layout or visual change on any other platform.

## Testing

- Verified fixed on a physical iPhone (iOS Safari), fresh load.
- A/B tested 4 candidate workarounds on-device to confirm this is the one that works (and that `translateZ`+`isolation` on the *parent* makes it worse).