### PR TITLE
fix(home): prevent iOS Safari from clipping the login logo glow

### DIFF
--- a/src/components/GlowLogo.tsx
+++ b/src/components/GlowLogo.tsx
@@ -53,6 +53,11 @@ const GlowLogo: React.FC<GlowLogoProps> = ({
         alt={alt}
         className={`w-full h-full object-contain ${imgClassName}`}
         onClick={onClick}
+        // translateZ(0) puts the drop-shadow on its own GPU layer so iOS
+        // Safari doesn't clip it to this box (overflow:visible is ignored
+        // for composited descendants when a blurred sibling forces the
+        // wrapper to composite).
+        style={{ transform: 'translateZ(0)' }}
       />
       {DOTS.map((dot, i) => (
         <span

--- a/src/index.css
+++ b/src/index.css
@@ -1159,25 +1159,28 @@ main {
   }
 }
 
+/* translateZ(0) keeps each star on its own GPU layer for the whole
+   animation so iOS Safari renders its box-shadow glow outside the logo
+   box instead of clipping it (see GlowLogo img for the same reason). */
 @keyframes twinkle-settle {
   0% {
     opacity: 0;
-    transform: scale(0);
+    transform: scale(0) translateZ(0);
   }
 
   25% {
     opacity: 1;
-    transform: scale(1.25);
+    transform: scale(1.25) translateZ(0);
   }
 
   45% {
     opacity: 1;
-    transform: scale(1);
+    transform: scale(1) translateZ(0);
   }
 
   100% {
     opacity: 0;
-    transform: scale(0.6);
+    transform: scale(0.6) translateZ(0);
   }
 }
 


### PR DESCRIPTION
Follow-up to #236, which merged the wrong commit. #236 only removed a redundant `overflow-hidden` from the HomePage root, which does **not** fix the clip (verified on-device: a fresh load still clipped). This PR adds the real fix.

## Root cause

iOS Safari clips GPU-composited descendants to their wrapper box, **ignoring `overflow: visible`**. The logo's glow (the `drop-shadow` filter on the `<img>` + the `box-shadow` twinkle dots) is meant to bleed outside the 144px logo box. The blurred, animated halo next to the logo forces the wrapper onto its own compositing layer, and iOS then clips the whole glow to a hard rectangle. Desktop browsers, headless WebKit, and even headed WebKit on macOS don't exercise that GPU path, so it only reproduced on real mobile Safari.

## Fix

Put the bleeding pieces on their own GPU layers with `translateZ(0)`:
- the logo `<img>` via an inline `transform: translateZ(0)`
- the twinkle dots via `translateZ(0)` in the `twinkle-settle` keyframes (an inline transform would fight the dots' scale animation)

## Testing

- Verified fixed on a physical iPhone (iOS Safari), fresh load.
- A/B tested 4 candidate workarounds on-device to confirm this is the one that works (`translateZ`+`isolation` on the *parent* made it worse).

## Note on #236

The `overflow-hidden` removal from #236 is already in main and is harmless (redundant: the background effects are clipped by their own inner wrapper, and `html/body/#root` clip at the viewport). Its commit message inaccurately claims it fixes the iOS clip. Reverting is optional — left as-is here to keep this PR minimal.