### PR TITLE
fix(web): lift bottom sheets above the soft keyboard on mobile browsers

### DIFF
--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -384,6 +384,26 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
     }
   }, [contentPx, isOpen, useContentSnap]);
 
+  // Chrome Android (HTTPS) sets overlaysContent = true via the
+  // VirtualKeyboard API, so the visual viewport never shrinks and the
+  // webViewportManager can't detect the keyboard. Drive the CSS var
+  // from the hook's state as well (uses the VK geometrychange event).
+  useEffect(() => {
+    if (IS_NATIVE || !isOpen) return;
+    const html = document.documentElement;
+    if (isKeyboardOpen && keyboardHeight > 0) {
+      html.style.setProperty('--sheet-kb-offset', `-${keyboardHeight}px`);
+      html.classList.add('keyboard-visible');
+    } else {
+      html.style.setProperty('--sheet-kb-offset', '0px');
+      html.classList.remove('keyboard-visible');
+    }
+    return () => {
+      html.style.setProperty('--sheet-kb-offset', '0px');
+      html.classList.remove('keyboard-visible');
+    };
+  }, [isOpen, isKeyboardOpen, keyboardHeight]);
+
   return (
     <Sheet
       ref={sheetRef}

--- a/src/index.css
+++ b/src/index.css
@@ -827,6 +827,19 @@ video::-webkit-media-controls-panel {
   background: var(--spark-border-light);
 }
 
+/* Web keyboard: lift the sheet above the soft keyboard.
+   --sheet-kb-offset is driven by the webViewportManager rAF poll.
+   !important overrides any inline transform from Framer Motion.
+   overflow:visible lets the container background extend past the root
+   clip boundary, covering the gap between the sheet and the keyboard
+   (iOS dvh/vh mismatch when the URL bar is visible). */
+.react-modal-sheet-root {
+  transform: translateY(var(--sheet-kb-offset, 0px)) !important;
+}
+html.keyboard-visible .react-modal-sheet-root {
+  overflow: visible !important;
+}
+
 .show-amount-panel-button {
   margin-bottom: 0.75em;
   cursor: pointer;

--- a/src/utils/webViewportManager.ts
+++ b/src/utils/webViewportManager.ts
@@ -64,6 +64,7 @@ export function pollWebViewport(): boolean {
       appliedKeyboardPx = keyboardPx;
       html.classList.add('keyboard-visible');
       html.style.setProperty('--keyboard-height', `${keyboardPx}px`);
+      html.style.setProperty('--sheet-kb-offset', `-${keyboardPx}px`);
     }
   } else if (keyboardVisible) {
     keyboardOffFrames += 1;
@@ -72,6 +73,7 @@ export function pollWebViewport(): boolean {
       appliedKeyboardPx = 0;
       html.classList.remove('keyboard-visible');
       html.style.setProperty('--keyboard-height', '0px');
+      html.style.setProperty('--sheet-kb-offset', '0px');
     }
   }
 


### PR DESCRIPTION
## Summary

- Drive `--sheet-kb-offset` CSS variable from the webViewportManager's rAF poll (every frame, no React state delay)
- Apply the offset via `!important` stylesheet rule on `.react-modal-sheet-root` to override Framer Motion's inline transform management
- Set `overflow: visible` on the sheet root when keyboard is visible so the container background extends past the clip boundary, covering the dvh/vh gap on iOS

## Context

Bottom sheets (react-modal-sheet) stayed behind the soft keyboard on iOS Safari/Chrome and Android Chrome. The library's root is a Framer Motion `motion.div` that silently drops `transform` values passed via the React `style` prop. Resizing the root to the visual viewport triggered ResizeObserver snap recalculation with a stale `y` motion value, making the sheet jump further behind the keyboard.

## Test plan

- [x] Open any bottom sheet with an input (Send, Receive) on iOS Safari
- [x] Tap the input field: sheet should lift above the keyboard immediately
- [x] Verify no transparent gap between sheet bottom and keyboard
- [x] Dismiss keyboard: sheet returns to normal position
- [x] Repeat on iOS Chrome and Android Chrome
- [x] Verify desktop browser is unaffected