### PR TITLE
fix(ui): raise ConfirmDialog above slide-in overlay pages

### DIFF
--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -569,7 +569,7 @@ export const ConfirmDialog: React.FC<{
       // transform, which makes position:fixed resolve relative to that
       // transformed ancestor and shoves the dialog off-screen whenever
       // the sheet is snapped or keyboard-lifted.
-      <div className="fixed inset-0 bg-black/85 backdrop-blur-md flex items-center justify-center z-50 p-4 transition-opacity duration-300">
+      <div className="fixed inset-0 bg-black/85 backdrop-blur-md flex items-center justify-center z-[70] p-4 transition-opacity duration-300">
         <DialogCard maxWidth="sm">
           <div className="text-center">
             <h3 className="font-display text-lg font-bold text-spark-text-primary mb-3">


### PR DESCRIPTION
## Problem

The switch-label confirm dialog on `LabelsPage` (and other confirms reached from Settings/Backup overlays) renders **behind** the visible page.

## Cause

`ConfirmDialog` portals to `document.body` at `z-50`, but `SlideInPage` (the slide-in overlay used for settings/backup pages) was raised to `z-60` to cover the side-menu drawer. Any confirm opened from inside one of those overlay pages now stacks below it.

## Fix

Bump the portaled `ConfirmDialog` overlay to `z-[70]`: above the `z-60` overlay/drawer layer, still below the `z-100` payment celebration.

## Other dialogs affected

`ConfirmDialog` is a single shared component, so this one change also fixes every other confirm reached from overlay pages: PasskeyManagementPage, PasskeyLocalStatePage, and StableBalanceFeeConfirm. No other portaled overlay was below z-60 (SideMenu z-50 is intentionally covered; Toasts and the z-100 celebration are unaffected).

## Test

- [ ] Settings → Passkey & Labels → Labels → switch a label: confirm dialog appears on top.