### PR TITLE
fix(send): read clipboard via native plugin on Capacitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/app": "^8.1.0",
         "@capacitor/app-launcher": "^8.0.1",
         "@capacitor/browser": "^8.0.3",
+        "@capacitor/clipboard": "^8.0.1",
         "@capacitor/core": "^8.3.0",
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/keyboard": "^8.0.3",
@@ -350,6 +351,15 @@
     },
     "node_modules/@capacitor/browser": {
       "version": "8.0.3",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/clipboard": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/clipboard/-/clipboard-8.0.1.tgz",
+      "integrity": "sha512-iOlbTi8MojKyLnYE+M27priXid7vHd0PlDwyHohPzkuQ8Rkp6q7ykwZmPEUD+OnU/Ink7Qw/pUOfKgraKmA6Eg==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@capacitor/app": "^8.1.0",
     "@capacitor/app-launcher": "^8.0.1",
     "@capacitor/browser": "^8.0.3",
+    "@capacitor/clipboard": "^8.0.1",
     "@capacitor/core": "^8.3.0",
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/keyboard": "^8.0.3",

--- a/src/features/send/steps/InputStep.tsx
+++ b/src/features/send/steps/InputStep.tsx
@@ -9,6 +9,8 @@ import { isCrossChainEnabled } from '@/services/settings';
 import { ClipboardIcon, QrCodeIcon, SpinnerIcon, ContactsIcon, CloseIcon } from '@/components/Icons';
 import type { Contact } from '@breeztech/breez-sdk-spark';
 import { dismissKeyboard } from '../../../utils/keyboard';
+import { Capacitor } from '@capacitor/core';
+import { Clipboard } from '@capacitor/clipboard';
 
 export interface InputStepProps {
   paymentInput: string;
@@ -40,16 +42,22 @@ const InputStep: React.FC<InputStepProps> = ({ paymentInput, selectedContactAddr
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const handlePaste = async () => {
-    // Not all browsers support clipboard.readText() (e.g. Firefox
-    // Android), and Chrome can deny it. On any failure, fall back to
-    // focusing the field so the native paste menu is one tap away
-    // instead of nothing happening.
-    if (!navigator.clipboard?.readText) {
-      inputRef.current?.focus();
-      return;
-    }
     try {
-      const text = await navigator.clipboard.readText();
+      // Read via the native Clipboard plugin in the Capacitor app: the
+      // WebView's navigator.clipboard is blocked on Android and shows
+      // iOS's in-page paste pill. Native read goes through the OS paste
+      // flow, which honors the per-app "Paste from Other Apps" setting.
+      let text: string | null;
+      if (Capacitor.isNativePlatform()) {
+        text = (await Clipboard.read()).value ?? null;
+      } else if (navigator.clipboard?.readText) {
+        text = await navigator.clipboard.readText();
+      } else {
+        // Old Firefox / non-secure context: no readText(). Focus the
+        // field so the user can paste manually.
+        inputRef.current?.focus();
+        return;
+      }
       if (text?.trim()) {
         setLocalPaymentInput(text);
         setSelectedContact(null);


### PR DESCRIPTION
On native builds, the Paste button now reads the clipboard through `@capacitor/clipboard` instead of the WebView's `navigator.clipboard`, which is blocked on Android and shows iOS's in-page paste pill. Web path unchanged.

Requires `@capacitor/clipboard` added to the glow-app shell + `npx cap sync` for the native plugin to register.