### PR TITLE
fix(passkey): disable immediateGet path until SDK support lands

### DIFF
--- a/src/services/passkeyPrfProvider.ts
+++ b/src/services/passkeyPrfProvider.ts
@@ -78,8 +78,16 @@ export async function signalUnknownCredentials(credentialIdsBase64: string[]): P
  * `getClientCapabilities('public-key')`. Returns false on browsers
  * that don't surface the capability API.
  */
+/**
+ * Temporarily forced off: the immediateGet / immediate-mediation path
+ * isn't wired through the SDK yet, so collapse every caller to the
+ * two-CTA discovery flow. Flip back to re-enable once the SDK supports it.
+ */
+const IMMEDIATE_GET_ENABLED = false;
+
 let cachedImmediateGet: boolean | null | undefined;
 export async function supportsImmediateGet(): Promise<boolean> {
+  if (!IMMEDIATE_GET_ENABLED) return false;
   if (native) return true;
   if (cachedImmediateGet === true) return true;
   if (cachedImmediateGet === false || cachedImmediateGet === null) return false;


### PR DESCRIPTION
This PR disables immediate-mediation passkey discovery path on web as it isn't wired through the SDK yet.

Until the SDK fixes lands, this collapses every caller to the standard two-CTA discovery flow so production users don't hit the broken immediate path.

## Revert

Flip `IMMEDIATE_GET_ENABLED` back to `true` once the SDK supports it.
