### PR TITLE
fix: route deleted-passkey iOS logins to the recovery screen

### DIFF
--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -290,18 +290,12 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
           || errorMessage.includes('empty allowCredentials');
         const elapsedMs = Date.now() - detectStartMs;
         const FAST_FAIL_MAX_MS = 300;
-        // Per-platform fast-fail dispatch (no UI rendered = OS
-        // deterministically has no matching cred). Android raises
-        // NoCredentialException (reliable on its own). iOS conflates
-        // no-cred and cancel into USER_CANCELLED so elapsed time is
-        // the only disambiguator. Web's NotAllowedError has no fast
-        // silent path; the slow-path branches below handle it.
-        const platform = Capacitor.isNativePlatform() ? Capacitor.getPlatform() : 'web';
-        let isFastFailNoCred = false;
-        if (elapsedMs < FAST_FAIL_MAX_MS) {
-          if (platform === 'android') isFastFailNoCred = isCredentialNotFound;
-          else if (platform === 'ios') isFastFailNoCred = isCancelled;
-        }
+        // Native fast-fail no-credential: the SDK's native core
+        // (PasskeyAssertionCore) times the ceremony itself and types a
+        // no-UI no-credential as CredentialNotFound on iOS and Android, so
+        // trust that over glow's coarser elapsed. Web's NotAllowedError has
+        // no fast silent path; the slow-path branches below handle it.
+        const isFastFailNoCred = Capacitor.isNativePlatform() && isCredentialNotFound;
         if (hasPasskeyHistory()) {
           if (isFastFailNoCred) {
             if (detectingFailCountRef.current === 0 && isFreshInstallRef.current) {


### PR DESCRIPTION
On iPhone, users who had deleted their passkey (for example, from iCloud Keychain) and later tried to sign in were shown a generic "Try again" message with no way to recover. Android already handled the same case correctly by routing users to the recovery screen. This change brings iPhone in line with Android.

Before | After
-- | --
Generic "Try again" message with no recovery path | User is taken to the recovery screen

The native login flow now relies on the SDK's typed <code inline="">CredentialNotFound</code> error instead of re-deriving the condition from elapsed time and platform-specific heuristics. The SDK consistently reports a deleted passkey as <code inline="">CredentialNotFound</code> on both iOS and Android, allowing both platforms to follow the same recovery path.</p><p>This is a native-only change. The web flow is unchanged. 