### PR TITLE
feat(cross-chain): show friendly chain display names

### DIFF
--- a/src/components/PaymentDetailsDialog.tsx
+++ b/src/components/PaymentDetailsDialog.tsx
@@ -10,7 +10,7 @@ import { getTokenAmountFromPayment, formatTokenAmount, buildTokenDisplayConfig }
 import { useFiatData } from '../contexts/FiatDataContext';
 import { useContactsContext } from '../contexts/ContactsContext';
 import { getPaymentDescription, getProviderDisplayName, isCrossChainPayment } from '../utils/paymentDescription';
-import { capitalizeFirst, getCrossChainDestination, formatReceiveAmount } from '../utils/crossChainFormat';
+import { formatChainName, getCrossChainDestination, formatReceiveAmount } from '../utils/crossChainFormat';
 
 interface PaymentDetailsDialogProps {
   optionalPayment: Payment | null;
@@ -149,7 +149,7 @@ const PaymentDetailsDialog: React.FC<PaymentDetailsDialogProps> = ({ optionalPay
             {dest?.chainName && (
               <PaymentInfoRow
                 label="Network"
-                value={capitalizeFirst(dest.chainName)}
+                value={formatChainName(dest.chainName)}
               />
             )}
             {dest?.recipientAddress && (

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -14,7 +14,7 @@ import { formatWithThinSpaces } from '../../../utils/formatNumber';
 import { formatTokenAmount } from '../../../utils/tokenFormatting';
 import { logger, LogCategory } from '@/services/logger';
 import { getProviderDisplayName } from '../../../utils/paymentDescription';
-import { truncateAddress, capitalizeFirst, formatCrossChainAmount, formatReceiveAmount } from '../../../utils/crossChainFormat';
+import { truncateAddress, formatChainName, formatCrossChainAmount, formatReceiveAmount } from '../../../utils/crossChainFormat';
 import { formatError } from '@/utils/formatError';
 import CryptoIcon from '../../../components/CryptoIcon';
 
@@ -425,7 +425,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
                       <div className="flex items-center gap-3">
                         <CryptoIcon chain={r.chain} size={32} />
                         <span className="font-display font-medium text-spark-text-primary">
-                          {capitalizeFirst(r.chain)}
+                          {formatChainName(r.chain)}
                         </span>
                       </div>
                       {r.contractAddress && (
@@ -487,7 +487,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
           ) : (
             <div className="mb-4 min-h-0 flex flex-col">
               <label className="block text-sm font-medium text-spark-text-primary mb-2 shrink-0">
-                Select Provider for {selectedAsset} ({capitalizeFirst(routesForSelection[0]?.chain ?? '')})
+                Select Provider for {selectedAsset} ({formatChainName(routesForSelection[0]?.chain ?? '')})
               </label>
               <div className="space-y-2 overflow-y-auto min-h-0 pr-1">
                 {visibleProviders.map((pq) => {
@@ -600,7 +600,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
               },
               {
                 label: 'Chain',
-                value: `${capitalizeFirst(confirmedRoute.chain)}`,
+                value: `${formatChainName(confirmedRoute.chain)}`,
               },
               {
                 label: 'Provider',

--- a/src/utils/crossChainFormat.ts
+++ b/src/utils/crossChainFormat.ts
@@ -12,6 +12,18 @@ export function capitalizeFirst(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+// Pretty display names for chains whose raw SDK identifier isn't presentable.
+// Keyed on the SDK's raw lowercased chain name, matching CHAIN_NAME_OVERRIDES
+// in CryptoIcon.tsx. Anything not listed falls back to capitalizeFirst.
+const CHAIN_DISPLAY_NAMES: Record<string, string> = {
+  bsc: 'BNB Smart Chain',
+};
+
+/** Human-friendly chain name for display (e.g. "bsc" → "BNB Smart Chain"). */
+export function formatChainName(chain: string): string {
+  return CHAIN_DISPLAY_NAMES[chain.toLowerCase()] ?? capitalizeFirst(chain);
+}
+
 /** Format a base-unit amount in its asset's full precision (trailing zeros trimmed). */
 export function formatCrossChainAmount(amount: bigint, decimals: number): string {
   const divisor = BigInt(10 ** decimals);


### PR DESCRIPTION
## Summary

Cross-chain destinations were displaying raw lowercased SDK chain identifiers with only first-letter capitalization, so `bsc` rendered as **"Bsc"**. This adds a small display-name map so it renders as **"BNB Smart Chain"**.

- Add `CHAIN_DISPLAY_NAMES` map and `formatChainName()` helper in `src/utils/crossChainFormat.ts`, following the existing `PROVIDER_OVERRIDES` pattern: key on the SDK's raw lowercased chain name, fall back to `capitalizeFirst` for anything unlisted.
- Route the three chain labels in the cross-chain send workflow and the "Network" row in the payment detail dialog through `formatChainName`.

## Notes

- The chain name is sourced from the Breez SDK (`CrossChainRoutePair.chain` / `ConversionInfo.chain` / `ConversionChain.name`), all plain strings. We chose to map presentation names client-side rather than in the SDK, consistent with how provider/ticker display names are already handled in glow.
- To add more friendly names later, extend `CHAIN_DISPLAY_NAMES` keyed on the raw lowercased SDK name (e.g. `'arbitrum one'`, `'polygon pos'`).
