### PR TITLE
fix(send): let the network list use the full sheet height

### DIFF
--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -402,7 +402,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
 
       {/* Step 3: Chain selection */}
       {step === 'chain' && (
-        <div className="flex flex-col" style={{ maxHeight: '60vh' }}>
+        <div className="flex flex-col">
           {error && (
             <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-sm text-red-400 shrink-0">
               {error}


### PR DESCRIPTION
Expanding the send sheet now expands the network list to fill the space, instead of leaving it stuck at a fixed height.