### PR TITLE
fix(send): fix the cross-chain network picker layout on mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,19 @@ import { MyIcon } from '../components/Icons';
 
 **Note:** Animated SVGs internal to a single component (e.g., `LoadingSpinner`, `ProcessingStep`) can stay in that component. The rule applies to reusable icons — always define them in `Icons.tsx`.
 
+## Bottom Sheets
+
+`BottomSheetContainer` / `BottomSheetCard` (`src/components/ui/sheets/BottomSheet.tsx`) wrap react-modal-sheet, which **snaps by translating a full-height sheet, not resizing it**. So at a partial (compact) snap the sheet's bottom sits below the viewport: `position: sticky bottom-0` and `position: fixed` are off-screen there (a `sticky top-0` header still works, and `fixed` is trapped by the sheet's transform anyway).
+
+**Scrollable content with a title/actions that must stay visible** (e.g. the cross-chain network picker in `CrossChainWorkflow.tsx`): don't let content overflow into a partial snap. Bound it so the sheet is content-sized and fully on screen, no sticky needed:
+
+- Cap the scroll area (`flex-1 min-h-0 overflow-y-auto`); keep the title/actions as `shrink-0` siblings above/below it.
+- Size the cap in **`dvh`, not `vh`**. `vh` is the largest (URL-bar-hidden) viewport, so a `vh` cap overflows the visible sheet on real mobile (fine on desktop + device simulator, which is the trap).
+- Add **`overscroll-y-none`** and **`touch-pan-y`** to the inner scroller, or on iOS it chains its scroll into / races the sheet's drag (the sheet's own scroller sets these; a nested one doesn't inherit them). `touch-pan-y` means the sheet no longer drags from the list, only from the handle/header/footer.
+- To grow the area when the sheet is dragged to full, read **`useSheetFullSnap()`** and raise the cap; a freeze guard in the container stops the growing content from flipping the snap ladder.
+
+The funded send/cross-chain flow isn't reachable locally; debug sheet layout with a throwaway `?sheettest` harness in `main.tsx` + browser measurement.
+
 ## Logging Practices
 
 The app uses a structured logging service (`src/services/logger.ts`) following OWASP guidelines.

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -44,7 +44,7 @@ export {
 export type { FormInputProps, FormTextareaProps } from './forms';
 
 // Bottom Sheets
-export { BottomSheetContainer, BottomSheetCard, useSheetFullSnap } from './sheets/BottomSheet';
+export { BottomSheetContainer, BottomSheetCard } from './sheets/BottomSheet';
 export type { BottomSheetMaxWidth, BottomSheetContainerProps, BottomSheetCardProps } from './sheets/BottomSheet';
 
 // Loading

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -44,7 +44,7 @@ export {
 export type { FormInputProps, FormTextareaProps } from './forms';
 
 // Bottom Sheets
-export { BottomSheetContainer, BottomSheetCard } from './sheets/BottomSheet';
+export { BottomSheetContainer, BottomSheetCard, useSheetFullSnap } from './sheets/BottomSheet';
 export type { BottomSheetMaxWidth, BottomSheetContainerProps, BottomSheetCardProps } from './sheets/BottomSheet';
 
 // Loading

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -16,7 +16,7 @@ import { Keyboard } from '@capacitor/keyboard';
 import { useStatusBarColor } from '../../../hooks/useStatusBarColor';
 import { STATUS_BAR_SURFACE } from '../../../utils/statusBarManager';
 import { useBackButton } from '../../../hooks/useBackButton';
-import { BottomSheetCardContext } from './BottomSheetCardContext';
+import { BottomSheetCardContext, SheetFullSnapContext } from './BottomSheetCardContext';
 
 /**
  * Bottom sheet adapter over react-modal-sheet.
@@ -86,14 +86,6 @@ const ContentMeasureContext = createContext<(px: number | null) => void>(
  * autofill pills.
  */
 const KeyboardClearanceContext = createContext(0);
-
-/**
- * True while the sheet is at its full (top) snap. Content reads this to
- * grow into the extra height when expanded (e.g. a capped list area that
- * should fill the screen once dragged to full).
- */
-const SheetFullSnapContext = createContext(false);
-export const useSheetFullSnap = () => useContext(SheetFullSnapContext);
 
 // On native the WebView itself resizes with the keyboard (Android
 // adjustResize, iOS resize: 'native'), so the library's keyboard

--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -87,6 +87,14 @@ const ContentMeasureContext = createContext<(px: number | null) => void>(
  */
 const KeyboardClearanceContext = createContext(0);
 
+/**
+ * True while the sheet is at its full (top) snap. Content reads this to
+ * grow into the extra height when expanded (e.g. a capped list area that
+ * should fill the screen once dragged to full).
+ */
+const SheetFullSnapContext = createContext(false);
+export const useSheetFullSnap = () => useContext(SheetFullSnapContext);
+
 // On native the WebView itself resizes with the keyboard (Android
 // adjustResize, iOS resize: 'native'), so the library's keyboard
 // machinery must stay off: its VirtualKeyboard API path flips
@@ -128,6 +136,15 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   const currentSnap = useRef(1);
   const fullyOpen = useRef(false);
   const [snapIndex, setSnapIndex] = useState(1);
+
+  // Freeze the measured content height while the user holds the sheet at
+  // the full snap: content that grows to fill the expanded sheet would
+  // otherwise push contentPx past the near-full collapse and flip the
+  // snap ladder, fighting its own expansion.
+  const reportContentPx = useCallback((px: number | null) => {
+    if (currentSnap.current === 2 && px !== null) return;
+    setContentPx(px);
+  }, []);
 
   // Manual keyboard mode (avoidKeyboard is off below): the hook keeps
   // --keyboard-inset-height up to date and we pad the content scroller
@@ -492,9 +509,11 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
           } as React.CSSProperties
         }
       >
-        <ContentMeasureContext.Provider value={setContentPx}>
+        <ContentMeasureContext.Provider value={reportContentPx}>
           <KeyboardClearanceContext.Provider value={clearancePx}>
-            {children}
+            <SheetFullSnapContext.Provider value={isFullSnap}>
+              {children}
+            </SheetFullSnapContext.Provider>
           </KeyboardClearanceContext.Provider>
         </ContentMeasureContext.Provider>
       </Sheet.Container>

--- a/src/components/ui/sheets/BottomSheetCardContext.tsx
+++ b/src/components/ui/sheets/BottomSheetCardContext.tsx
@@ -2,3 +2,11 @@ import { createContext, useContext } from 'react';
 
 export const BottomSheetCardContext = createContext<HTMLDivElement | null>(null);
 export const useBottomSheetCardEl = () => useContext(BottomSheetCardContext);
+
+/**
+ * True while the sheet is at its full (top) snap. Content reads this to
+ * grow into the extra height when expanded (e.g. a capped list area that
+ * should fill the screen once dragged to full).
+ */
+export const SheetFullSnapContext = createContext(false);
+export const useSheetFullSnap = () => useContext(SheetFullSnapContext);

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -413,7 +413,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
             </div>
           )}
           <label className="block text-sm font-medium text-spark-text-primary mb-2 shrink-0">Select Network for {selectedAsset}</label>
-          <div className="flex-1 min-h-0 overflow-y-auto overscroll-y-none space-y-2 pr-1">
+          <div className="flex-1 min-h-0 overflow-y-auto overscroll-y-none touch-pan-y space-y-2 pr-1">
             {chainsForAsset.map(r => {
                 const key = chainGroupKey(r);
                 const isExpanded = expandedChain === key;

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -413,7 +413,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
             </div>
           )}
           <label className="block text-sm font-medium text-spark-text-primary mb-2 shrink-0">Select Network for {selectedAsset}</label>
-          <div className="flex-1 min-h-0 overflow-y-auto space-y-2 pr-1">
+          <div className="flex-1 min-h-0 overflow-y-auto overscroll-y-none space-y-2 pr-1">
             {chainsForAsset.map(r => {
                 const key = chainGroupKey(r);
                 const isExpanded = expandedChain === key;

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -5,7 +5,7 @@ import type {
   CrossChainRoutePair,
   PrepareSendPaymentResponse,
 } from '@breeztech/breez-sdk-spark';
-import { PrimaryButton, SecondaryButton } from '../../../components/ui';
+import { PrimaryButton, SecondaryButton, useSheetFullSnap } from '../../../components/ui';
 import { ChevronDownIcon, CopyFilledIcon, CheckIcon, SpinnerIcon } from '../../../components/Icons';
 import { FeeBreakdownCard } from '../../../components/FeeBreakdownCard';
 import { useWallet } from '../../../contexts/WalletContext';
@@ -74,6 +74,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
   onRun,
 }) => {
   const wallet = useWallet();
+  const isSheetFull = useSheetFullSnap();
   const stableBalance = useStableBalance();
   const [step, setStep] = useState<WorkflowStep>('loading');
   const [routes, setRoutes] = useState<CrossChainRoutePair[]>([]);
@@ -400,18 +401,20 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
         </div>
       )}
 
-      {/* Step 3: Chain selection */}
+      {/* Step 3: Chain selection. Bounded list area so the title, the
+          internally-scrolling list, and the actions all stay on-screen
+          (the sheet is content-sized, no off-screen partial snap). The cap
+          grows when the sheet is dragged to full so the list fills it. */}
       {step === 'chain' && (
-        <div className="flex flex-col">
+        <div className="flex flex-col" style={{ maxHeight: isSheetFull ? '85vh' : '60vh' }}>
           {error && (
             <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-sm text-red-400 shrink-0">
               {error}
             </div>
           )}
-          <div className="mb-4 min-h-0 flex flex-col">
-            <label className="block text-sm font-medium text-spark-text-primary mb-2 shrink-0">Select Network for {selectedAsset}</label>
-            <div className="space-y-2 overflow-y-auto min-h-0 pr-1">
-              {chainsForAsset.map(r => {
+          <label className="block text-sm font-medium text-spark-text-primary mb-2 shrink-0">Select Network for {selectedAsset}</label>
+          <div className="flex-1 min-h-0 overflow-y-auto space-y-2 pr-1">
+            {chainsForAsset.map(r => {
                 const key = chainGroupKey(r);
                 const isExpanded = expandedChain === key;
                 const isCopied = copiedAddress === key;
@@ -459,7 +462,6 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
                   </div>
                 );
               })}
-            </div>
           </div>
           <div className="flex gap-3 shrink-0 pt-2">
             <SecondaryButton onClick={goBackFromChain} className="flex-1">

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -406,7 +406,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
           (the sheet is content-sized, no off-screen partial snap). The cap
           grows when the sheet is dragged to full so the list fills it. */}
       {step === 'chain' && (
-        <div className="flex flex-col" style={{ maxHeight: isSheetFull ? '85vh' : '60vh' }}>
+        <div className="flex flex-col" style={{ maxHeight: isSheetFull ? '85dvh' : '60dvh' }}>
           {error && (
             <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-sm text-red-400 shrink-0">
               {error}

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -5,7 +5,8 @@ import type {
   CrossChainRoutePair,
   PrepareSendPaymentResponse,
 } from '@breeztech/breez-sdk-spark';
-import { PrimaryButton, SecondaryButton, useSheetFullSnap } from '../../../components/ui';
+import { PrimaryButton, SecondaryButton } from '../../../components/ui';
+import { useSheetFullSnap } from '../../../components/ui/sheets/BottomSheetCardContext';
 import { ChevronDownIcon, CopyFilledIcon, CheckIcon, SpinnerIcon } from '../../../components/Icons';
 import { FeeBreakdownCard } from '../../../components/FeeBreakdownCard';
 import { useWallet } from '../../../contexts/WalletContext';


### PR DESCRIPTION
The cross-chain **Select Network** step now keeps the title, the network list, and the **Back / Continue** buttons on screen together, with the list scrolling inside a fixed area. Dragging the sheet to full grows the list and the buttons stay at the bottom.

Fixes the buttons being pushed off-screen after #250 removed the list's height cap.

**How:**
- Bounded list area (no sticky positioning), so the sheet is content-sized and never overflows.
- Sized in `dvh` so it fits the real mobile viewport (`vh` overflowed the visible screen on phones).
- `overscroll-y-none` + `touch-pan-y` on the list so its scroll doesn't fight the sheet's drag.