### PR TITLE
feat: USD amount entry when sending BTC

### DIFF
--- a/src/features/send/hooks/useBalanceValidation.ts
+++ b/src/features/send/hooks/useBalanceValidation.ts
@@ -37,8 +37,8 @@ export function useBalanceValidation(
 ): BalanceValidation {
   const stable = useStableBalance();
   // Mirror useAmountInput: stable balance wins; otherwise a fiat override
-  // (cross-chain "Send USD") supplies the config + rate so a typed fiat amount
-  // can be validated against the BTC balance.
+  // (USD toggle, cross-chain "Send USD") supplies the config + rate so a
+  // typed fiat amount can be validated against the BTC balance.
   const config = stable.isActive ? stable.displayConfig : (fiatOverride?.config ?? null);
   const btcFiatRate = stable.isActive ? stable.btcFiatRate : (fiatOverride?.btcFiatRate ?? 0);
   const isActive = stable.isActive;

--- a/src/features/send/steps/AmountStep.test.tsx
+++ b/src/features/send/steps/AmountStep.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { BreezSdk } from '@breeztech/breez-sdk-spark';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { FiatDataProvider } from '@/contexts/FiatDataContext';
+import { StableBalanceProvider } from '@/contexts/StableBalanceContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import AmountStep, { AmountStepProps } from './AmountStep';
+
+// Mock rates put BTC at $100,000, so $1 = 1,000 sats.
+function renderAmountStep(props: Partial<AmountStepProps> = {}, client?: BreezSdk) {
+  const onNext = vi.fn();
+  const mockClient = client ?? createMockClient();
+  render(
+    <WalletProvider client={mockClient} isConnected>
+      <FiatDataProvider>
+        <StableBalanceProvider>
+          <AmountStep
+            paymentInput="sp1test"
+            amount=""
+            balanceSats={100000}
+            isLoading={false}
+            error={null}
+            onBack={vi.fn()}
+            onNext={onNext}
+            {...props}
+          />
+        </StableBalanceProvider>
+      </FiatDataProvider>
+    </WalletProvider>
+  );
+  return { onNext, client: mockClient };
+}
+
+describe('AmountStep USD entry (no stable balance)', () => {
+  it('starts in sats and continues with a sats amount', async () => {
+    const { onNext } = renderAmountStep();
+
+    const input = screen.getByTestId('amount-input');
+    expect(input).toHaveAttribute('placeholder', 'Enter amount in satoshis');
+
+    fireEvent.change(input, { target: { value: '1500' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => expect(onNext).toHaveBeenCalledWith(1500n, false));
+  });
+
+  it('toggles to USD and converts the typed dollars to sats', async () => {
+    const { onNext } = renderAmountStep();
+
+    // The switcher appears once the USD rate loads.
+    const switcher = await screen.findByRole('button', { name: '₿' });
+    fireEvent.click(switcher);
+
+    const input = screen.getByTestId('amount-input');
+    expect(input).toHaveAttribute('placeholder', 'Enter amount in $');
+
+    fireEvent.change(input, { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => expect(onNext).toHaveBeenCalledWith(5000n, false));
+  });
+
+  it('rejects a USD amount that exceeds the BTC balance', async () => {
+    const { onNext } = renderAmountStep();
+
+    fireEvent.click(await screen.findByRole('button', { name: '₿' }));
+    fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '500' } });
+
+    // $500 = 500,000 sats > 100,000 sats balance
+    await screen.findByText('Amount exceeds available balance');
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it('offers no USD toggle while the rate has not loaded', async () => {
+    const client = createMockClient({
+      listFiatRates: vi.fn().mockResolvedValue({ rates: [] }),
+    } as unknown as Partial<BreezSdk>);
+    renderAmountStep({}, client);
+
+    await waitFor(() => expect(client.listFiatRates).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: '₿' })).toBeNull();
+    expect(screen.getByTestId('amount-input')).toHaveAttribute(
+      'placeholder',
+      'Enter amount in satoshis'
+    );
+  });
+
+  it('keeps cross-chain (amountFirst) USD-only with no toggle', async () => {
+    renderAmountStep({ amountFirst: true });
+
+    expect(screen.getByTestId('amount-input')).toHaveAttribute(
+      'placeholder',
+      'Enter amount in USD'
+    );
+    expect(screen.queryByRole('button', { name: '₿' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '$' })).toBeNull();
+  });
+});

--- a/src/features/send/steps/AmountStep.tsx
+++ b/src/features/send/steps/AmountStep.tsx
@@ -6,17 +6,12 @@ import {
   TOKEN_QUICK_AMOUNTS,
   SATS_QUICK_AMOUNTS,
   formatQuickAmount,
-  buildFiatDisplayConfig,
 } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
-import { useAmountInput } from '../../../hooks/useAmountInput';
+import { useAmountInput, useUsdFiatOverride } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import { useHasPendingConversion } from '../../../contexts/WalletContext';
-import { useFiatData } from '../../../contexts/FiatDataContext';
 import { dismissKeyboard } from '../../../utils/keyboard';
-
-/** Cross-chain destinations are USD stablecoins (USDC/USDT) — amounts are USD. */
-const CROSS_CHAIN_FIAT_CURRENCY = 'USD';
 
 export interface AmountStepProps {
   paymentInput: string;
@@ -42,18 +37,10 @@ const AmountStep: React.FC<AmountStepProps> = ({
   onNext,
   amountFirst = false,
 }) => {
-  const { fiatCurrencies, fiatRates } = useFiatData();
-
-  // Cross-chain ("Send USD") denominates in USD even without a stable-balance
-  // token: build a fiat config from FiatData and let the user type dollars,
-  // converted to sats client-side via the BTC→USD rate and funded from BTC.
-  const fiatOverride = useMemo(() => {
-    if (!amountFirst) return undefined;
-    return {
-      config: buildFiatDisplayConfig(CROSS_CHAIN_FIAT_CURRENCY, fiatCurrencies),
-      btcFiatRate: fiatRates.find(r => r.coin === CROSS_CHAIN_FIAT_CURRENCY)?.value ?? 0,
-    };
-  }, [amountFirst, fiatCurrencies, fiatRates]);
+  // USD entry without a stable-balance token, funded from BTC. Cross-chain
+  // ("Send USD", amountFirst) starts in USD; plain BTC sends start in sats
+  // with USD as a toggleable secondary option (#253).
+  const fiatOverride = useUsdFiatOverride(amountFirst);
 
   const input = useAmountInput({ initialAmount: amount, balanceSats, tokenBalance, fiatOverride });
   const {
@@ -63,7 +50,6 @@ const AmountStep: React.FC<AmountStepProps> = ({
     isTokenMode,
     setIsTokenMode,
     toggleDenomination,
-    isStableBalanceActive,
     tokenIdentifier,
     tokenSymbol,
     config,
@@ -217,8 +203,8 @@ const AmountStep: React.FC<AmountStepProps> = ({
             min={isTokenMode ? undefined : 1}
             data-testid="amount-input"
           />
-          {/* Cross-chain ("Send USD", amountFirst) is USD-only — no sats toggle. */}
-          {!amountFirst && isStableBalanceActive && tokenSymbol && (
+          {/* Cross-chain ("Send USD", amountFirst) is USD-only: no sats toggle. */}
+          {!amountFirst && tokenSymbol && (
             <CurrencySwitcher
               isTokenMode={isTokenMode}
               tokenSymbol={tokenSymbol}

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -10,7 +10,7 @@ import {
   formatQuickAmount,
 } from '../../../utils/tokenFormatting';
 import CurrencySwitcher from '../../../components/ui/CurrencySwitcher';
-import { useAmountInput } from '../../../hooks/useAmountInput';
+import { useAmountInput, useUsdFiatOverride } from '../../../hooks/useAmountInput';
 import { useBalanceValidation } from '../hooks/useBalanceValidation';
 import { useHasPendingConversion } from '../../../contexts/WalletContext';
 
@@ -26,7 +26,10 @@ interface LnurlWorkflowProps {
 }
 
 const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, balanceSats, tokenBalance, onBack, onRun, onPrepare, onPay }) => {
-  const input = useAmountInput({ balanceSats, tokenBalance });
+  // USD as a secondary entry option on BTC sends (#253): starts in sats,
+  // toggleable to USD, converted to sats client-side.
+  const fiatOverride = useUsdFiatOverride();
+  const input = useAmountInput({ balanceSats, tokenBalance, fiatOverride });
   const {
     amountInput: amount,
     setAmount,
@@ -43,7 +46,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     tokenSendAllBelowThreshold,
   } = input;
 
-  const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance);
+  const balance = useBalanceValidation(isTokenMode, setIsTokenMode, balanceSats, tokenBalance, fiatOverride);
   const hasPendingConversion = useHasPendingConversion();
 
   const [step, setStep] = useState<PaymentStep>('amount');
@@ -175,8 +178,10 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     // Safe to parse — validateAmount already confirmed the input is valid
     const sats = balance.parseInputToSats(amount)!;
 
-    // LNURL range constraints (sats mode only — token mode is validated by the SDK)
-    if (!isTokenMode) {
+    // LNURL range constraints. Skipped for stable-balance token mode: the SDK
+    // validates there, and conversion may adjust the amount. USD-toggle mode
+    // (token mode without stable balance) computes exact sats, so check it.
+    if (!isTokenMode || !isStableBalanceActive) {
       if (minSats && sats < minSats) {
         setError(`Amount must be at least ₿${minSats.toLocaleString()}`);
         return;
@@ -286,7 +291,7 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
             min={isTokenMode ? undefined : minSats}
             max={isTokenMode ? undefined : maxSats}
           />
-          {isStableBalanceActive && tokenSymbol && (
+          {tokenSymbol && (
             <CurrencySwitcher
               isTokenMode={isTokenMode}
               tokenSymbol={tokenSymbol}

--- a/src/hooks/useAmountInput.ts
+++ b/src/hooks/useAmountInput.ts
@@ -1,12 +1,40 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useStableBalance } from '../contexts/StableBalanceContext';
+import { useFiatData } from '../contexts/FiatDataContext';
 import {
+  buildFiatDisplayConfig,
   parseAmountToSats,
   sanitizeTokenInput,
   tokenAmountDisplaysAsZero,
   type TokenDisplayConfig,
 } from '../utils/tokenFormatting';
 import type { Sats } from '../types/sats';
+
+export interface FiatOverride {
+  config: TokenDisplayConfig;
+  btcFiatRate: number;
+  /** Start the input in fiat mode (USD-denominated flows like cross-chain)
+   *  instead of sats with fiat as a toggleable secondary option. */
+  startInFiat: boolean;
+}
+
+/**
+ * USD fiat override for amount inputs, built from live fiat data. Lets a
+ * BTC-balance user type dollars: the amount is converted to sats client-side.
+ *
+ * Returns undefined while the USD rate hasn't loaded, so callers offer no
+ * fiat entry that can't parse. Exception: `startInFiat` flows (cross-chain
+ * "Send USD") are USD-denominated by design and must not fall back to sats
+ * entry, so they keep the config even before the rate arrives.
+ */
+export function useUsdFiatOverride(startInFiat = false): FiatOverride | undefined {
+  const { fiatCurrencies, fiatRates } = useFiatData();
+  return useMemo(() => {
+    const btcFiatRate = fiatRates.find(r => r.coin === 'USD')?.value ?? 0;
+    if (!startInFiat && btcFiatRate <= 0) return undefined;
+    return { config: buildFiatDisplayConfig('USD', fiatCurrencies), btcFiatRate, startInFiat };
+  }, [startInFiat, fiatCurrencies, fiatRates]);
+}
 
 export interface UseAmountInputOptions {
   /** Pre-fill the input on mount (e.g. when re-opening a dialog with a value). */
@@ -17,13 +45,13 @@ export interface UseAmountInputOptions {
   tokenBalance?: bigint;
   /**
    * Fiat input config for flows that denominate in a fiat currency *without*
-   * holding a stable-balance token (e.g. cross-chain "Send USD" funded by BTC).
-   * Only takes effect when stable balance is inactive; when active, the
-   * stable-balance config wins. When present, the hook starts in fiat
-   * ("token") mode and uses this config/rate for parsing and display — the
-   * fiat amount is converted to sats via `btcFiatRate`.
+   * holding a stable-balance token (a BTC send with the USD toggle, or
+   * cross-chain "Send USD"). Only takes effect when stable balance is
+   * inactive; when active, the stable-balance config wins. When present, the
+   * hook uses this config/rate for fiat-mode parsing and display: the fiat
+   * amount is converted to sats via `btcFiatRate`. See `useUsdFiatOverride`.
    */
-  fiatOverride?: { config: TokenDisplayConfig; btcFiatRate: number };
+  fiatOverride?: FiatOverride;
 }
 
 export interface UseAmountInputResult {
@@ -103,14 +131,15 @@ export function useAmountInput(options: UseAmountInputOptions = {}): UseAmountIn
   const { initialAmount = '', balanceSats, tokenBalance, fiatOverride } = options;
   const stableBalance = useStableBalance();
 
-  // When stable balance is off, a fiat override (e.g. cross-chain "Send USD")
-  // supplies the currency config + rate so the user can still denominate in
-  // fiat. Stable balance always wins when active.
-  const fiatOverrideActive = !stableBalance.isActive && !!fiatOverride;
+  // When stable balance is off, a fiat override (USD toggle, cross-chain
+  // "Send USD") supplies the currency config + rate so the user can still
+  // denominate in fiat. Stable balance always wins when active.
   const config = stableBalance.isActive ? stableBalance.displayConfig : (fiatOverride?.config ?? null);
   const btcFiatRate = stableBalance.isActive ? stableBalance.btcFiatRate : (fiatOverride?.btcFiatRate ?? 0);
 
-  const [isTokenMode, setIsTokenMode] = useState(stableBalance.isActive || fiatOverrideActive);
+  const [isTokenMode, setIsTokenMode] = useState(
+    stableBalance.isActive || (fiatOverride?.startInFiat ?? false),
+  );
   const [amountInput, setAmountInput] = useState(initialAmount);
 
   // Adjust-state-on-prop-change pattern (React docs): when stable

--- a/src/utils/tokenFormatting.ts
+++ b/src/utils/tokenFormatting.ts
@@ -20,8 +20,9 @@ export interface TokenPaymentInfo {
 /**
  * Build a token-less display config for a pure fiat currency (e.g. "USD").
  *
- * Used by the cross-chain "Send USD" flow so a BTC-balance (non-stable) user
- * can type a dollar amount without holding a USD token. There's no token here,
+ * Used for fiat entry without a stable-balance token (the USD toggle on BTC
+ * sends, cross-chain "Send USD") so a BTC-balance user can type a dollar
+ * amount without holding a USD token. There's no token here,
  * so `decimals` equals `fractionSize` (the minor unit *is* the base unit). The
  * USD amount is converted to sats client-side via `btcFiatRate` (the SDK build
  * on this branch has no fiat-amount model), so only `symbol`/`fractionSize` are


### PR DESCRIPTION
Closes #253

## What

Adds the ability to enter a USD amount when sending BTC, as a secondary option using the same currency switcher we show with stable balance. The amount input starts in sats; tapping the switcher pill toggles to USD, and the typed dollars are converted to sats client-side via the BTC-USD rate.

Applies to both amount-entry surfaces in the send flow:

- `AmountStep` (spark address, BTC address, amountless bolt11)
- `LnurlWorkflow` (lightning addresses / LNURL-pay)

## How

Reuses the `fiatOverride` mechanism that already powers the cross-chain "Send USD" flow, instead of introducing a parallel code path:

- New `useUsdFiatOverride(startInFiat)` hook in `useAmountInput.ts` builds the override (USD display config + BTC-USD rate) from `FiatDataContext`. It returns `undefined` until a USD rate has loaded, so the toggle is never offered when it could not parse.
- `FiatOverride.startInFiat` distinguishes USD-denominated flows (cross-chain: starts in USD, no toggle, unchanged) from sats-first flows where USD is a secondary option.
- The `CurrencySwitcher` is now gated on a display config being available (stable balance active OR fiat override present) rather than on stable balance alone.
- The LNURL min/max range check now also runs in USD mode, since the computed sats are exact there. Stable-balance token mode still defers to the SDK (conversion may adjust the amount).

## Zero-regression notes

- Stable balance active: the stable-balance config still wins everywhere; behavior is unchanged.
- Cross-chain ("Send USD"): still starts in USD with no sats toggle, including before rates load.
- Sats entry: untouched; the toggle simply is not shown when no USD rate is available.
- Send All, quick amounts, and balance validation in USD mode ride on the paths already built (and shipped) for cross-chain and stable-balance token mode.

## Testing

- New `AmountStep.test.tsx` component tests (real providers + mock SDK client): sats path unchanged, USD toggle appears and converts $5 to 5,000 sats at the mocked rate, USD amounts exceeding the BTC balance are rejected, no toggle without a rate, and cross-chain stays USD-only.
- `npx tsc --noEmit` clean, full vitest suite 70/70, lint clean (only pre-existing warnings in passkey-migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)