### PR TITLE
fix(passkey): restore the unified welcome flow on native apps

### DIFF
--- a/src/services/passkeyPrfProvider.test.ts
+++ b/src/services/passkeyPrfProvider.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let isNative = false;
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => isNative },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('supportsImmediateGet', () => {
+  it('returns true on native even while the browser kill switch is off (PR #246 regression)', async () => {
+    isNative = true;
+    const { supportsImmediateGet } = await import('./passkeyPrfProvider');
+    await expect(supportsImmediateGet()).resolves.toBe(true);
+  });
+
+  it('returns false in browsers while the kill switch is off', async () => {
+    isNative = false;
+    const { supportsImmediateGet } = await import('./passkeyPrfProvider');
+    await expect(supportsImmediateGet()).resolves.toBe(false);
+  });
+});

--- a/src/services/passkeyPrfProvider.ts
+++ b/src/services/passkeyPrfProvider.ts
@@ -97,16 +97,22 @@ export async function signalUnknownCredentials(credentialIdsBase64: string[]): P
  * that don't surface the capability API.
  */
 /**
- * Temporarily forced off: the immediateGet / immediate-mediation path
- * isn't wired through the SDK yet, so collapse every caller to the
+ * Browser-only kill switch: the immediateGet / immediate-mediation path
+ * isn't wired through the SDK yet, so browser callers collapse to the
  * two-CTA discovery flow. Flip back to re-enable once the SDK supports it.
+ *
+ * This switch must not gate native: there the provider does its own
+ * deterministic credential lookup and never depends on the WebAuthn
+ * immediateGet capability, so the native check below runs first. When
+ * PR #246 put this check before the native early-return, it silently
+ * disabled the unified welcome flow in native builds through 0.1.0.
  */
 const IMMEDIATE_GET_ENABLED = false;
 
 let cachedImmediateGet: boolean | null | undefined;
 export async function supportsImmediateGet(): Promise<boolean> {
-  if (!IMMEDIATE_GET_ENABLED) return false;
   if (native) return true;
+  if (!IMMEDIATE_GET_ENABLED) return false;
   if (cachedImmediateGet === true) return true;
   if (cachedImmediateGet === false || cachedImmediateGet === null) return false;
   try {


### PR DESCRIPTION
## What happened

Native apps (iOS and Android) lost the streamlined welcome screen: fresh installs showed the legacy two-button welcome ("Create Passkey" / "Use Existing Passkey") instead of "Get Started" / "Use Passkey". The regression shipped in native builds including release 0.1.0.

## Why

#246 turned off the browser immediateGet experiment with a kill switch, but the switch was checked before the native early-return in `supportsImmediateGet()`, so it disabled native too. Native never depended on the browser WebAuthn capability being probed there: the native provider does its own deterministic credential lookup.

## Fix

Check native first, then the kill switch, re-scoping the switch to browsers only. The comment above the switch now documents why the ordering matters. Added a small regression test covering native with the switch off.

Browser behavior is unchanged: the kill switch still collapses browsers to the two-CTA flow until SDK support lands.

## Manual QA

Fresh install on an iOS or Android device: the welcome screen shows "Get Started" / "Use Passkey" instead of the two passkey buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)