### PR TITLE
fix: accept comma as decimal separator in token amount inputs

### DIFF
--- a/src/hooks/useAmountInput.ts
+++ b/src/hooks/useAmountInput.ts
@@ -8,6 +8,7 @@ import {
   tokenAmountDisplaysAsZero,
   type TokenDisplayConfig,
 } from '../utils/tokenFormatting';
+import { normalizeDecimalInput } from '../utils/decimalInput';
 import type { Sats } from '../types/sats';
 
 export interface FiatOverride {
@@ -158,7 +159,7 @@ export function useAmountInput(options: UseAmountInputOptions = {}): UseAmountIn
   const setAmount = useCallback(
     (value: string) => {
       if (isTokenMode && config) {
-        const sanitized = sanitizeTokenInput(value, config.fractionSize);
+        const sanitized = sanitizeTokenInput(normalizeDecimalInput(value), config.fractionSize);
         if (sanitized !== null) setAmountInput(sanitized);
       } else {
         setAmountInput(value.replace(/[^0-9]/g, ''));

--- a/src/utils/decimalInput.test.ts
+++ b/src/utils/decimalInput.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeDecimalInput } from './decimalInput';
+
+describe('normalizeDecimalInput', () => {
+  it('maps a comma separator to a dot', () => {
+    expect(normalizeDecimalInput('5,25')).toBe('5.25');
+  });
+
+  it('drops a second separator', () => {
+    expect(normalizeDecimalInput('5.2,5')).toBe('5.25');
+    expect(normalizeDecimalInput('5,2.5')).toBe('5.25');
+  });
+
+  it('leaves dot input unchanged', () => {
+    expect(normalizeDecimalInput('1.5')).toBe('1.5');
+  });
+
+  it('leaves the empty string unchanged', () => {
+    expect(normalizeDecimalInput('')).toBe('');
+  });
+
+  it('keeps a trailing separator while typing', () => {
+    expect(normalizeDecimalInput('5,')).toBe('5.');
+  });
+
+  it('strips characters that are neither digits nor separators', () => {
+    expect(normalizeDecimalInput('1a2')).toBe('12');
+  });
+});

--- a/src/utils/decimalInput.ts
+++ b/src/utils/decimalInput.ts
@@ -1,0 +1,11 @@
+/**
+ * Normalizes a decimal amount field value. iOS decimal keyboards follow the
+ * device region, so comma-locales (Turkish, most of Europe) only offer ","
+ * with no "." key. Maps "," to ".", keeps the first separator (a second
+ * separator keystroke is dropped), and strips any other non-digit character.
+ */
+export function normalizeDecimalInput(raw: string): string {
+  const cleaned = raw.replace(/,/g, '.').replace(/[^0-9.]/g, '');
+  const [head, ...rest] = cleaned.split('.');
+  return rest.length ? `${head}.${rest.join('')}` : head;
+}


### PR DESCRIPTION
On iOS the decimal keyboard follows the device region: comma-decimal locales (Turkish, most of Europe) get a "," key and no "." key. Token and USD amount fields rejected every comma keystroke, so users in those regions could not type fractional amounts (cents) at all.

This adds a small pure helper, `normalizeDecimalInput`, that maps "," to ".", keeps at most one decimal separator, and strips other non-digit characters. It is applied in `useAmountInput.setAmount`, the shared input path for every token-mode amount field (send, receive invoice, LNURL pay, buy), so both separators now work everywhere. Sats mode is unchanged.

Closes #256

**Manual QA:** on an iOS device or simulator with region set to Turkey or Germany, type `5,25` in the send token amount field and in the receive (create invoice) token amount field, and confirm it is accepted as `5.25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)