### PR TITLE
fix(ios): floor the injected bottom inset with live env()

### DIFF
--- a/src/utils/safeAreaInsets.ts
+++ b/src/utils/safeAreaInsets.ts
@@ -37,10 +37,10 @@ import { Capacitor } from '@capacitor/core';
  * to 0 through the CSS fallback. Every path reads the
  * `--safe-area-inset-*` custom property first and falls back to
  * `env()`: the variable is written by Capacitor's SystemBars on
- * Android native and by webViewportManager in iOS standalone web
- * apps (which zeroes the bottom inset when the OS already reserves
- * the home-indicator strip outside the layout viewport); everywhere
- * else it is undefined and `env()` behavior is unchanged.
+ * Android native and by webViewportManager on iOS native / standalone
+ * (as max(latched inset, env()), so it can only raise the bottom
+ * inset, never hide a live env() value); everywhere else it is
+ * undefined and `env()` behavior is unchanged.
  */
 const isAndroidNative =
   typeof window !== 'undefined' &&

--- a/src/utils/webViewportManager.ts
+++ b/src/utils/webViewportManager.ts
@@ -50,8 +50,14 @@ const EDITABLE_SELECTOR = 'input, textarea, [contenteditable="true"]';
  *
  * Policy: pad for the success mode, always.
  *
- *   --safe-area-inset-bottom = the device's home-indicator inset,
- *   unconditionally, on iOS native / standalone.
+ *   --safe-area-inset-bottom = max(latched inset, live env()), set
+ *   unconditionally on iOS native / standalone. The env() term is the
+ *   floor: once the var is set at all, it hides env() from every
+ *   var(--x, env(...)) consumer, so a fixed not-yet-latched 0px would
+ *   shadow a valid env() reading. On a fresh install WKWebView often
+ *   populates env() only after every boot-time probe has run (WASM
+ *   init hogs the main thread past the settle window), which made the
+ *   bottom padding a per-launch coin flip until something latched.
  *
  * The short-viewport state is a broken OS state regardless of what we
  * do (the black band below the shortened window is the system root
@@ -113,7 +119,8 @@ function applyIosBottomInset(): void {
   // last value in landscape rather than computing garbage.
   if (!window.matchMedia('(orientation: portrait)').matches) return;
   latchBottomInset(measureBottomGapPx());
-  const value = `${latchedBottomInsetPx}px`;
+  // env() floor: an unlatched 0 must never shadow a live env() value.
+  const value = `max(${latchedBottomInsetPx}px, env(safe-area-inset-bottom, 0px))`;
   if (value !== lastAppliedInsetVar) {
     lastAppliedInsetVar = value;
     html.style.setProperty('--safe-area-inset-bottom', value);


### PR DESCRIPTION
Fixes an intermittent missing bottom safe-area padding in the native iOS app, introduced by #258.

The iOS bottom-gap path writes `--safe-area-inset-bottom` as a latched pixel value, and a set custom property hides `env()` from every `var(--x, env(...))` consumer. On a fresh install the latch starts at 0, and on cold starts WKWebView often populates `env(safe-area-inset-bottom)` only after all boot-time probes have run (WASM init keeps the main thread busy past the settle window), so the var stayed `0px` for the whole session and the footer sat on the home indicator. Whether a later event (resume, focus) rescued the latch varied per launch, which made the bug look random; once anything latched, localStorage hid it on that install forever.

The fix writes `max(<latched>px, env(safe-area-inset-bottom, 0px))` instead: `env()` passes through while the latch is empty, and the latch still floors the documented full-bleed state where `env()` misreports 0. The short-viewport behavior is unchanged.

**Manual QA:** deployed to a physical iPhone 14; repeated cold launches now show the home-indicator clearance consistently (previously flaky on installs without a latched value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)