### PR TITLE
add LNURL-withdraw

### DIFF
--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -9,7 +9,7 @@ import BitcoinWorkflow from './workflows/BitcoinWorkflow';
 import SparkWorkflow from './workflows/SparkWorkflow';
 import LnurlWorkflow from './workflows/LnurlWorkflow';
 import LnurlAuthWorkflow from './workflows/LnurlAuthWorkflow';
-import LnurlWithdrawWorkflow from './workflows/LnurlWithdrawWorkflow';
+import LnurlWithdrawWorkflow, { LNURL_WITHDRAW_COMPLETION_TIMEOUT_SECS } from './workflows/LnurlWithdrawWorkflow';
 import CrossChainWorkflow from './workflows/CrossChainWorkflow';
 import AmountStep from './steps/AmountStep';
 import ConfirmStep from './steps/ConfirmStep';
@@ -134,7 +134,10 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
             <DialogHeader
               title={dialogTitle}
               onClose={handleClose}
-              icon={send.paymentInput?.parsedInput.type === 'lnurlWithdraw' ? <ArrowDownIcon /> : <ArrowUpIcon />}
+              // The input step is always the send entry point, so it keeps the send
+              // icon even when a scanned lnurl-withdraw is still in paymentInput (e.g.
+              // after Back). Only the withdraw workflow step flips to the receive icon.
+              icon={send.currentStep !== 'input' && send.paymentInput?.parsedInput.type === 'lnurlWithdraw' ? <ArrowDownIcon /> : <ArrowUpIcon />}
             />
 
             {send.currentStep === 'input' && (
@@ -239,7 +242,11 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     parsed={lnurlWithdrawDetails}
                     onBack={() => send.setCurrentStep('input')}
                     onWithdraw={(amountSats) =>
-                      wallet.lnurlWithdraw({ amountSats, withdrawRequest: lnurlWithdrawDetails })
+                      wallet.lnurlWithdraw({
+                        amountSats,
+                        withdrawRequest: lnurlWithdrawDetails,
+                        completionTimeoutSecs: LNURL_WITHDRAW_COMPLETION_TIMEOUT_SECS,
+                      })
                     }
                     onDone={handleClose}
                   />

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -9,6 +9,7 @@ import BitcoinWorkflow from './workflows/BitcoinWorkflow';
 import SparkWorkflow from './workflows/SparkWorkflow';
 import LnurlWorkflow from './workflows/LnurlWorkflow';
 import LnurlAuthWorkflow from './workflows/LnurlAuthWorkflow';
+import LnurlWithdrawWorkflow from './workflows/LnurlWithdrawWorkflow';
 import CrossChainWorkflow from './workflows/CrossChainWorkflow';
 import AmountStep from './steps/AmountStep';
 import ConfirmStep from './steps/ConfirmStep';
@@ -18,9 +19,9 @@ import ContactsSubView from './components/ContactsSubView';
 import { PrepareLnurlPayRequest } from '@breeztech/breez-sdk-spark';
 import { logger, LogCategory } from '@/services/logger';
 import { formatError } from '@/utils/formatError';
-import { ArrowUpIcon } from '@/components/Icons';
+import { ArrowUpIcon, ArrowDownIcon } from '@/components/Icons';
 import { useSendPayment } from './hooks/useSendPayment';
-import { getPaymentMethodName, getLnurlPayRequestDetails, getLnurlAuthRequestDetails } from './utils';
+import { getPaymentMethodName, getLnurlPayRequestDetails, getLnurlAuthRequestDetails, getLnurlWithdrawRequestDetails } from './utils';
 
 interface SendPaymentDialogProps {
   isOpen: boolean;
@@ -91,12 +92,13 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
 
   const lnurlPayDetails = getLnurlPayRequestDetails(send.paymentInput);
   const lnurlAuthDetails = getLnurlAuthRequestDetails(send.paymentInput);
+  const lnurlWithdrawDetails = getLnurlWithdrawRequestDetails(send.paymentInput);
 
   // Prepare can fail before producing a response (e.g. insufficient funds on a
   // fixed-amount payment). With no response and no LNURL workflow to render, show
   // the error on the confirm step with the send action disabled, rather than a
   // blank step. Only read inside the workflow-step block below.
-  const prepareFailed = !send.prepareResponse && !lnurlPayDetails && !lnurlAuthDetails && !!send.error;
+  const prepareFailed = !send.prepareResponse && !lnurlPayDetails && !lnurlAuthDetails && !lnurlWithdrawDetails && !!send.error;
 
   return (
     <BottomSheetContainer isOpen={isOpen} onClose={handleClose} showBackdrop>
@@ -132,7 +134,7 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
             <DialogHeader
               title={dialogTitle}
               onClose={handleClose}
-              icon={<ArrowUpIcon />}
+              icon={send.paymentInput?.parsedInput.type === 'lnurlWithdraw' ? <ArrowDownIcon /> : <ArrowUpIcon />}
             />
 
             {send.currentStep === 'input' && (
@@ -230,6 +232,16 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
                     onAuth={async (requestData) => {
                       return await wallet.lnurlAuth(requestData);
                     }}
+                  />
+                )}
+                {lnurlWithdrawDetails && (
+                  <LnurlWithdrawWorkflow
+                    parsed={lnurlWithdrawDetails}
+                    onBack={() => send.setCurrentStep('input')}
+                    onWithdraw={(amountSats) =>
+                      wallet.lnurlWithdraw({ amountSats, withdrawRequest: lnurlWithdrawDetails })
+                    }
+                    onDone={handleClose}
                   />
                 )}
                 {prepareFailed && (

--- a/src/features/send/hooks/useSendPayment.ts
+++ b/src/features/send/hooks/useSendPayment.ts
@@ -188,7 +188,8 @@ export function useSendPayment(): UseSendPaymentReturn {
       } else if (
         effective.type === 'lnurlPay' ||
         effective.type === 'lightningAddress' ||
-        effective.type === 'lnurlAuth'
+        effective.type === 'lnurlAuth' ||
+        effective.type === 'lnurlWithdraw'
       ) {
         setCurrentStep('workflow');
       } else {

--- a/src/features/send/steps/ProcessingStep.tsx
+++ b/src/features/send/steps/ProcessingStep.tsx
@@ -3,22 +3,25 @@ import type { ProcessingPhase } from '../hooks/useSendPayment';
 
 export interface ProcessingStepProps {
   /** Operation type to customize messaging (default: 'payment') */
-  operationType?: 'payment' | 'auth';
+  operationType?: 'payment' | 'auth' | 'withdraw';
   /** Processing phase for conversion payments */
   processingPhase?: ProcessingPhase;
 }
 
 const ProcessingStep: React.FC<ProcessingStepProps> = ({ operationType = 'payment', processingPhase = 'sending' }) => {
   const isAuth = operationType === 'auth';
+  const isWithdraw = operationType === 'withdraw';
   const isConverting = processingPhase === 'converting';
 
   const getTitle = () => {
     if (isAuth) return 'Authenticating...';
+    if (isWithdraw) return 'Waiting for payment...';
     if (isConverting) return 'Converting...';
     return 'Sending...';
   };
   const getDescription = () => {
     if (isAuth) return 'Please wait while we verify your identity...';
+    if (isWithdraw) return 'Completing the transfer. This can take a moment...';
     if (isConverting) return 'Please wait while we convert the amount...';
     return 'Please wait while we process your transaction...';
   };

--- a/src/features/send/utils.ts
+++ b/src/features/send/utils.ts
@@ -1,5 +1,5 @@
 import type { SendInput } from '@/types/domain';
-import type { LnurlPayRequestDetails, LnurlAuthRequestDetails } from '@breeztech/breez-sdk-spark';
+import type { LnurlPayRequestDetails, LnurlAuthRequestDetails, LnurlWithdrawRequestDetails } from '@breeztech/breez-sdk-spark';
 
 export function getPaymentMethodName(input: SendInput | null): string {
   if (!input) return '';
@@ -16,6 +16,9 @@ export function getPaymentMethodName(input: SendInput | null): string {
       return 'Lightning Address';
     case 'lnurlAuth':
       return 'LNURL Auth';
+    case 'lnurlWithdraw':
+      // Withdraw pulls funds into this wallet, so the dialog reads as a receive.
+      return 'Receive';
     case 'crossChainAddress':
       return 'Send USD';
     default:
@@ -35,6 +38,13 @@ export function getLnurlPayRequestDetails(input: SendInput | null): LnurlPayRequ
 
 export function getLnurlAuthRequestDetails(input: SendInput | null): LnurlAuthRequestDetails | null {
   if (input && input.parsedInput.type === 'lnurlAuth') {
+    return input.parsedInput;
+  }
+  return null;
+}
+
+export function getLnurlWithdrawRequestDetails(input: SendInput | null): LnurlWithdrawRequestDetails | null {
+  if (input && input.parsedInput.type === 'lnurlWithdraw') {
     return input.parsedInput;
   }
   return null;

--- a/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo, useState } from 'react';
+import type { LnurlWithdrawRequestDetails, LnurlWithdrawResponse } from '@breeztech/breez-sdk-spark';
+import { FormError, PrimaryButton, SecondaryButton } from '../../../components/ui';
+import { logger, LogCategory } from '../../../services/logger';
+import { formatError } from '../../../utils/formatError';
+import { formatWithSpaces } from '../../../utils/formatNumber';
+import { useInvoicePaid } from '../../../hooks/useInvoicePaid';
+import ProcessingStep from '../steps/ProcessingStep';
+
+interface LnurlWithdrawWorkflowProps {
+  parsed: LnurlWithdrawRequestDetails;
+  onBack: () => void;
+  /** Runs the withdrawal for `amountSats`. The SDK creates the invoice and posts
+   *  it to the LNURL callback; the funds arrive as an ordinary Lightning receive. */
+  onWithdraw: (amountSats: number) => Promise<LnurlWithdrawResponse>;
+  /** Close the flow once the incoming payment is confirmed. The app-wide
+   *  "Payment Received" celebration is driven by the SDK event, not here. */
+  onDone: () => void;
+}
+
+const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, onBack, onWithdraw, onDone }) => {
+  // LNURL bounds are in msat; withdraw amounts are whole sats. Floor the ceiling
+  // and round the floor up so any chosen amount stays inside the server's msat
+  // window. A sub-1-sat ceiling (maxWithdrawable < 1000 msat) can't be serviced
+  // by a sat-denominated wallet, so surface that rather than rounding up to 1 and
+  // sending an over-max request the callback would reject. `minSats` clamps to
+  // `maxSats` so a sub-sat-wide range collapses to a single fixed amount.
+  const maxSats = useMemo(() => Math.floor(parsed.maxWithdrawable / 1000), [parsed]);
+  const unserviceable = maxSats < 1;
+  const minSats = useMemo(
+    () => Math.min(Math.ceil(parsed.minWithdrawable / 1000), Math.max(maxSats, 1)),
+    [parsed, maxSats],
+  );
+  const isFixed = !unserviceable && minSats === maxSats;
+
+  // Editable amounts default to the max (withdraw everything available).
+  const [amount, setAmount] = useState<string>(String(maxSats));
+  const [error, setError] = useState<string | null>(null);
+  const [isWaiting, setIsWaiting] = useState(false);
+  const [invoice, setInvoice] = useState<string | null>(null);
+
+  // Backstop for when lnurlWithdraw resolves before settlement: close once the
+  // created invoice is paid. Inert until `invoice` is set.
+  useInvoicePaid(invoice, onDone);
+
+  const description = parsed.defaultDescription?.trim();
+  const sourceHost = useMemo(() => {
+    try {
+      return new URL(parsed.callback).host;
+    } catch {
+      return null;
+    }
+  }, [parsed]);
+
+  const amountNum = parseInt(amount, 10) || 0;
+  const outOfRange = amountNum > 0 && (amountNum < minSats || amountNum > maxSats);
+  const validAmount = !unserviceable && (isFixed || (amountNum > 0 && !outOfRange));
+  const inlineError = !isFixed && !unserviceable && outOfRange
+    ? amountNum < minSats
+      ? `Amount must be at least ₿${formatWithSpaces(minSats)}`
+      : `Amount must be at most ₿${formatWithSpaces(maxSats)}`
+    : null;
+
+  const onReceive = async () => {
+    if (unserviceable) return;
+    const sats = isFixed ? maxSats : amountNum;
+    if (sats < minSats || sats > maxSats) {
+      setError(`Amount must be between ₿${formatWithSpaces(minSats)} and ₿${formatWithSpaces(maxSats)}`);
+      return;
+    }
+
+    setError(null);
+    setIsWaiting(true);
+    try {
+      const resp = await onWithdraw(sats);
+      // Settled during the call: done. Otherwise keep waiting for the
+      // invoice-paid event on the invoice the SDK just posted.
+      if (resp.payment) {
+        onDone();
+        return;
+      }
+      setInvoice(resp.paymentRequest);
+    } catch (err) {
+      logger.error(LogCategory.PAYMENT, 'LNURL withdraw failed', { error: formatError(err) });
+      setError(`Withdraw failed: ${formatError(err)}`);
+      setIsWaiting(false);
+    }
+  };
+
+  if (isWaiting) {
+    return <ProcessingStep operationType="withdraw" />;
+  }
+
+  return (
+    <div className="space-y-5">
+      {(description || sourceHost) && (
+        <div className="text-center">
+          {description && <p className="text-spark-text-primary font-medium">{description}</p>}
+          {sourceHost && <p className="text-spark-text-secondary text-sm mt-1">from {sourceHost}</p>}
+        </div>
+      )}
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="block text-sm font-medium text-spark-text-primary">
+            Amount to receive
+          </label>
+          {!isFixed && !unserviceable && (
+            <span className="text-xs text-spark-text-secondary">
+              {formatWithSpaces(minSats)} – {formatWithSpaces(maxSats)} sats
+            </span>
+          )}
+        </div>
+
+        {unserviceable ? (
+          <div className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-secondary text-sm text-center">
+            This withdraw link is below the ₿1 minimum this wallet can receive.
+          </div>
+        ) : isFixed ? (
+          <div className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary flex items-center justify-center text-2xl font-semibold">
+            <span className="inline-flex items-center">
+              <span className="text-[0.8em] opacity-70 mr-px">₿</span>
+              {formatWithSpaces(maxSats)}
+            </span>
+          </div>
+        ) : (
+          <input
+            type="number"
+            inputMode="numeric"
+            value={amount}
+            onChange={(e) => { setAmount(e.target.value); setError(null); }}
+            placeholder={`Between ${formatWithSpaces(minSats)} and ${formatWithSpaces(maxSats)} sats`}
+            className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary placeholder-spark-text-muted focus:border-spark-electric focus:ring-2 focus:ring-spark-electric/20 transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            min={minSats}
+            max={maxSats}
+          />
+        )}
+      </div>
+
+      <FormError error={inlineError || error} />
+
+      <div className="flex gap-3">
+        <SecondaryButton onClick={onBack} className="flex-1">
+          Back
+        </SecondaryButton>
+        <PrimaryButton onClick={onReceive} disabled={!validAmount} className="flex-1">
+          Receive
+        </PrimaryButton>
+      </div>
+    </div>
+  );
+};
+
+export default LnurlWithdrawWorkflow;

--- a/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
@@ -47,14 +47,22 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
     }
   }, [parsed]);
 
-  const amountNum = parseInt(amount, 10) || 0;
-  const outOfRange = amountNum > 0 && (amountNum < minSats || amountNum > maxSats);
-  const validAmount = !unserviceable && (isFixed || (amountNum > 0 && !outOfRange));
-  const inlineError = !isFixed && !unserviceable && outOfRange
-    ? amountNum < minSats
-      ? `Amount must be at least ₿${formatWithSpaces(minSats)}`
-      : `Amount must be at most ₿${formatWithSpaces(maxSats)}`
-    : null;
+  // Validate the input as-is rather than coercing it: a non-integer like "5.5"
+  // or "1e5" is rejected, never parsed into a different value than shown, so what
+  // the field displays is exactly what gets withdrawn.
+  const isInteger = /^\d+$/.test(amount);
+  const amountNum = isInteger ? parseInt(amount, 10) : NaN;
+  const outOfRange = isInteger && (amountNum < minSats || amountNum > maxSats);
+  const validAmount = !unserviceable && (isFixed || (isInteger && !outOfRange));
+  const inlineError = isFixed || unserviceable || amount === ''
+    ? null
+    : !isInteger
+      ? 'Enter a whole number of sats'
+      : amountNum < minSats
+        ? `Amount must be at least ₿${formatWithSpaces(minSats)}`
+        : amountNum > maxSats
+          ? `Amount must be at most ₿${formatWithSpaces(maxSats)}`
+          : null;
 
   // Reached only with a valid, in-range amount: the Receive button is disabled
   // otherwise. The SDK waits up to completionTimeoutSecs for settlement, so the
@@ -99,7 +107,7 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
           </label>
           {!isFixed && !unserviceable && (
             <span className="text-xs text-spark-text-secondary">
-              {formatWithSpaces(minSats)} – {formatWithSpaces(maxSats)} sats
+              {formatWithSpaces(minSats)} to {formatWithSpaces(maxSats)} sats
             </span>
           )}
         </div>

--- a/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWithdrawWorkflow.tsx
@@ -4,8 +4,12 @@ import { FormError, PrimaryButton, SecondaryButton } from '../../../components/u
 import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
 import { formatWithSpaces } from '../../../utils/formatNumber';
-import { useInvoicePaid } from '../../../hooks/useInvoicePaid';
 import ProcessingStep from '../steps/ProcessingStep';
+
+// Seconds the SDK waits for the withdrawal to settle before returning. The SDK
+// bounds the wait, so the await resolves with the outcome (a settled payment or
+// not) and the spinner can't hang.
+export const LNURL_WITHDRAW_COMPLETION_TIMEOUT_SECS = 60;
 
 interface LnurlWithdrawWorkflowProps {
   parsed: LnurlWithdrawRequestDetails;
@@ -19,29 +23,20 @@ interface LnurlWithdrawWorkflowProps {
 }
 
 const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, onBack, onWithdraw, onDone }) => {
-  // LNURL bounds are in msat; withdraw amounts are whole sats. Floor the ceiling
-  // and round the floor up so any chosen amount stays inside the server's msat
-  // window. A sub-1-sat ceiling (maxWithdrawable < 1000 msat) can't be serviced
-  // by a sat-denominated wallet, so surface that rather than rounding up to 1 and
-  // sending an over-max request the callback would reject. `minSats` clamps to
-  // `maxSats` so a sub-sat-wide range collapses to a single fixed amount.
+  // LNURL bounds are in msat; this wallet receives whole sats. Round the floor up
+  // and the ceiling down so any chosen amount stays inside the server's msat
+  // window, and require at least 1 sat. If no whole sat fits that window (a
+  // sub-1-sat ceiling, or a range narrower than a sat that straddles a boundary),
+  // maxSats < minSats and the link is unserviceable.
   const maxSats = useMemo(() => Math.floor(parsed.maxWithdrawable / 1000), [parsed]);
-  const unserviceable = maxSats < 1;
-  const minSats = useMemo(
-    () => Math.min(Math.ceil(parsed.minWithdrawable / 1000), Math.max(maxSats, 1)),
-    [parsed, maxSats],
-  );
+  const minSats = useMemo(() => Math.max(1, Math.ceil(parsed.minWithdrawable / 1000)), [parsed]);
+  const unserviceable = maxSats < minSats;
   const isFixed = !unserviceable && minSats === maxSats;
 
   // Editable amounts default to the max (withdraw everything available).
   const [amount, setAmount] = useState<string>(String(maxSats));
   const [error, setError] = useState<string | null>(null);
   const [isWaiting, setIsWaiting] = useState(false);
-  const [invoice, setInvoice] = useState<string | null>(null);
-
-  // Backstop for when lnurlWithdraw resolves before settlement: close once the
-  // created invoice is paid. Inert until `invoice` is set.
-  useInvoicePaid(invoice, onDone);
 
   const description = parsed.defaultDescription?.trim();
   const sourceHost = useMemo(() => {
@@ -61,25 +56,22 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
       : `Amount must be at most ₿${formatWithSpaces(maxSats)}`
     : null;
 
+  // Reached only with a valid, in-range amount: the Receive button is disabled
+  // otherwise. The SDK waits up to completionTimeoutSecs for settlement, so the
+  // await resolves with the outcome and the spinner can't hang.
   const onReceive = async () => {
-    if (unserviceable) return;
     const sats = isFixed ? maxSats : amountNum;
-    if (sats < minSats || sats > maxSats) {
-      setError(`Amount must be between ₿${formatWithSpaces(minSats)} and ₿${formatWithSpaces(maxSats)}`);
-      return;
-    }
-
     setError(null);
     setIsWaiting(true);
     try {
       const resp = await onWithdraw(sats);
-      // Settled during the call: done. Otherwise keep waiting for the
-      // invoice-paid event on the invoice the SDK just posted.
       if (resp.payment) {
         onDone();
         return;
       }
-      setInvoice(resp.paymentRequest);
+      // Completion window elapsed without settlement.
+      setError('The payment did not arrive in time. Please try again.');
+      setIsWaiting(false);
     } catch (err) {
       logger.error(LogCategory.PAYMENT, 'LNURL withdraw failed', { error: formatError(err) });
       setError(`Withdraw failed: ${formatError(err)}`);
@@ -114,7 +106,7 @@ const LnurlWithdrawWorkflow: React.FC<LnurlWithdrawWorkflowProps> = ({ parsed, o
 
         {unserviceable ? (
           <div className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-secondary text-sm text-center">
-            This withdraw link is below the ₿1 minimum this wallet can receive.
+            This withdraw link has no valid amount this wallet can receive.
           </div>
         ) : isFixed ? (
           <div className="w-full p-4 bg-spark-dark border border-spark-border rounded-xl text-spark-text-primary flex items-center justify-center text-2xl font-semibold">


### PR DESCRIPTION
Add LNURL-withdraw to the general input box flow. The input box is generally for sends, but a withdraw goes there as well. The flow is more logical when scanning a QR.

If min and max are equal, it shows a fixed amount. If not, you can enter an amount.

When clicking receive, it waits until you have the received the amount.