### PR TITLE
disclose payment history doesn't carry over during passkey migration

### DIFF
--- a/src/features/passkey-migration/steps/ExplainStep.tsx
+++ b/src/features/passkey-migration/steps/ExplainStep.tsx
@@ -23,6 +23,9 @@ const ExplainStep: React.FC<ExplainStepProps> = ({ entry, onContinue, onSecondar
         choose <em>Skip</em> to continue.
       </p>
     )}
+    <p className="text-xs text-spark-text-muted mb-4">
+      Your funds are transferred in a single transaction. Your payment history won't carry over.
+    </p>
     <div className="flex flex-col gap-3">
       <PrimaryButton onClick={onContinue}>Continue</PrimaryButton>
       <SecondaryButton onClick={onSecondary}>{entry === 'banner' ? 'Not now' : 'Skip'}</SecondaryButton>


### PR DESCRIPTION
This PR adds a disclosure to the passkey migration step that informs users their payment history won't carry over.