### PR TITLE
fix(passkey): verify the sweep target and scope the RP-pinned credential

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ Device-level keys (`passkeyService.ts`):
 - `passkeyRegistered`: this device has ever successfully used a passkey
 - `passkeyLabel`: active wallet label for the current passkey session
 - `passkeyActiveCredentialId`: the cred we last signed in with; passed back as `allowCredentials` to pin the next derive
+- `passkeyActiveCredentialRpId`: the RP ID that cred lives under; a ceremony targeting a different RP treats the pin as absent (a cross-RP pin never matches and dead-ends the OS sheet)
 - `passkeyFirstSeenAt` / `passkeyLastSeenAt`: device-level timestamps for the first / most recent PRF ceremony
 - `passkeyPendingSwitchFromCredentialId`: the cred we were signed in with before a switch attempt, used by the switch-recovery branch in `PasskeyPage`
 - `passkeyAaguid:<credId>` / `passkeyBackupEligible:<credId>`: provider AAGUID + BE flag captured at create time, drives the provider icon + sync indicator in the management page

--- a/src/services/passkeyMigrationService.test.ts
+++ b/src/services/passkeyMigrationService.test.ts
@@ -6,9 +6,16 @@ import {
   migrateContacts,
   createMigrationSession,
   transferLightningAddress,
+  seedsMatch,
+  RorSeedVerificationError,
 } from './passkeyMigrationService';
-import { setMigrationRorCredentialId, clearMigrationRorCredentialId } from './passkeyService';
-import type { BreezSdk, Contact, GetInfoResponse, LightningAddressInfo } from '@breeztech/breez-sdk-spark';
+import { setMigrationRorCredentialId, clearMigrationRorCredentialId, buildBrowserPasskeyClient } from './passkeyService';
+import type { BreezSdk, Contact, GetInfoResponse, LightningAddressInfo, PasskeyClient, Seed } from '@breeztech/breez-sdk-spark';
+
+vi.mock('./passkeyService', async (importActual) => {
+  const actual = await importActual<typeof import('./passkeyService')>();
+  return { ...actual, buildBrowserPasskeyClient: vi.fn() };
+});
 
 const infoWithPubkey = (identityPubkey: string): GetInfoResponse =>
   ({
@@ -144,6 +151,101 @@ describe('transferLightningAddress', () => {
     const to = { claimLightningAddressTransfer: vi.fn() } as unknown as BreezSdk;
 
     expect(await transferLightningAddress(from, to, 'pk', 'Default')).toBe(true);
+  });
+});
+
+describe('seedsMatch', () => {
+  const seed = (mnemonic: string, passphrase?: string): Seed => ({ type: 'mnemonic', mnemonic, passphrase });
+
+  it('matches identical mnemonics and rejects different ones', () => {
+    expect(seedsMatch(seed('a b c'), seed('a b c'))).toBe(true);
+    expect(seedsMatch(seed('a b c'), seed('x y z'))).toBe(false);
+  });
+
+  it('treats a differing passphrase as a different seed', () => {
+    expect(seedsMatch(seed('a b c', 'p'), seed('a b c'))).toBe(false);
+    expect(seedsMatch(seed('a b c', 'p'), seed('a b c', 'p'))).toBe(true);
+  });
+});
+
+describe('createMigrationSession.createRorCredential', () => {
+  const seedOf = (mnemonic: string): Seed => ({ type: 'mnemonic', mnemonic });
+  const credId = new Uint8Array([9, 9, 9]);
+
+  const mockClient = (registerSeed: Seed, signInSeed: Seed, credentialId: Uint8Array | null = credId) => {
+    const client = {
+      register: vi.fn().mockResolvedValue({
+        wallet: { seed: registerSeed, label: 'Default' },
+        labels: [],
+        credential: credentialId ? { credentialId } : undefined,
+      }),
+      signIn: vi.fn().mockResolvedValue({
+        wallet: { seed: signInSeed, label: 'Default' },
+        labels: [],
+        credential: { credentialId },
+      }),
+    };
+    vi.mocked(buildBrowserPasskeyClient).mockReturnValue(client as unknown as PasskeyClient);
+    return client;
+  };
+
+  it('derives the destination seed pinned to the created credential and reuses it for the primary label', async () => {
+    clearMigrationRorCredentialId();
+    const client = mockClient(seedOf('a b c'), seedOf('a b c'));
+
+    const session = createMigrationSession();
+    await session.createRorCredential('Default');
+
+    // The destination derive is pinned to the just-created credential.
+    expect(client.signIn).toHaveBeenCalledTimes(1);
+    expect(client.signIn).toHaveBeenCalledWith({ label: 'Default', allowCredentials: [credId] });
+    // The pinned seed is handed off without another ceremony.
+    expect(await session.deriveRorSeed('Default')).toEqual(seedOf('a b c'));
+    expect(client.signIn).toHaveBeenCalledTimes(1);
+    clearMigrationRorCredentialId();
+  });
+
+  it('sweeps toward the PINNED wallet, not register\'s unpinned result, when they differ', async () => {
+    clearMigrationRorCredentialId();
+    const client = mockClient(seedOf('a b c'), seedOf('x y z'));
+
+    const session = createMigrationSession();
+    await session.createRorCredential('Default');
+
+    // Sweep toward the pinned derive ('x y z'), not register's unpinned 'a b c'.
+    expect(client.signIn).toHaveBeenCalledWith({ label: 'Default', allowCredentials: [credId] });
+    expect(await session.deriveRorSeed('Default')).toEqual(seedOf('x y z'));
+    clearMigrationRorCredentialId();
+  });
+
+  it('reports a prior credential live after the destination prompt is cancelled, so a retry probes instead of duplicating', async () => {
+    clearMigrationRorCredentialId();
+    const client = {
+      register: vi.fn().mockResolvedValue({
+        wallet: { seed: seedOf('a b c'), label: 'Default' },
+        labels: [],
+        credential: { credentialId: credId },
+      }),
+      signIn: vi.fn().mockRejectedValue(new Error('user cancelled')),
+    };
+    vi.mocked(buildBrowserPasskeyClient).mockReturnValue(client as unknown as PasskeyClient);
+
+    const session = createMigrationSession();
+    await expect(session.createRorCredential('Default')).rejects.toThrow();
+    // rorCredId was set + persisted before the pinned prompt, so the SAME session
+    // routes a retry to the probe branch rather than registering a second passkey.
+    expect(session.hasPriorRorCredential()).toBe(true);
+    clearMigrationRorCredentialId();
+  });
+
+  it('refuses to proceed when the platform reports no credential id', async () => {
+    clearMigrationRorCredentialId();
+    const client = mockClient(seedOf('a b c'), seedOf('a b c'), null);
+
+    await expect(createMigrationSession().createRorCredential('Default'))
+      .rejects.toBeInstanceOf(RorSeedVerificationError);
+    expect(client.signIn).not.toHaveBeenCalled();
+    clearMigrationRorCredentialId();
   });
 });
 

--- a/src/services/passkeyMigrationService.ts
+++ b/src/services/passkeyMigrationService.ts
@@ -168,13 +168,10 @@ export async function transferLightningAddress(
   transfereePubkey: string,
   label: string,
 ): Promise<boolean> {
-  let currentAddress: Awaited<ReturnType<BreezSdk['getLightningAddress']>> = undefined;
-  try {
-    currentAddress = await from.getLightningAddress();
-  } catch (e) {
+  const currentAddress = await from.getLightningAddress().catch((e) => {
     logger.warn(LogCategory.AUTH, 'Migration: failed to fetch lightning address; skipping transfer', { label, error: formatError(e) });
-    return false;
-  }
+    return undefined;
+  });
   if (!currentAddress) return false;
 
   const { username, description } = currentAddress;

--- a/src/services/passkeyMigrationService.ts
+++ b/src/services/passkeyMigrationService.ts
@@ -289,9 +289,10 @@ export function createMigrationSession(): MigrationSession {
   let rorClient: PasskeyClient | null = null;
   // Pin every legacy ceremony (including label discovery) to the active passkey,
   // else the first signIn's picker lets a multi-passkey user drift to a different
-  // wallet and migrate the wrong one. Null (fresh-browser login, no active cred)
+  // wallet and migrate the wrong one. Null (fresh-browser login, no active cred,
+  // or a pin recorded under the ROR RP that can never match a legacy ceremony)
   // falls back to the picker, which is the right way to choose the passkey there.
-  let legacyCredId: Uint8Array | undefined = getActivePasskeyCredentialIdBytes() ?? undefined;
+  let legacyCredId: Uint8Array | undefined = getActivePasskeyCredentialIdBytes(LEGACY_RP_ID) ?? undefined;
   // A prior attempt's ROR credential id (persisted at create time), if any.
   // Seeding rorCredId with it pins the resume probe to that exact passkey.
   const priorRorCredId = getMigrationRorCredentialIdBytes() ?? undefined;

--- a/src/services/passkeyMigrationService.ts
+++ b/src/services/passkeyMigrationService.ts
@@ -42,6 +42,16 @@ export function orderLabelsForMigration(labels: string[], storedLabel: string): 
   return [...others, primary];
 }
 
+/** No credential id from the platform: can't pin the destination derive or resume onto it. */
+export class RorSeedVerificationError extends Error {}
+
+export function seedsMatch(a: Seed, b: Seed): boolean {
+  if (a.type === 'mnemonic' && b.type === 'mnemonic') {
+    return a.mnemonic === b.mnemonic && (a.passphrase ?? '') === (b.passphrase ?? '');
+  }
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
 /** Refuse to migrate a wallet onto itself (a same-identity transfer is a no-op self-send). */
 export function assertDifferentWallet(
   oldInfo: GetInfoResponse,
@@ -298,12 +308,12 @@ export function createMigrationSession(): MigrationSession {
   const priorRorCredId = getMigrationRorCredentialIdBytes() ?? undefined;
   let rorCredId: Uint8Array | undefined = priorRorCredId;
   let rorCredential: RegisterResponse['credential'] = undefined;
-  // Win A: register already derives the primary label's ROR seed; cache it so
-  // deriveRorSeed reuses it instead of running a second ceremony for that label.
+  // The primary label's pinned ROR seed, cached so deriveRorSeed reuses it
+  // instead of running another ceremony for that label.
   let rorPrimarySeed: Seed | undefined;
   let rorPrimaryLabel: string | undefined;
-  // Win B: the label-discovery signIn already derives its (default) label's
-  // legacy seed; cache it so deriveLegacySeed reuses it for that label.
+  // The default label's legacy seed from label discovery, cached so
+  // deriveLegacySeed reuses it for that label.
   let legacyDiscoverySeed: Seed | undefined;
   let legacyDiscoveryLabel: string | undefined;
 
@@ -343,7 +353,7 @@ export function createMigrationSession(): MigrationSession {
 
   return {
     hasPriorRorCredential() {
-      return priorRorCredId !== undefined;
+      return rorCredId !== undefined || getMigrationRorCredentialIdBytes() != null;
     },
     async enumerateLabels(storedLabel) {
       const resp = await legacySignIn();
@@ -352,8 +362,8 @@ export function createMigrationSession(): MigrationSession {
       return orderLabelsForMigration(resp.labels.length > 0 ? resp.labels : [storedLabel], storedLabel);
     },
     async deriveLegacySeed(label) {
-      // Reuse the discovery signIn's seed for its label (Win B); deterministic.
-      // Hand it off once, then drop the session's copy so it does not linger.
+      // Reuse the discovery signIn's seed for its label; hand it off once,
+      // then drop the session's copy so it does not linger.
       if (label === legacyDiscoveryLabel && legacyDiscoverySeed) {
         const seed = legacyDiscoverySeed;
         legacyDiscoverySeed = undefined;
@@ -379,25 +389,34 @@ export function createMigrationSession(): MigrationSession {
       rorClient = registerClient;
       rorCredential = registration.credential;
       logCeremony('Migration: ROR passkey created', ROR_RP_ID as string, false, registration.credential?.credentialId, primaryLabel);
-      if (registration.credential?.credentialId) {
-        rorCredId = registration.credential.credentialId;
-        // Persist immediately: a crash/close after this point (even after some
-        // funds move) must resume onto THIS passkey via a pinned probe, never
-        // create a duplicate wallet.
-        setMigrationRorCredentialId(registration.credential.credentialId);
+      if (!registration.credential?.credentialId) {
+        // No credential id: can't pin the destination derive; refuse before any sweep.
+        throw new RorSeedVerificationError('platform did not report the created credential id');
       }
-      rorPrimarySeed = registration.wallet.seed;
+      rorCredId = registration.credential.credentialId;
+      // Persist now so an interrupted run resumes onto THIS passkey (pinned probe),
+      // never a duplicate.
+      setMigrationRorCredentialId(registration.credential.credentialId);
+      // Pin the destination derive to the created credential: register()'s own
+      // derive is unpinned and can bind to another resident passkey, so ignore
+      // its returned seed in favor of this pinned one.
+      const pinned = await rorSignIn(primaryLabel);
+      if (!seedsMatch(pinned.wallet.seed, registration.wallet.seed)) {
+        logger.warn(LogCategory.AUTH, 'Migration: register-returned seed differs from the pinned derive; using the pinned wallet', {
+          label: primaryLabel,
+        });
+      }
+      rorPrimarySeed = pinned.wallet.seed;
       rorPrimaryLabel = primaryLabel;
     },
     async deriveRorSeed(label) {
-      // Reuse register's already-derived seed for the primary label (Win A).
-      // Deterministic: same passkey + label always yields the same seed. Hand it
-      // off once, then drop the session's copy so it does not linger.
+      // Reuse the pinned primary seed; hand off once, then drop the session's
+      // copy so it does not linger.
       if (label === rorPrimaryLabel && rorPrimarySeed) {
         const seed = rorPrimarySeed;
         rorPrimarySeed = undefined;
         rorPrimaryLabel = undefined;
-        logger.info(LogCategory.AUTH, 'Migration: reusing register-derived ROR seed (no ceremony)', { label });
+        logger.info(LogCategory.AUTH, 'Migration: reusing cached primary seed (no ceremony)', { label });
         return seed;
       }
       return (await rorSignIn(label)).wallet.seed;

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -56,6 +56,7 @@ const PASSKEY_FIRST_SEEN_KEY = 'passkeyFirstSeenAt';
 const PASSKEY_LAST_SEEN_KEY = 'passkeyLastSeenAt';
 const PASSKEY_LABEL_LAST_USED_PREFIX = 'passkeyLabelLastUsed:';
 const PASSKEY_RP_ID_KEY = 'passkeyRpId';
+const PASSKEY_ACTIVE_CRED_RP_KEY = 'passkeyActiveCredentialRpId';
 
 // ---------- PasskeyApi ----------
 
@@ -392,6 +393,10 @@ class WebPasskey implements PasskeyApi {
       userName: request.userName,
       userDisplayName: request.userDisplayName,
     });
+    logger.info(LogCategory.AUTH, 'Passkey register ceremony', {
+      rpId,
+      label: request.label ?? null,
+    });
     try {
       const response = await oneShot.register({
         label: request.label,
@@ -481,6 +486,8 @@ export function recordRegisteredCredential(
   const credentialIdB64 = bytesToBase64(cred.credentialId);
   if (userName) setCredentialUserName(credentialIdB64, userName);
   localStorage.setItem('passkeyActiveCredentialId', credentialIdB64);
+  localStorage.setItem(PASSKEY_ACTIVE_CRED_RP_KEY, rpId);
+  setPasskeyRpId(rpId);
   logger.info(LogCategory.AUTH, 'Passkey credential registered', {
     credentialId: credentialIdB64,
     rpId,
@@ -514,9 +521,11 @@ export function recordRegisteredCredential(
  * the OS picker can't substitute a sibling credential for the same
  * RP and derive a different wallet's seed.
  */
-export function getActivePasskeyCredentialIdBytes(): Uint8Array | null {
+export function getActivePasskeyCredentialIdBytes(forRpId?: string): Uint8Array | null {
   const b64 = localStorage.getItem('passkeyActiveCredentialId');
   if (!b64) return null;
+  const pinRpId = localStorage.getItem(PASSKEY_ACTIVE_CRED_RP_KEY);
+  if (forRpId && pinRpId && pinRpId !== forRpId) return null;
   try {
     return base64ToBytes(b64);
   } catch {
@@ -528,10 +537,14 @@ export function getActivePasskeyCredentialIdBytes(): Uint8Array | null {
  * Pin this cred as active (so subsequent derives constrain
  * `allowCredentials`) and stamp its last-used timestamp.
  */
-export function recordSignedInCredential(credentialId: Uint8Array | undefined): void {
+export function recordSignedInCredential(
+  credentialId: Uint8Array | undefined,
+  ceremonyRpId: string = rpId,
+): void {
   if (!credentialId) return;
   const b64 = bytesToBase64(credentialId);
   localStorage.setItem('passkeyActiveCredentialId', b64);
+  localStorage.setItem(PASSKEY_ACTIVE_CRED_RP_KEY, ceremonyRpId);
   markCredentialUsed(b64);
   markPasskeyUsed();
 }
@@ -551,18 +564,24 @@ export async function signInPinnedToActiveCredential(
   label?: string,
   rpIdOverride?: string,
 ): Promise<SignInResponse> {
-  const activeCredId = getActivePasskeyCredentialIdBytes();
+  const effectiveRpId = rpIdOverride ?? getPasskeyRpId() ?? rpId;
+  const activeCredId = getActivePasskeyCredentialIdBytes(effectiveRpId);
   const allowCredentials = activeCredId ? [activeCredId] : [];
+  logger.info(LogCategory.AUTH, 'Passkey sign-in ceremony', {
+    rpId: effectiveRpId,
+    pinned: !!activeCredId,
+    label: label ?? null,
+  });
   // Web only: derive against a specific RP ID (e.g. a legacy-RP user before
   // migration, whose credential lives under LEGACY_RP_ID). On native the RP ID
   // is fixed by the plugin, so the override is ignored.
-  const useScoped = !Capacitor.isNativePlatform() && !!rpIdOverride && rpIdOverride !== rpId;
+  const useScoped = !Capacitor.isNativePlatform() && effectiveRpId !== rpId;
   let response: SignInResponse;
   if (useScoped) {
     // Sign in on a client scoped to the session RP, then retain it as the
     // cached client. signIn primes the Nostr identity, so a later labels()/store
     // is a cache hit rather than a cold, unpinned re-derive (the OS picker).
-    const client = buildBrowserPasskeyClient({ rpId: rpIdOverride });
+    const client = buildBrowserPasskeyClient({ rpId: effectiveRpId });
     response = await client.signIn({ label, allowCredentials });
     const api = getPasskey();
     if (api instanceof WebPasskey) api.adoptClient(client);
@@ -570,13 +589,13 @@ export async function signInPinnedToActiveCredential(
     response = await getPasskey().signIn({ label, allowCredentials });
   }
   logger.info(LogCategory.AUTH, 'Passkey sign-in ceremony completed', {
-    rpId: rpIdOverride ?? rpId,
+    rpId: effectiveRpId,
     credentialId: response.credential?.credentialId
       ? bytesToBase64(response.credential.credentialId)
       : null,
     label: response.wallet.label,
   });
-  recordSignedInCredential(response.credential?.credentialId);
+  recordSignedInCredential(response.credential?.credentialId, effectiveRpId);
   return response;
 }
 
@@ -726,6 +745,7 @@ export async function clearPasskeyHistory(): Promise<void> {
   }
   localStorage.removeItem(PASSKEY_REGISTERED_KEY);
   localStorage.removeItem('passkeyActiveCredentialId');
+  localStorage.removeItem(PASSKEY_ACTIVE_CRED_RP_KEY);
   localStorage.removeItem(PASSKEY_FIRST_SEEN_KEY);
   localStorage.removeItem(PASSKEY_LAST_SEEN_KEY);
   clearAllLabelLastUsed();
@@ -760,6 +780,7 @@ export function clearPasskeyMode(): void {
   // that must survive logout so the correct RP ID is used on next sign-in.
   localStorage.removeItem(PASSKEY_LABEL_KEY);
   localStorage.removeItem('passkeyActiveCredentialId');
+  localStorage.removeItem(PASSKEY_ACTIVE_CRED_RP_KEY);
   invalidatePasskey();
 }
 
@@ -852,6 +873,7 @@ export function recordMigratedRorCredential(
  */
 export function pinActivePasskeyCredentialId(credentialId: string): void {
   localStorage.setItem('passkeyActiveCredentialId', credentialId);
+  localStorage.setItem(PASSKEY_ACTIVE_CRED_RP_KEY, rpId);
   localStorage.removeItem(PASSKEY_LABEL_KEY);
   unhideCredential(credentialId);
   invalidatePasskey();


### PR DESCRIPTION
Closes #263, closes #264

This PR fixes two problems in the passkey upgrade flow that could block sign-in or move funds somewhere the user can't reach.

The upgrade could sweep funds into a wallet derived from the wrong passkey and still report success, leaving the money unrecoverable. It now verifies the destination is the newly created wallet before moving anything, and stops safely if it isn't.

Switching the passkey RP also left sign-in pointing at the wrong credential, so the next sign-in failed with the OS "no passkey available" prompt. Sign-in is now tied to the selected RP, so the correct passkey is offered.