### PR TITLE
make passkey migration progress more transparent

### DIFF
--- a/src/features/passkey-migration/PasskeyMigrationModal.tsx
+++ b/src/features/passkey-migration/PasskeyMigrationModal.tsx
@@ -50,7 +50,9 @@ const PasskeyMigrationModal: React.FC<PasskeyMigrationModalProps> = (props) => {
           <h2 className="font-display text-lg font-bold text-spark-text-primary">
             {flow.phase === 'done'
               ? 'Upgrade complete'
-              : entry === 'login' ? 'Check passkey' : 'Upgrade passkey'}
+              : flow.isInFlight
+                ? 'Upgrading passkey'
+                : entry === 'login' ? 'Check passkey' : 'Upgrade passkey'}
           </h2>
         </div>
 

--- a/src/features/passkey-migration/PasskeyMigrationModal.tsx
+++ b/src/features/passkey-migration/PasskeyMigrationModal.tsx
@@ -78,7 +78,7 @@ const PasskeyMigrationModal: React.FC<PasskeyMigrationModalProps> = (props) => {
         )}
 
         {flow.phase === 'done' && (
-          <DoneStep onDone={flow.done} lnAddressFailedLabels={flow.lnAddressFailedLabels} />
+          <DoneStep onDone={flow.done} lnAddressFailures={flow.lnAddressFailures} />
         )}
 
         {flow.phase === 'error' && (

--- a/src/features/passkey-migration/PasskeyMigrationModal.tsx
+++ b/src/features/passkey-migration/PasskeyMigrationModal.tsx
@@ -78,7 +78,7 @@ const PasskeyMigrationModal: React.FC<PasskeyMigrationModalProps> = (props) => {
         )}
 
         {flow.phase === 'done' && (
-          <DoneStep onDone={flow.done} lnAddressTransferFailed={flow.lnAddressTransferFailed} />
+          <DoneStep onDone={flow.done} lnAddressFailedLabels={flow.lnAddressFailedLabels} />
         )}
 
         {flow.phase === 'error' && (

--- a/src/features/passkey-migration/hooks/useMigrationFlow.ts
+++ b/src/features/passkey-migration/hooks/useMigrationFlow.ts
@@ -48,8 +48,8 @@ export interface MigrationFlow {
   primaryLabel: string;
   isInFlight: boolean;
   spinnerText: string;
-  /** At least one label's Lightning address could not be moved (funds are fine). */
-  lnAddressTransferFailed: boolean;
+  /** Labels whose Lightning address could not be moved (funds are fine). */
+  lnAddressFailedLabels: string[];
   /** The recorded shared passkey is unreachable (e.g. deleted); offer a fresh start. */
   canStartOver: boolean;
   // actions
@@ -82,7 +82,10 @@ export function useMigrationFlow({
   const [primaryLabel, setPrimaryLabel] = useState('Default');
   // Set if any label's Lightning-address transfer fails; surfaces a Done-screen
   // notice (funds still moved, but incoming LN may land in the old wallet).
-  const [lnAddressTransferFailed, setLnAddressTransferFailed] = useState(false);
+  const [lnAddressFailedLabels, setLnAddressFailedLabels] = useState<string[]>([]);
+  // Current sub-step of the silent sweep, so a long move reads as progress
+  // (connect + sync sits under 'funds', then the address, then contacts).
+  const [sweepDetail, setSweepDetail] = useState<'funds' | 'Lightning address' | 'contacts'>('funds');
   // Set only when a recorded shared passkey can't be reached (e.g. the user deleted
   // it): the error screen then offers a fresh start instead of a Retry dead-end.
   const [canStartOver, setCanStartOver] = useState(false);
@@ -129,7 +132,7 @@ export function useMigrationFlow({
     setUnclaimedCount(0);
     setConfirmedLabels([]);
     setCurrentLabelIndex(0);
-    setLnAddressTransferFailed(false);
+    setLnAddressFailedLabels([]);
     setCanStartOver(false);
     labelsToMigrateRef.current = [];
     seedCacheRef.current = new Map();
@@ -417,6 +420,9 @@ export function useMigrationFlow({
       const isLast = index === labels.length - 1;
 
       logger.info(LogCategory.AUTH, 'Migration sweep-label: starting', { label, index, total: labels.length, isLast });
+      // Connect + sync + balance sweep all read as "funds"; the address and
+      // contacts get their own sub-step below.
+      setSweepDetail('funds');
 
       let oldSdk: BreezSdk | null = null;
       let oldSdkOwnedByModal = false;
@@ -476,9 +482,11 @@ export function useMigrationFlow({
         // 5. Sweep sats + tokens, transfer the Lightning address, migrate contacts.
         await sweepBalances(oldSdk, newSdk, oldInfo, label);
         if (cancelled) return;
+        setSweepDetail('Lightning address');
         const lnTransferFailed = await transferLightningAddress(oldSdk, newSdk, newInfo.identityPubkey, label);
-        if (lnTransferFailed) setLnAddressTransferFailed(true);
+        if (lnTransferFailed) setLnAddressFailedLabels((prev) => [...prev, label]);
         if (cancelled) return;
+        setSweepDetail('contacts');
         await migrateContacts(oldSdk, newSdk, label);
         if (cancelled) return;
 
@@ -631,7 +639,7 @@ export function useMigrationFlow({
     setCurrentLabelIndex(0);
     // A retry re-runs every label's transfer, so clear the prior run's warning:
     // otherwise a transient read failure leaves a false notice after a clean retry.
-    setLnAddressTransferFailed(false);
+    setLnAddressFailedLabels([]);
     // Re-validate state before sweeping if we already have a label list;
     // otherwise restart from enumeration / explain.
     if (labelsToMigrateRef.current.length > 0) {
@@ -656,7 +664,7 @@ export function useMigrationFlow({
     setError(null);
     setCanStartOver(false);
     setCurrentLabelIndex(0);
-    setLnAddressTransferFailed(false);
+    setLnAddressFailedLabels([]);
     setPhase('derive-new-passkey');
   }, []);
 
@@ -676,9 +684,9 @@ export function useMigrationFlow({
       case 'derive-new-passkey': return 'Setting up your new passkey...';
       case 'sweep-label': {
         if (confirmedLabels.length > 1) {
-          return `Moving your funds (${currentLabelIndex + 1} of ${confirmedLabels.length})...`;
+          return `Moving your ${sweepDetail} (${currentLabelIndex + 1} of ${confirmedLabels.length})...`;
         }
-        return 'Moving your funds...';
+        return `Moving your ${sweepDetail}...`;
       }
       case 'switch': return 'Finishing up...';
       default: return '';
@@ -693,7 +701,7 @@ export function useMigrationFlow({
     primaryLabel,
     isInFlight,
     spinnerText,
-    lnAddressTransferFailed,
+    lnAddressFailedLabels,
     canStartOver,
     startFromBanner,
     checkForOldPasskey,

--- a/src/features/passkey-migration/hooks/useMigrationFlow.ts
+++ b/src/features/passkey-migration/hooks/useMigrationFlow.ts
@@ -29,7 +29,7 @@ import {
   type MigrationSession,
 } from '@/services/passkeyMigrationService';
 import { formatError } from '@/utils/formatError';
-import type { MigrationEntry, MigrationOutcome, MigrationPhase } from '../types';
+import type { LnAddressFailure, MigrationEntry, MigrationOutcome, MigrationPhase } from '../types';
 
 export interface UseMigrationFlowArgs {
   isOpen: boolean;
@@ -49,7 +49,7 @@ export interface MigrationFlow {
   isInFlight: boolean;
   spinnerText: string;
   /** Labels whose Lightning address could not be moved (funds are fine). */
-  lnAddressFailedLabels: string[];
+  lnAddressFailures: LnAddressFailure[];
   /** The recorded shared passkey is unreachable (e.g. deleted); offer a fresh start. */
   canStartOver: boolean;
   // actions
@@ -82,7 +82,7 @@ export function useMigrationFlow({
   const [primaryLabel, setPrimaryLabel] = useState('Default');
   // Set if any label's Lightning-address transfer fails; surfaces a Done-screen
   // notice (funds still moved, but incoming LN may land in the old wallet).
-  const [lnAddressFailedLabels, setLnAddressFailedLabels] = useState<string[]>([]);
+  const [lnAddressFailures, setLnAddressFailures] = useState<LnAddressFailure[]>([]);
   // Current sub-step of the silent sweep, so a long move reads as progress
   // (connect + sync sits under 'funds', then the address, then contacts).
   const [sweepDetail, setSweepDetail] = useState<'funds' | 'Lightning address' | 'contacts'>('funds');
@@ -132,7 +132,7 @@ export function useMigrationFlow({
     setUnclaimedCount(0);
     setConfirmedLabels([]);
     setCurrentLabelIndex(0);
-    setLnAddressFailedLabels([]);
+    setLnAddressFailures([]);
     setCanStartOver(false);
     labelsToMigrateRef.current = [];
     seedCacheRef.current = new Map();
@@ -483,8 +483,8 @@ export function useMigrationFlow({
         await sweepBalances(oldSdk, newSdk, oldInfo, label);
         if (cancelled) return;
         setSweepDetail('Lightning address');
-        const lnTransferFailed = await transferLightningAddress(oldSdk, newSdk, newInfo.identityPubkey, label);
-        if (lnTransferFailed) setLnAddressFailedLabels((prev) => [...prev, label]);
+        const failedAddress = await transferLightningAddress(oldSdk, newSdk, newInfo.identityPubkey, label);
+        if (failedAddress) setLnAddressFailures((prev) => [...prev, { label, address: failedAddress }]);
         if (cancelled) return;
         setSweepDetail('contacts');
         await migrateContacts(oldSdk, newSdk, label);
@@ -639,7 +639,7 @@ export function useMigrationFlow({
     setCurrentLabelIndex(0);
     // A retry re-runs every label's transfer, so clear the prior run's warning:
     // otherwise a transient read failure leaves a false notice after a clean retry.
-    setLnAddressFailedLabels([]);
+    setLnAddressFailures([]);
     // Re-validate state before sweeping if we already have a label list;
     // otherwise restart from enumeration / explain.
     if (labelsToMigrateRef.current.length > 0) {
@@ -664,7 +664,7 @@ export function useMigrationFlow({
     setError(null);
     setCanStartOver(false);
     setCurrentLabelIndex(0);
-    setLnAddressFailedLabels([]);
+    setLnAddressFailures([]);
     setPhase('derive-new-passkey');
   }, []);
 
@@ -701,7 +701,7 @@ export function useMigrationFlow({
     primaryLabel,
     isInFlight,
     spinnerText,
-    lnAddressFailedLabels,
+    lnAddressFailures,
     canStartOver,
     startFromBanner,
     checkForOldPasskey,

--- a/src/features/passkey-migration/steps/DoneStep.tsx
+++ b/src/features/passkey-migration/steps/DoneStep.tsx
@@ -3,20 +3,21 @@ import { PrimaryButton } from '@/components/ui/buttons';
 
 interface DoneStepProps {
   onDone: () => void;
-  /** Warn that incoming Lightning payments may still land in the old wallet. */
-  lnAddressTransferFailed?: boolean;
+  /** Labels whose Lightning address couldn't be moved (funds are fine). */
+  lnAddressFailedLabels?: string[];
 }
 
 /** Success screen after the new wallet has been adopted. */
-const DoneStep: React.FC<DoneStepProps> = ({ onDone, lnAddressTransferFailed }) => (
+const DoneStep: React.FC<DoneStepProps> = ({ onDone, lnAddressFailedLabels = [] }) => (
   <>
     <p className="text-sm text-spark-text-secondary mb-4 text-center">
       Your funds have been moved to your new passkey.
     </p>
-    {lnAddressTransferFailed && (
+    {lnAddressFailedLabels.length > 0 && (
       <p className="text-xs text-spark-warning mb-4 text-center">
-        Your Lightning address couldn't be transferred. 
-        Payments sent to it will continue to arrive in your old wallet until the transfer is complete.
+        {lnAddressFailedLabels.length === 1
+          ? `Your Lightning address for "${lnAddressFailedLabels[0]}" couldn't be transferred. Payments sent to it will continue to arrive in your old wallet until the transfer is complete.`
+          : `Your Lightning addresses for ${lnAddressFailedLabels.map((l) => `"${l}"`).join(', ')} couldn't be transferred. Payments sent to them will continue to arrive in your old wallets until the transfers are complete.`}
       </p>
     )}
     <div className="flex flex-col gap-3">

--- a/src/features/passkey-migration/steps/DoneStep.tsx
+++ b/src/features/passkey-migration/steps/DoneStep.tsx
@@ -1,24 +1,40 @@
 import React from 'react';
 import { PrimaryButton } from '@/components/ui/buttons';
+import type { LnAddressFailure } from '../types';
 
 interface DoneStepProps {
   onDone: () => void;
-  /** Labels whose Lightning address couldn't be moved (funds are fine). */
-  lnAddressFailedLabels?: string[];
+  /** Lightning addresses that couldn't be moved (funds are fine either way). */
+  lnAddressFailures?: LnAddressFailure[];
 }
 
 /** Success screen after the new wallet has been adopted. */
-const DoneStep: React.FC<DoneStepProps> = ({ onDone, lnAddressFailedLabels = [] }) => (
+const DoneStep: React.FC<DoneStepProps> = ({ onDone, lnAddressFailures = [] }) => (
   <>
     <p className="text-sm text-spark-text-secondary mb-4 text-center">
       Your funds have been moved to your new passkey.
     </p>
-    {lnAddressFailedLabels.length > 0 && (
-      <p className="text-xs text-spark-warning mb-4 text-center">
-        {lnAddressFailedLabels.length === 1
-          ? `Your Lightning address for "${lnAddressFailedLabels[0]}" couldn't be transferred. Payments sent to it will continue to arrive in your old wallet until the transfer is complete.`
-          : `Your Lightning addresses for ${lnAddressFailedLabels.map((l) => `"${l}"`).join(', ')} couldn't be transferred. Payments sent to them will continue to arrive in your old wallets until the transfers are complete.`}
-      </p>
+    {lnAddressFailures.length > 0 && (
+      <div className="mb-4">
+        <p className="text-xs text-spark-warning mb-2 text-center">
+          {lnAddressFailures.length === 1
+            ? "This Lightning address couldn't be transferred:"
+            : "These Lightning addresses couldn't be transferred:"}
+        </p>
+        <ul className="space-y-1.5">
+          {lnAddressFailures.map(({ label, address }) => (
+            <li key={label} className="rounded-xl border border-spark-border bg-spark-dark px-3 py-2 text-left">
+              <div className="text-sm font-medium text-spark-text-primary break-all">{address}</div>
+              <div className="text-xs text-spark-text-muted">{label}</div>
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-spark-warning mt-2 text-center">
+          {lnAddressFailures.length === 1
+            ? "Payments sent to it will continue to arrive in your old wallet until the transfer is complete."
+            : "Payments sent to them will continue to arrive in your old wallets until the transfers are complete."}
+        </p>
+      </div>
     )}
     <div className="flex flex-col gap-3">
       <PrimaryButton onClick={onDone}>Done</PrimaryButton>

--- a/src/features/passkey-migration/steps/MigrationProgressStep.tsx
+++ b/src/features/passkey-migration/steps/MigrationProgressStep.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AnimatePresence, motion } from 'motion/react';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { AlertTriangleIcon } from '@/components/Icons';
 
@@ -9,7 +10,22 @@ interface MigrationProgressStepProps {
 /** In-flight spinner shared by every working phase, with a keep-open reminder. */
 const MigrationProgressStep: React.FC<MigrationProgressStepProps> = ({ text }) => (
   <div className="flex flex-col items-center justify-center py-6">
-    <LoadingSpinner text={text} />
+    <LoadingSpinner />
+    {/* Crossfade the label so a phase or sub-step change reads as forward progress, not a jump. */}
+    <div className="mt-4 h-5 flex items-center justify-center overflow-hidden">
+      <AnimatePresence mode="wait">
+        <motion.p
+          key={text}
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -6 }}
+          transition={{ duration: 0.2, ease: 'easeOut' }}
+          className="font-display font-medium text-spark-text-primary text-sm"
+        >
+          {text}
+        </motion.p>
+      </AnimatePresence>
+    </div>
     <div className="mt-3 flex items-center justify-center gap-2 text-xs text-amber-400/80">
       <AlertTriangleIcon size="xs" />
       <span>Keep this window open</span>

--- a/src/features/passkey-migration/types.ts
+++ b/src/features/passkey-migration/types.ts
@@ -1,6 +1,9 @@
 /** Where the migration modal was opened from. */
 export type MigrationEntry = 'banner' | 'login';
 
+/** A label whose Lightning address couldn't be moved, with the address that still routes to the old wallet. */
+export type LnAddressFailure = { label: string; address: string };
+
 /** Outcome reported back to the caller when the modal closes. */
 export type MigrationOutcome =
   /** No old passkey found / user skipped. Caller may proceed with a fresh shared passkey. */

--- a/src/services/passkeyMigrationService.test.ts
+++ b/src/services/passkeyMigrationService.test.ts
@@ -124,33 +124,33 @@ describe('migrateContacts', () => {
 describe('transferLightningAddress', () => {
   const lnInfo = { username: 'alice', description: 'desc', lightningAddress: 'alice@x' } as LightningAddressInfo;
 
-  it('returns false when there is no address to move', async () => {
+  it('returns null when there is no address to move', async () => {
     const from = { getLightningAddress: vi.fn().mockResolvedValue(undefined) } as unknown as BreezSdk;
     const to = { claimLightningAddressTransfer: vi.fn() } as unknown as BreezSdk;
 
-    expect(await transferLightningAddress(from, to, 'pk', 'Default')).toBe(false);
+    expect(await transferLightningAddress(from, to, 'pk', 'Default')).toBeNull();
     expect(to.claimLightningAddressTransfer).not.toHaveBeenCalled();
   });
 
-  it('returns false on a successful transfer', async () => {
+  it('returns null on a successful transfer', async () => {
     const from = {
       getLightningAddress: vi.fn().mockResolvedValue(lnInfo),
       authorizeLightningAddressTransfer: vi.fn().mockResolvedValue({ username: 'alice', pubkey: 'p', signature: 's' }),
     } as unknown as BreezSdk;
     const to = { claimLightningAddressTransfer: vi.fn().mockResolvedValue(lnInfo) } as unknown as BreezSdk;
 
-    expect(await transferLightningAddress(from, to, 'pk', 'Default')).toBe(false);
+    expect(await transferLightningAddress(from, to, 'pk', 'Default')).toBeNull();
     expect(to.claimLightningAddressTransfer).toHaveBeenCalled();
   });
 
-  it('returns true when the address exists but the transfer throws', async () => {
+  it('returns the failed address when the address exists but the transfer throws', async () => {
     const from = {
       getLightningAddress: vi.fn().mockResolvedValue(lnInfo),
       authorizeLightningAddressTransfer: vi.fn().mockRejectedValue(new Error('boom')),
     } as unknown as BreezSdk;
     const to = { claimLightningAddressTransfer: vi.fn() } as unknown as BreezSdk;
 
-    expect(await transferLightningAddress(from, to, 'pk', 'Default')).toBe(true);
+    expect(await transferLightningAddress(from, to, 'pk', 'Default')).toBe('alice@x');
   });
 });
 

--- a/src/services/passkeyMigrationService.ts
+++ b/src/services/passkeyMigrationService.ts
@@ -158,36 +158,36 @@ export async function sweepBalances(
  *
  * Best effort: failures are logged but never block the migration. If the
  * current Lightning address can't be determined, the transfer is skipped.
- * Returns `true` only when a transfer was attempted and failed, allowing the
- * caller to warn that incoming Lightning payments may still arrive at the
- * original address.
+ * Returns the failed Lightning address only when a transfer was attempted and
+ * failed, so the caller can tell the user which address still routes to the
+ * old wallet; otherwise `null`.
  */
 export async function transferLightningAddress(
   from: BreezSdk,
   to: BreezSdk,
   transfereePubkey: string,
   label: string,
-): Promise<boolean> {
+): Promise<string | null> {
   const currentAddress = await from.getLightningAddress().catch((e) => {
     logger.warn(LogCategory.AUTH, 'Migration: failed to fetch lightning address; skipping transfer', { label, error: formatError(e) });
     return undefined;
   });
-  if (!currentAddress) return false;
+  if (!currentAddress) return null;
 
-  const { username, description } = currentAddress;
+  const { username, description, lightningAddress } = currentAddress;
   logger.info(LogCategory.AUTH, 'Migration: transferring lightning address', { label, username });
   try {
     const authorization = await from.authorizeLightningAddressTransfer({ transfereePubkey });
     await to.claimLightningAddressTransfer({ authorization, description });
     logger.info(LogCategory.AUTH, 'Migration: lightning address transferred', { label, username });
-    return false;
+    return null;
   } catch (e) {
     logger.error(LogCategory.AUTH, 'Migration: lightning address transfer failed', {
       label,
       username,
       error: formatError(e),
     });
-    return true;
+    return lightningAddress;
   }
 }
 


### PR DESCRIPTION
This PR improves the passkey migration UX by making progress steps clearer and partial migrations more explicit.

During migration, the progress screen now reflects what's actually happening: migrating funds, then LN addresses, then contacts. Steps transition smoothly from one to the next, and the title now reads "Upgrading passkey" so it's clear the migration is still in progress.

If a LN address failed to transfer, the completion screen now lists the specific addresses that weren't transferred (one per wallet) instead of showing a generic warning. This makes it clear which addresses still point to the legacy passkey.