### PR TITLE
Add option to reset passkey migration state to developer settings

### DIFF
--- a/src/pages/PasskeyLocalStatePage.tsx
+++ b/src/pages/PasskeyLocalStatePage.tsx
@@ -9,6 +9,7 @@ import {
   clearAllCredentialMeta,
   clearAllHiddenCredentials,
   clearAllCredentialAaguids,
+  resetPasskeyMigrationState,
 } from '../services/passkeyService';
 import { useToast } from '@/contexts/ToastContext';
 import { logger, LogCategory } from '@/services/logger';
@@ -26,7 +27,7 @@ interface PasskeyLocalStatePageProps {
   onCompleted: () => void;
 }
 
-type ConfirmKind = 'forget' | 'wipe' | 'aaguids' | null;
+type ConfirmKind = 'forget' | 'wipe' | 'aaguids' | 'resetMigration' | null;
 
 // `passkeyHome` is where the OS keeps the passkey itself. `systemDelete`
 // is the surface users navigate to remove it. The credential IDs Glow
@@ -129,10 +130,18 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack, o
     setConfirm(null);
   };
 
+  const handleResetMigration = () => {
+    resetPasskeyMigrationState();
+    showToast('success', 'Migration state reset');
+    setConfirm(null);
+    onCompleted();
+  };
+
   const items: Array<{ kind: ConfirmKind; title: string }> = [
     { kind: 'forget', title: 'Forget history' },
     { kind: 'wipe', title: 'Wipe tracked passkeys' },
     { kind: 'aaguids', title: 'Clear provider info' },
+    { kind: 'resetMigration', title: 'Reset migration state' },
   ];
 
   return (
@@ -185,6 +194,17 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack, o
         cancelLabel="Cancel"
         variant="danger"
         onConfirm={handleClearAaguids}
+        onCancel={() => setConfirm(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={confirm === 'resetMigration'}
+        title="Reset migration state?"
+        message="Dev only. Re-arms the passkey-RP migration: clears the migrated flag, reverts to the legacy RP, and drops any in-flight migration passkey. Glow signs you out; sign in with your legacy passkey to run the migration again."
+        confirmLabel="Reset"
+        cancelLabel="Cancel"
+        variant="warning"
+        onConfirm={handleResetMigration}
         onCancel={() => setConfirm(null)}
       />
     </SlideInPage>

--- a/src/pages/PasskeyLocalStatePage.tsx
+++ b/src/pages/PasskeyLocalStatePage.tsx
@@ -200,7 +200,7 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack, o
       <ConfirmDialog
         isOpen={confirm === 'resetMigration'}
         title="Reset migration state?"
-        message="Dev only. Re-arms the passkey-RP migration: clears the migrated flag, reverts to the legacy RP, and drops any in-flight migration passkey. Glow signs you out; sign in with your legacy passkey to run the migration again."
+        message="Resets the passkey migration by clearing the migration flag, reverting to the legacy RP, and removing any in-progress migration passkey. Glow will sign you out. Sign in with your legacy passkey to run the migration again."
         confirmLabel="Reset"
         cancelLabel="Cancel"
         variant="warning"

--- a/src/pages/PasskeySettingsPage.tsx
+++ b/src/pages/PasskeySettingsPage.tsx
@@ -56,7 +56,7 @@ const PasskeySettingsPage: React.FC<PasskeySettingsPageProps> = ({
   const [activeRpId, setActiveRpId] = useState<string>(getPasskeyRpId() ?? LEGACY_RP_ID);
   const rpIdOptions = [
     { label: 'Legacy', value: LEGACY_RP_ID },
-    { label: 'shared', value: SHARED_RP_ID ?? LEGACY_RP_ID },
+    { label: 'Shared', value: SHARED_RP_ID ?? LEGACY_RP_ID },
   ];
 
   return (

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -23,7 +23,7 @@ import {
 } from '@breeztech/breez-sdk-spark/passkey-prf-provider';
 import { Capacitor } from '@capacitor/core';
 import { LocalStorageCredentialRegistry } from './localStorageCredentialRegistry';
-import { rpId, rpName, signalUnknownCredentials } from './passkeyPrfProvider';
+import { rpId, rpName, signalUnknownCredentials, LEGACY_RP_ID } from './passkeyPrfProvider';
 import { logger, LogCategory } from './logger';
 import {
   clearAllCredentialMeta,
@@ -821,6 +821,22 @@ export function isPasskeyMigrated(): boolean {
 export function setPasskeyMigrated(): void {
   localStorage.setItem(PASSKEY_MIGRATED_KEY, 'true');
   logger.info(LogCategory.AUTH, 'Marked passkey as migrated');
+}
+
+/**
+ * Dev/test only: re-arm the passkey-RP migration. Drops the migrated flag,
+ * reverts to the legacy RP (so the next sign-in is on the legacy wallet and
+ * `onLegacyRp` holds), and clears any in-flight migration credential so a
+ * re-run creates a fresh shared passkey instead of resuming onto an old one.
+ */
+export function resetPasskeyMigrationState(): void {
+  localStorage.removeItem(PASSKEY_MIGRATED_KEY);
+  // Pin the RP back to legacy explicitly. Removing the key falls back to the
+  // module default (the shared RP when configured), which would leave the next
+  // sign-in on the new RP instead of the legacy wallet.
+  setPasskeyRpId(LEGACY_RP_ID);
+  clearMigrationSharedCredentialId();
+  logger.warn(LogCategory.AUTH, 'Reset passkey migration state (dev)');
 }
 
 // The shared credential id created mid-migration, persisted (base64) the moment


### PR DESCRIPTION
This PR adds an option to reset the passkey migration state for recovery and troubleshooting.

A new Reset migration state action is available in the developer settings. It clears the migration flag, reverts to the legacy passkey, removes any in-progress migration passkey, and signs out so the migration can be run again from a clean state.

Also cleans up the RP switch label and the reset confirmation text.