### PR TITLE
remember migrated credentials for switching passkeys

### DIFF
--- a/src/pages/PasskeyLocalStatePage.tsx
+++ b/src/pages/PasskeyLocalStatePage.tsx
@@ -9,6 +9,7 @@ import {
   clearAllCredentialMeta,
   clearAllHiddenCredentials,
   clearAllCredentialAaguids,
+  clearMigrationCredentialPairs,
   resetPasskeyMigrationState,
 } from '../services/passkeyService';
 import { useToast } from '@/contexts/ToastContext';
@@ -102,6 +103,7 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack, o
     clearAllLabelLastUsed();
     clearAllCredentialMeta();
     clearAllHiddenCredentials();
+    clearMigrationCredentialPairs();
     // AAGUIDs intentionally kept: they're only captured at create
     // time and not recoverable on sign-in. Wiping them would lose
     // provider name/icon for any credential that still exists on the

--- a/src/services/passkeyMigrationService.ts
+++ b/src/services/passkeyMigrationService.ts
@@ -18,7 +18,7 @@ import {
 } from '@breeztech/breez-sdk-spark';
 import { buildConnectConfig } from '@/hooks/buildConnectConfig';
 import { logger, LogCategory } from './logger';
-import { buildBrowserPasskeyClient, recordMigratedSharedCredential, getActivePasskeyCredentialIdBytes, adoptSessionPasskeyClient, setMigrationSharedCredentialId, getMigrationSharedCredentialIdBytes, bytesToBase64 } from './passkeyService';
+import { buildBrowserPasskeyClient, recordMigratedSharedCredential, recordMigrationCredentialPair, getActivePasskeyCredentialIdBytes, adoptSessionPasskeyClient, setMigrationSharedCredentialId, getMigrationSharedCredentialIdBytes, bytesToBase64 } from './passkeyService';
 import { LEGACY_RP_ID, SHARED_RP_ID, createPasskeyTimestampLabel, PasskeyCredentialNotFoundError } from './passkeyPrfProvider';
 import { formatError } from '../utils/formatError';
 
@@ -413,6 +413,17 @@ export function createMigrationSession(): MigrationSession {
     },
     commitSharedCredential() {
       if (sharedCredential && SHARED_RP_ID) {
+        // Pair the legacy source passkey with this shared destination so a later
+        // RP switch pins straight to the counterpart. Keyed by the legacy cred:
+        // re-migrating the same passkey (after a reset) overrides its old pair.
+        if (legacyCredId && sharedCredential.credentialId) {
+          recordMigrationCredentialPair(
+            LEGACY_RP_ID,
+            bytesToBase64(legacyCredId),
+            SHARED_RP_ID,
+            bytesToBase64(sharedCredential.credentialId),
+          );
+        }
         recordMigratedSharedCredential(sharedCredential, userName, SHARED_RP_ID);
       }
       // Hand the primed, pinned shared client to the app session so post-migration

--- a/src/services/passkeyService.test.ts
+++ b/src/services/passkeyService.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  recordMigrationCredentialPair,
+  getMigrationCounterpartCredentialIdBytes,
+  clearMigrationCredentialPairs,
+  bytesToBase64,
+} from './passkeyService';
+
+const LEGACY = 'legacy.example';
+const SHARED = 'shared.example';
+
+// Credential ids are stored as base64, so use real base64 (the getter decodes it).
+const cred = (n: number) => bytesToBase64(new Uint8Array([n, n, n]));
+const legacyA = cred(1);
+const sharedA = cred(2);
+const legacyB = cred(3);
+const sharedB = cred(4);
+
+const setActive = (credId: string, rpId: string) => {
+  localStorage.setItem('passkeyActiveCredentialId', credId);
+  localStorage.setItem('passkeyActiveCredentialRpId', rpId);
+};
+const counterpart = (targetRp: string) => {
+  const bytes = getMigrationCounterpartCredentialIdBytes(targetRp);
+  return bytes ? bytesToBase64(bytes) : null;
+};
+
+describe('migration credential pairs', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('pins the shared counterpart when signed in on the legacy credential', () => {
+    recordMigrationCredentialPair(LEGACY, legacyA, SHARED, sharedA);
+    setActive(legacyA, LEGACY);
+    expect(counterpart(SHARED)).toBe(sharedA);
+  });
+
+  it('pins the legacy counterpart when signed in on the shared credential (reverse)', () => {
+    recordMigrationCredentialPair(LEGACY, legacyA, SHARED, sharedA);
+    setActive(sharedA, SHARED);
+    expect(counterpart(LEGACY)).toBe(legacyA);
+  });
+
+  it('keeps only the latest destination when the same source is re-migrated', () => {
+    recordMigrationCredentialPair(LEGACY, legacyA, SHARED, sharedA);
+    recordMigrationCredentialPair(LEGACY, legacyA, SHARED, sharedB);
+    setActive(legacyA, LEGACY);
+    expect(counterpart(SHARED)).toBe(sharedB);
+    // the stale destination no longer reverse-maps
+    setActive(sharedA, SHARED);
+    expect(counterpart(LEGACY)).toBeNull();
+  });
+
+  it('accumulates pairs for distinct source passkeys', () => {
+    recordMigrationCredentialPair(LEGACY, legacyA, SHARED, sharedA);
+    recordMigrationCredentialPair(LEGACY, legacyB, SHARED, sharedB);
+    setActive(legacyA, LEGACY);
+    expect(counterpart(SHARED)).toBe(sharedA);
+    setActive(legacyB, LEGACY);
+    expect(counterpart(SHARED)).toBe(sharedB);
+  });
+
+  it('returns null for an active credential with no recorded pair', () => {
+    recordMigrationCredentialPair(LEGACY, legacyA, SHARED, sharedA);
+    setActive(cred(9), LEGACY);
+    expect(counterpart(SHARED)).toBeNull();
+  });
+
+  it('ignores a degenerate same-RP pair', () => {
+    recordMigrationCredentialPair(LEGACY, legacyA, LEGACY, sharedA);
+    setActive(legacyA, LEGACY);
+    expect(counterpart(LEGACY)).toBeNull();
+  });
+
+  it('clears all pairs', () => {
+    recordMigrationCredentialPair(LEGACY, legacyA, SHARED, sharedA);
+    clearMigrationCredentialPairs();
+    setActive(legacyA, LEGACY);
+    expect(counterpart(SHARED)).toBeNull();
+  });
+});

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -565,11 +565,15 @@ export async function signInPinnedToActiveCredential(
   rpIdOverride?: string,
 ): Promise<SignInResponse> {
   const effectiveRpId = rpIdOverride ?? getPasskeyRpId() ?? rpId;
-  const activeCredId = getActivePasskeyCredentialIdBytes(effectiveRpId);
-  const allowCredentials = activeCredId ? [activeCredId] : [];
+  // Same-RP pin first. On a cross-RP switch (the active pin is for the other RP)
+  // fall back to the migrated counterpart credential for this RP, so the OS goes
+  // straight to it instead of listing every passkey. Null on both => OS picker.
+  const pinCredId = getActivePasskeyCredentialIdBytes(effectiveRpId)
+    ?? getMigrationCounterpartCredentialIdBytes(effectiveRpId);
+  const allowCredentials = pinCredId ? [pinCredId] : [];
   logger.info(LogCategory.AUTH, 'Passkey sign-in ceremony', {
     rpId: effectiveRpId,
-    pinned: !!activeCredId,
+    pinned: !!pinCredId,
     label: label ?? null,
   });
   // Web only: derive against a specific RP ID (e.g. a legacy-RP user before
@@ -860,6 +864,81 @@ export function getMigrationSharedCredentialIdBytes(): Uint8Array | null {
 }
 export function clearMigrationSharedCredentialId(): void {
   localStorage.removeItem(PASSKEY_MIGRATION_SHARED_CRED_KEY);
+}
+
+// ---------- Migration credential pairs (device metadata; survives logout) ----------
+
+// Maps a migrated source (legacy) credential to the shared credential it migrated
+// to, so a later RP switch can pin `allowCredentials` straight to the counterpart
+// instead of surfacing the full passkey picker. One entry per source credential
+// (re-migrating the same passkey overwrites its destination with the latest);
+// distinct passkeys accumulate. Persisted so it survives logout.
+const PASSKEY_MIGRATION_CRED_PAIRS_KEY = 'passkeyMigrationCredentialPairs';
+type MigrationCredentialPair = { oldRpId: string; oldCredId: string; newRpId: string; newCredId: string };
+// ponytail: bound the list; a device migrates a handful of passkeys, not hundreds.
+const MAX_MIGRATION_CRED_PAIRS = 50;
+
+function safeBase64ToBytes(b64: string): Uint8Array | null {
+  try {
+    return base64ToBytes(b64);
+  } catch {
+    return null;
+  }
+}
+
+function readMigrationCredentialPairs(): MigrationCredentialPair[] {
+  const raw = localStorage.getItem(PASSKEY_MIGRATION_CRED_PAIRS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Remember that `oldCredId` (under `oldRpId`) migrated to `newCredId` (under
+ * `newRpId`). Upserts by source credential: re-migrating the same passkey keeps
+ * only the latest destination; other passkeys accumulate.
+ */
+export function recordMigrationCredentialPair(
+  oldRpId: string,
+  oldCredId: string,
+  newRpId: string,
+  newCredId: string,
+): void {
+  if (!oldCredId || !newCredId || oldRpId === newRpId) return;
+  const pairs = readMigrationCredentialPairs().filter((p) => p.oldCredId !== oldCredId);
+  pairs.push({ oldRpId, oldCredId, newRpId, newCredId });
+  localStorage.setItem(
+    PASSKEY_MIGRATION_CRED_PAIRS_KEY,
+    JSON.stringify(pairs.slice(-MAX_MIGRATION_CRED_PAIRS)),
+  );
+}
+
+/**
+ * Given the credential currently signed in with, return the migrated counterpart
+ * credential that lives under `targetRpId` (bytes for `allowCredentials`), or null
+ * when no pair matches (an unmigrated passkey, or a first-ever switch to that RP).
+ */
+export function getMigrationCounterpartCredentialIdBytes(targetRpId: string): Uint8Array | null {
+  const activeCredId = localStorage.getItem('passkeyActiveCredentialId');
+  const activeRpId = localStorage.getItem(PASSKEY_ACTIVE_CRED_RP_KEY);
+  if (!activeCredId || !activeRpId) return null;
+  for (const p of readMigrationCredentialPairs()) {
+    if (p.oldCredId === activeCredId && p.oldRpId === activeRpId && p.newRpId === targetRpId) {
+      return safeBase64ToBytes(p.newCredId);
+    }
+    if (p.newCredId === activeCredId && p.newRpId === activeRpId && p.oldRpId === targetRpId) {
+      return safeBase64ToBytes(p.oldCredId);
+    }
+  }
+  return null;
+}
+
+export function clearMigrationCredentialPairs(): void {
+  localStorage.removeItem(PASSKEY_MIGRATION_CRED_PAIRS_KEY);
 }
 
 /**


### PR DESCRIPTION
Switching between the legacy and shared passkeys from the developer settings currently shows the full system passkey picker, requiring the user to manually select the matching credential each time.

This PR remembers the relationship between each migrated legacy/shared passkey pair. When switching, Glow requests the matching passkey directly instead of showing the full picker.

The mapping is stored per passkey and persists across sign-outs, so previously migrated passkeys continue to switch seamlessly, not just the most recently migrated one.