### PR TITLE
show the migration prompt again after signing back in

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,6 +183,7 @@ const AppContent: React.FC = () => {
 
   const handleLogout = async () => {
     setUserScreen('home');
+    hasAutoOpenedMigrationRef.current = false;
     await sdk.handleLogout();
   };
 


### PR DESCRIPTION
The passkey migration prompt only appeared once per page load. After signing out and back in (for example after resetting migration state), a wallet that still needs migration reconnected without prompting again.

It now shows again whenever you sign back in on a wallet that still needs migration, with no page reload needed.