### PR TITLE
stop showing and sweeping a label twice

### DIFF
--- a/src/services/passkeyMigrationService.test.ts
+++ b/src/services/passkeyMigrationService.test.ts
@@ -56,6 +56,15 @@ describe('orderLabelsForMigration', () => {
   it('prefers the stored label over Default when both are present', () => {
     expect(orderLabelsForMigration(['a', 'Default', 'b'], 'a')).toEqual(['Default', 'b', 'a']);
   });
+
+  it('collapses byte-identical duplicates so no label is swept twice', () => {
+    expect(orderLabelsForMigration(['a', 'a', 'b', 'Default'], 'Default')).toEqual(['a', 'b', 'Default']);
+    expect(orderLabelsForMigration(['Default', 'Default'], 'Default')).toEqual(['Default']);
+  });
+
+  it('keeps case/whitespace variants as distinct labels', () => {
+    expect(orderLabelsForMigration(['a', 'A', 'a '], 'a')).toEqual(['A', 'a ', 'a']);
+  });
 });
 
 describe('assertDifferentWallet', () => {

--- a/src/services/passkeyMigrationService.ts
+++ b/src/services/passkeyMigrationService.ts
@@ -33,7 +33,10 @@ const STORAGE_DIR = 'spark-wallet-example';
  * `passkeyLabel`, or 'Default' as a fallback) is migrated LAST. Other labels
  * keep relative order. The last-migrated new SDK is the one the session adopts.
  */
-export function orderLabelsForMigration(labels: string[], storedLabel: string): string[] {
+export function orderLabelsForMigration(rawLabels: string[], storedLabel: string): string[] {
+  // Collapse byte-identical duplicates so a label (one wallet) is never swept
+  // twice; distinct strings are distinct wallets and are kept.
+  const labels = [...new Set(rawLabels)];
   if (labels.length === 0) return [];
   let primary: string | undefined = labels.find((l) => l === storedLabel);
   if (!primary) primary = labels.find((l) => l === 'Default');

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -901,7 +901,11 @@ export function hasPasskeyHistory(): boolean {
 
 export async function listLabels(): Promise<string[]> {
   logger.info(LogCategory.AUTH, 'Listing labels from nostr relays');
-  return getPasskey().labels().list();
+  // Collapse byte-identical duplicates: partial relay coverage can return the
+  // same label event twice, which would list one label (one wallet) twice.
+  // Distinct strings (incl. case/whitespace variants) are different wallets and
+  // are kept as-is.
+  return [...new Set(await getPasskey().labels().list())];
 }
 
 export async function saveLabel(label: string): Promise<void> {


### PR DESCRIPTION
When label events are only partially propagated across relays, the label list could return the same label twice, so it appeared twice in the label pickers and the migration counted and swept it twice (e.g. "3 labels" but only 2 wallets).

Glow now merges exact-duplicate labels when reading the list. Only byte-identical labels are collapsed (they resolve to the same wallet); labels that differ in any way, including case or spacing, are kept as separate wallets. The migration's shown count and the wallets it actually moves now come from the same deduped list, so they always match.