### PR TITLE
Optional biometric unlock with an app-lock PIN

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,36 +103,18 @@
       z-index: 9999;
     }
     
-    /* Elegant spinner */
-    .splash-loader {
-      width: 32px;
-      height: 32px;
-      position: relative;
-    }
-    
-    .splash-loader::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border-radius: 50%;
-      border: 2px solid transparent;
-      border-top-color: #d4a574;
-      border-right-color: rgba(212, 165, 116, 0.3);
-      animation: spin 1s cubic-bezier(0.5, 0.2, 0.5, 0.8) infinite;
-    }
-    
-    .splash-loader::after {
-      content: '';
-      position: absolute;
-      inset: 6px;
-      border-radius: 50%;
-      border: 1.5px solid transparent;
-      border-top-color: rgba(212, 165, 116, 0.6);
-      animation: spin 0.6s cubic-bezier(0.5, 0.2, 0.5, 0.8) infinite reverse;
-    }
-    
-    @keyframes spin {
-      to { transform: rotate(360deg); }
+    /* Glow logo, not a spinner: this page is the continuation of the
+       native splash (same canvas), so the launch reads as one splash
+       until the wallet is ready. Sign-of-life for the long tail comes
+       from the wallet page itself once it reveals.
+
+       33.6vw: measured from the iOS splash asset (logo bbox 918px of
+       2732px), which LaunchScreen renders aspect-fit as a screen-width
+       square — so the native logo is 33.6% of device width and this
+       must match or the handoff visibly resizes. */
+    .splash-logo {
+      width: 33.6vw;
+      max-width: 192px;
     }
   </style>
 </head>
@@ -140,7 +122,7 @@
 <body>
   <!-- Splash screen shown during initial load -->
   <div id="splash">
-    <div class="splash-loader"></div>
+    <img class="splash-logo" src="/assets/Glow_Logo.svg" alt="" />
   </div>
   
   <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -581,7 +581,11 @@ const AppContent: React.FC = () => {
               <ContactsProvider>
                 {renderCurrentScreen()}
               </ContactsProvider>
-              {sdk.celebrationPayment !== null && (
+              {/* Held back (not just covered) while locked: the
+                  celebration auto-dismisses on a timer, so mounting it
+                  behind the lock screen would burn it unseen. Deferring
+                  the mount plays it in full after unlock. */}
+              {sdk.celebrationPayment !== null && !appLock.locked && (
                 <PaymentReceivedCelebration
                   payment={sdk.celebrationPayment}
                   onClose={sdk.dismissCelebration}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,9 @@ import RestorePage from './pages/RestorePage';
 import GeneratePage from './pages/GeneratePage';
 import GetRefundPage from './pages/GetRefundPage';
 import BackupPage from './pages/BackupPage';
+import SecurityPage from './pages/SecurityPage';
+import LockScreen from './components/LockScreen';
+import { useAppLock } from './hooks/useAppLock';
 import PasskeyPage from './pages/PasskeyPage';
 import type { MigrationEntry, MigrationOutcome } from './features/passkey-migration/types';
 import SettingsPage from './pages/SettingsPage';
@@ -45,7 +48,7 @@ import type { Seed, Payment, BreezSdk } from '@breeztech/breez-sdk-spark';
 
 const PASSKEY_MIGRATION_ENABLED = true;
 
-type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'unlock' | 'unlocking' | 'passkeySettings' | 'passkeyManagement' | 'labels' | 'passkeyLocalState';
+type Screen = 'home' | 'restore' | 'generate' | 'wallet' | 'getRefund' | 'settings' | 'backup' | 'security' | 'fiatCurrencies' | 'buyProviders' | 'passkey' | 'unlock' | 'unlocking' | 'passkeySettings' | 'passkeyManagement' | 'labels' | 'passkeyLocalState';
 
 // Full-screen dim spinner shown while sdk.isLoading is true (logout in
 // progress, SDK reconnect, etc). Wrapped as its own component so the
@@ -99,6 +102,9 @@ const AppContent: React.FC = () => {
   useIOSViewportFix();
 
   const sdk = useBreezSdk(showToast);
+  // App lock overlays everything (including the unlock/backup screens)
+  // while locked; rendered last in the tree so it stacks on top.
+  const appLock = useAppLock();
 
   // SDK startup state takes precedence; otherwise the user's screen
   // wins, with one exception: an SDK auto-reconnect (saved mnemonic /
@@ -209,6 +215,7 @@ const AppContent: React.FC = () => {
     switch (currentScreen) {
       case 'settings':
       case 'backup':
+      case 'security':
       case 'getRefund':
         setUserScreen('wallet');
         return true;
@@ -319,6 +326,7 @@ const AppContent: React.FC = () => {
           }}
           onOpenSettings={() => setUserScreen('settings')}
           onOpenBackup={() => setUserScreen('backup')}
+          onOpenSecurity={() => setUserScreen('security')}
           onOpenBuyProviders={() => { setBuyProvidersSource('wallet'); setUserScreen('buyProviders'); }}
           onBuyBitcoin={sdk.handleBuyBitcoin}
           network={sdk.config?.network}
@@ -385,7 +393,6 @@ const AppContent: React.FC = () => {
               setUserScreen('home');
             }}
             sdkConnected={passkeySdkConnected}
-            isSecuringSeed={sdk.isSecuringSeed}
             onFlowComplete={handlePasskeyFlowComplete}
             consumeFreshInstallSignal={sdk.consumeFreshInstallSignal}
             skipDetection={passkeySkipDetection}
@@ -528,6 +535,14 @@ const AppContent: React.FC = () => {
           </>
         );
 
+      case 'security':
+        return (
+          <>
+            {renderWalletPage()}
+            <SecurityPage onBack={() => setUserScreen('wallet')} />
+          </>
+        );
+
       case 'restore':
         return (
           <RestorePage
@@ -585,6 +600,13 @@ const AppContent: React.FC = () => {
               )}
               <InstallPrompt />
               <OfflineBanner />
+              {appLock.locked && (
+                <LockScreen
+                  biometricGate={appLock.biometricGate}
+                  unlockWithPin={appLock.unlockWithPin}
+                  unlockWithBiometric={appLock.unlockWithBiometric}
+                />
+              )}
             </StableBalanceProvider>
           </FiatDataProvider>
         </WalletStatusProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -603,6 +603,7 @@ const AppContent: React.FC = () => {
               {appLock.locked && (
                 <LockScreen
                   biometricGate={appLock.biometricGate}
+                  suppressAutoBiometric={currentScreen === 'unlocking' || currentScreen === 'unlock'}
                   unlockWithPin={appLock.unlockWithPin}
                   unlockWithBiometric={appLock.unlockWithBiometric}
                 />

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -121,6 +121,12 @@ export const EyeOffIcon: React.FC<IconProps> = ({ className = '', size = 'md' })
   </svg>
 );
 
+export const FaceIdIcon: React.FC<IconProps> = ({ className = '', size = 'md' }) => (
+  <svg className={`${sizeClasses[size]} ${className}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M4 8V6a2 2 0 012-2h2M16 4h2a2 2 0 012 2v2M20 16v2a2 2 0 01-2 2h-2M8 20H6a2 2 0 01-2-2v-2M9 9v1M15 9v1M12 9.5v2.75a.75.75 0 01-.75.75M9.25 15.5a4 4 0 005.5 0" />
+  </svg>
+);
+
 export const FingerprintIcon: React.FC<IconProps> = ({ className = '', size = 'md' }) => (
   <svg className={`${sizeClasses[size]} ${className}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4" />

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -127,6 +127,12 @@ export const FingerprintIcon: React.FC<IconProps> = ({ className = '', size = 'm
   </svg>
 );
 
+export const BackspaceIcon: React.FC<IconProps> = ({ className = '', size = 'md' }) => (
+  <svg className={`${sizeClasses[size]} ${className}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zM18 9l-6 6M12 9l6 6" />
+  </svg>
+);
+
 export const NostrKeyIcon: React.FC<IconProps> = ({ className = '', size = 'md' }) => (
   <svg className={`${sizeClasses[size]} ${className}`} viewBox="0 0 64 64" fill="currentColor">
     <path d="M27.651 7.768c-2.558-2.549-6.713-2.521-9.262.036L1.895 24.355c-2.55 2.558-2.517 6.64.04 9.19l27.043 27.042c2.558 2.548 6.705 2.527 9.255-.03l8.038-8.038c-2.345 2.344-4.274.658-6.56-1.618l-4.483-4.483c-3.404 1.347-7.382.677-10.14-2.075l-3.416-3.416a1.151 1.151 0 0 1-.36-.854c0-.162.031-.322.093-.472.063-.15.16-.276.275-.39l1.933-1.933-4.209-4.209c-.659-.658-.766-1.72-.177-2.437a1.776 1.776 0 0 1 2.633-.13l4.266 4.263 2.89-2.89-4.22-4.208c-.659-.658-.766-1.719-.172-2.441a1.78 1.78 0 0 1 2.634-.13l4.283 4.254 1.815-1.815c.114-.115.226-.218.375-.28a1.227 1.227 0 0 1 1.343.266l3.422 3.415c2.723 2.718 3.435 6.674 2.162 10.052l4.484 4.484c2.286 2.276 4.199 3.976 6.543 1.632l10.143-10.143c-2.438 2.438-4.44.56-6.85-1.847L27.65 7.768Z" fillOpacity="0.85" />

--- a/src/components/LockScreen.tsx
+++ b/src/components/LockScreen.tsx
@@ -12,12 +12,17 @@ import { useBackButton } from '../hooks/useBackButton';
 
 interface LockScreenProps {
   biometricGate: boolean;
+  /** True while another OS auth ceremony is in flight underneath (the
+   *  legacy vault unlock): concurrent BiometricPrompt calls cancel each
+   *  other on Android, so the auto-fire waits until it clears. */
+  suppressAutoBiometric?: boolean;
   unlockWithPin: (pin: string) => Promise<boolean>;
   unlockWithBiometric: () => Promise<void>;
 }
 
 const LockScreen: React.FC<LockScreenProps> = ({
   biometricGate,
+  suppressAutoBiometric = false,
   unlockWithPin,
   unlockWithBiometric,
 }) => {
@@ -32,8 +37,8 @@ const LockScreen: React.FC<LockScreenProps> = ({
   }, [unlockWithBiometric]);
 
   useEffect(() => {
-    if (biometricGate) void tryBiometric();
-  }, [biometricGate, tryBiometric]);
+    if (biometricGate && !suppressAutoBiometric) void tryBiometric();
+  }, [biometricGate, suppressAutoBiometric, tryBiometric]);
 
   return (
     <div className="fixed inset-0 z-[100] bg-spark-surface flex flex-col">

--- a/src/components/LockScreen.tsx
+++ b/src/components/LockScreen.tsx
@@ -6,8 +6,9 @@
  * Android can't pop the lock.
  */
 
-import React, { useCallback, useEffect } from 'react';
-import { PinEntry } from './PinEntry';
+import React, { useCallback, useEffect, useState } from 'react';
+import { PinEntry, PinScreenLayout } from './PinEntry';
+import { getBiometryInfo, BiometryKind } from '../services/secureStorage';
 import { useBackButton } from '../hooks/useBackButton';
 
 interface LockScreenProps {
@@ -28,32 +29,75 @@ const LockScreen: React.FC<LockScreenProps> = ({
 }) => {
   useBackButton(useCallback(() => true, []), true);
 
+  // With the biometric gate on, the pad stays hidden until the OS
+  // prompt settles: it only appears when the user cancels or biometrics
+  // are unavailable, so the happy path is Face ID over a bare logo, not
+  // over a PIN pad.
+  const [padVisible, setPadVisible] = useState(!biometricGate);
+
+  // Face vs fingerprint icon for the pad's biometric slot.
+  const [biometryKind, setBiometryKind] = useState<BiometryKind | undefined>(undefined);
+  useEffect(() => {
+    let cancelled = false;
+    void getBiometryInfo().then((info) => {
+      if (!cancelled && info) setBiometryKind(info.kind);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
   const tryBiometric = useCallback(async () => {
-    try {
-      await unlockWithBiometric();
-    } catch {
-      // Cancelled or unavailable: the PIN pad remains.
-    }
+    // Never rejects. If we're still mounted afterwards the attempt
+    // didn't unlock (cancel / lockout / unavailable): reveal the pad.
+    await unlockWithBiometric();
+    setPadVisible(true);
   }, [unlockWithBiometric]);
 
   useEffect(() => {
-    if (biometricGate && !suppressAutoBiometric) void tryBiometric();
+    if (!biometricGate) setPadVisible(true);
+    else if (!suppressAutoBiometric) void tryBiometric();
   }, [biometricGate, suppressAutoBiometric, tryBiometric]);
 
   return (
-    <div className="fixed inset-0 z-[100] bg-spark-surface flex flex-col">
-      <div className="flex-1 flex items-center justify-center p-6">
-        <div className="max-w-sm w-full space-y-8">
-          <div className="flex flex-col items-center gap-4">
-            <img src="/assets/Glow_Logo.svg" alt="Glow" className="w-24 h-24" />
-            <p className="text-sm text-spark-text-secondary">Enter your PIN to unlock</p>
-          </div>
-          <PinEntry
-            onSubmit={async (pin) => ((await unlockWithPin(pin)) ? null : 'Incorrect PIN')}
-            onBiometric={biometricGate ? () => { void tryBiometric(); } : undefined}
-          />
+    // z above .toast-container (99999): the lock must cover toasts too,
+    // both to keep the PIN screen clean and because a payment-received
+    // toast over the lock would leak amounts on a locked device.
+    <div className="fixed inset-0 z-[100000] bg-spark-surface flex flex-col">
+      {padVisible ? (
+        // Safe-area insets live on this branch only: the pad anchors to
+        // the screen edges (1/3 / 2/3 split), while the pending branch
+        // below must center in the FULL screen like the splash does.
+        // The extra 2.5rem (the old py-10) keeps the pad clear of the
+        // bottom safe area; overflow scrolls on short screens.
+        <div
+          className="flex-1 flex flex-col px-4 max-w-sm w-full mx-auto overflow-y-auto"
+          style={{
+            paddingTop: 'calc(env(safe-area-inset-top) + 2.5rem)',
+            paddingBottom: 'calc(env(safe-area-inset-bottom) + 2.5rem)',
+          }}
+        >
+          <PinScreenLayout
+            prompt={
+              <p className="text-sm text-spark-text-secondary">Enter your PIN to unlock</p>
+            }
+          >
+            <PinEntry
+              onSubmit={async (pin) => ((await unlockWithPin(pin)) ? null : 'Incorrect PIN')}
+              // Gate flag AND live availability, so a Face ID outage
+              // (denied / locked out) never leaves a dead button.
+              onBiometric={biometricGate && biometryKind ? () => { void tryBiometric(); } : undefined}
+              biometryKind={biometryKind}
+            />
+          </PinScreenLayout>
         </div>
-      </div>
+      ) : (
+        // Biometric pending: replicate the splash exactly (33.6vw,
+        // measured from the native splash asset — see index.html's
+        // .splash-logo) so cold start -> Face ID reads as one
+        // continuous frame, no logo resize or jump.
+        <div className="flex-1 flex items-center justify-center">
+          <img src="/assets/Glow_Logo.svg" alt="Glow" className="w-[33.6vw] max-w-48" />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/LockScreen.tsx
+++ b/src/components/LockScreen.tsx
@@ -1,0 +1,56 @@
+/**
+ * Full-screen app lock overlay (native only). PIN pad with an optional
+ * biometric path: when the biometric gate is on, the OS prompt fires
+ * once automatically and stays retriable from the pad's fingerprint
+ * button. PIN always works as fallback. Hardware back is absorbed so
+ * Android can't pop the lock.
+ */
+
+import React, { useCallback, useEffect } from 'react';
+import { PinEntry } from './PinEntry';
+import { useBackButton } from '../hooks/useBackButton';
+
+interface LockScreenProps {
+  biometricGate: boolean;
+  unlockWithPin: (pin: string) => Promise<boolean>;
+  unlockWithBiometric: () => Promise<void>;
+}
+
+const LockScreen: React.FC<LockScreenProps> = ({
+  biometricGate,
+  unlockWithPin,
+  unlockWithBiometric,
+}) => {
+  useBackButton(useCallback(() => true, []), true);
+
+  const tryBiometric = useCallback(async () => {
+    try {
+      await unlockWithBiometric();
+    } catch {
+      // Cancelled or unavailable: the PIN pad remains.
+    }
+  }, [unlockWithBiometric]);
+
+  useEffect(() => {
+    if (biometricGate) void tryBiometric();
+  }, [biometricGate, tryBiometric]);
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-spark-surface flex flex-col">
+      <div className="flex-1 flex items-center justify-center p-6">
+        <div className="max-w-sm w-full space-y-8">
+          <div className="flex flex-col items-center gap-4">
+            <img src="/assets/Glow_Logo.svg" alt="Glow" className="w-24 h-24" />
+            <p className="text-sm text-spark-text-secondary">Enter your PIN to unlock</p>
+          </div>
+          <PinEntry
+            onSubmit={async (pin) => ((await unlockWithPin(pin)) ? null : 'Incorrect PIN')}
+            onBiometric={biometricGate ? () => { void tryBiometric(); } : undefined}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LockScreen;

--- a/src/components/PinEntry.tsx
+++ b/src/components/PinEntry.tsx
@@ -1,6 +1,6 @@
 /**
- * PIN entry UI (native app lock) — Misty Breez's lock-screen pattern in
- * Glow's visual language: a row of masked digit dots above a 3×4
+ * PIN entry UI (native app lock): Misty Breez's lock-screen pattern in
+ * Glow's visual language, a row of masked digit dots above a 3x4
  * numeric pad. One component file for the dots, the pad, and the
  * self-contained entry flow so every consumer (create, change, gate,
  * lock screen) renders identically.

--- a/src/components/PinEntry.tsx
+++ b/src/components/PinEntry.tsx
@@ -1,29 +1,64 @@
 /**
  * PIN entry UI (native app lock): Misty Breez's lock-screen pattern in
  * Glow's visual language, a row of masked digit dots above a 3x4
- * numeric pad. One component file for the dots, the pad, and the
- * self-contained entry flow so every consumer (create, change, gate,
- * lock screen) renders identically.
+ * numeric pad. One component file for the dots, the pad, the
+ * self-contained entry flow, and the in-page auth gate so every
+ * consumer (create, change, gate, lock screen) renders identically.
  */
 
-import React, { useState } from 'react';
-import { PIN_LENGTH } from '@/services/appLock';
-import { BackspaceIcon, FingerprintIcon } from './Icons';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { PIN_LENGTH, isBiometricGateEnabled, isBiometricGateEnabledSync, verifyPin } from '@/services/appLock';
+import { authenticateBiometric, getBiometryInfo, BiometryKind } from '@/services/secureStorage';
+import { useBackButton } from '@/hooks/useBackButton';
+import { BackspaceIcon, FaceIdIcon, FingerprintIcon, TrashIcon } from './Icons';
 
 export const PinDots: React.FC<{ filled: number; error?: boolean }> = ({ filled, error = false }) => (
-  <div className="flex justify-center gap-4" role="status" aria-label={`${filled} of ${PIN_LENGTH} digits entered`}>
+  <div
+    className={`flex justify-center gap-4 ${error ? 'animate-pin-shake' : ''}`}
+    role="status"
+    aria-label={`${filled} of ${PIN_LENGTH} digits entered`}
+  >
     {Array.from({ length: PIN_LENGTH }, (_, i) => (
       <div
         key={i}
-        className={`w-4 h-4 rounded-full border transition-colors ${
-          error
-            ? 'border-spark-error bg-spark-error/60'
-            : i < filled
-              ? 'border-spark-primary bg-spark-primary'
-              : 'border-spark-border bg-transparent'
+        className={`w-5 h-5 rounded-full border-2 transition-colors ${
+          i < filled
+            ? error
+              ? 'border-spark-error bg-spark-error/60'
+              : 'border-spark-primary bg-spark-primary'
+            : 'border-spark-border-light bg-transparent'
         }`}
       />
     ))}
+  </div>
+);
+
+/**
+ * Shared frame for every PIN surface (lock screen, gates, create /
+ * change flows): logo + prompt + dots + error + pad as one group,
+ * centered in the lower two thirds with the top third left as
+ * breathing room. The logo rides 40dp above the prompt, one size on
+ * every surface. Needs a flexed parent chain to stretch against; the
+ * hosting page provides uniform padding.
+ */
+export const PinScreenLayout: React.FC<{
+  prompt?: React.ReactNode;
+  /** Extra classes on the root, e.g. `pt-8` on app-bar pages so the
+   *  composition lands at the same screen position as the lock screen
+   *  (measured: flex reabsorbs ~2/3 of the padding, 32px => 11px). */
+  className?: string;
+  children?: React.ReactNode;
+}> = ({ prompt, className = '', children }) => (
+  <div className={`flex-1 flex flex-col ${className}`}>
+    <div className="flex-1" />
+    <div className="flex-[2] flex flex-col justify-center">
+      {/* w-36 = 144px, matching the HomePage / UnlockPage logo. mb-10 =
+          40dp logo-to-label; mb-6 matches PinEntry's internal space-y-6
+          rhythm so the prompt reads as part of the group. */}
+      <img src="/assets/Glow_Logo.svg" alt="Glow" className="w-36 h-36 mx-auto mb-10" />
+      {prompt && <div className="mb-6 text-center">{prompt}</div>}
+      {children}
+    </div>
   </div>
 );
 
@@ -47,10 +82,15 @@ const PadButton: React.FC<{
 export const PinPad: React.FC<{
   onDigit: (d: string) => void;
   onBackspace: () => void;
+  /** Clears the whole PIN; shown in the bottom-left slot when no
+   *  biometric button occupies it. */
+  onClear: () => void;
   disabled?: boolean;
   /** Renders a biometric button in the bottom-left pad slot. */
   onBiometric?: () => void;
-}> = ({ onDigit, onBackspace, disabled = false, onBiometric }) => (
+  /** Icon for the biometric button; fingerprint when unknown. */
+  biometryKind?: BiometryKind;
+}> = ({ onDigit, onBackspace, onClear, disabled = false, onBiometric, biometryKind = 'fingerprint' }) => (
   <div className="grid grid-cols-3 gap-2 max-w-xs mx-auto w-full">
     {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((d) => (
       <PadButton key={d} onClick={() => onDigit(d)} disabled={disabled}>
@@ -59,10 +99,14 @@ export const PinPad: React.FC<{
     ))}
     {onBiometric ? (
       <PadButton onClick={onBiometric} disabled={disabled} aria-label="Use biometrics">
-        <FingerprintIcon size="lg" className="text-spark-primary" />
+        {biometryKind === 'face'
+          ? <FaceIdIcon size="lg" className="text-spark-primary" />
+          : <FingerprintIcon size="lg" className="text-spark-primary" />}
       </PadButton>
     ) : (
-      <div />
+      <PadButton onClick={onClear} disabled={disabled} aria-label="Clear PIN">
+        <TrashIcon size="lg" />
+      </PadButton>
     )}
     <PadButton onClick={() => onDigit('0')} disabled={disabled}>
       0
@@ -84,7 +128,13 @@ export const PinEntry: React.FC<{
   onSubmit: (pin: string) => Promise<string | null> | string | null;
   disabled?: boolean;
   onBiometric?: () => void;
-}> = ({ onSubmit, disabled = false, onBiometric }) => {
+  biometryKind?: BiometryKind;
+  /** Parent-owned error shown in the same reserved line as internal
+   *  errors (which take precedence). Lets multi-step flows surface
+   *  mismatch feedback across a remount without adding a second error
+   *  row that would change the screen's shape. */
+  persistentError?: string | null;
+}> = ({ onSubmit, disabled = false, onBiometric, biometryKind, persistentError = null }) => {
   const [pin, setPin] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -100,6 +150,11 @@ export const PinEntry: React.FC<{
         const result = await onSubmit(next);
         if (result != null) {
           setError(result);
+          // Dots stay filled (red, shaking) through the hold, then
+          // clear: one deliberate animation instead of an abrupt
+          // wipe. The hold also stops a stray tap from eating the
+          // error message or leaking into the next attempt.
+          await new Promise((resolve) => setTimeout(resolve, 500));
           setPin('');
         }
       } finally {
@@ -108,18 +163,120 @@ export const PinEntry: React.FC<{
     }
   };
 
+  const shownError = error ?? persistentError;
+
   return (
     <div className="space-y-6">
       <PinDots filled={pin.length} error={error != null} />
-      <p className={`text-center text-sm min-h-5 ${error ? 'text-spark-error' : 'text-transparent'}`}>
-        {error ?? ' '}
+      {/* NBSP placeholder, not a plain space: whitespace-only text
+          collapses to a zero-height line box and the row grows 4px
+          when real text lands (measured), shifting everything above. */}
+      <p className={`text-center text-sm ${shownError ? 'text-spark-error' : 'text-transparent'}`}>
+        {shownError ?? '\u00A0'}
       </p>
       <PinPad
         onDigit={(d) => { void handleDigit(d); }}
         onBackspace={() => { setError(null); setPin((p) => p.slice(0, -1)); }}
+        onClear={() => { setError(null); setPin(''); }}
         disabled={disabled || busy}
         onBiometric={onBiometric}
+        biometryKind={biometryKind}
       />
     </div>
+  );
+};
+
+/**
+ * In-page app-lock gate: lock icon + PIN pad, with the OS biometric
+ * prompt auto-fired once when the biometric gate is enabled in
+ * Security settings (retriable from the pad's fingerprint button; PIN
+ * always works as fallback). Renders inside a page body, unlike the
+ * full-screen LockScreen overlay. Only meaningful when a PIN is set:
+ * the caller checks `isPinEnabled()` before mounting.
+ */
+export const PinGate: React.FC<{
+  /** Shown in the OS biometric prompt, e.g. "Unlock Security settings". */
+  reason: string;
+  onUnlocked: () => void;
+}> = ({ reason, onUnlocked }) => {
+  // Sync mirror seed so the first paint already knows whether to hold
+  // the pad back for the biometric prompt; the async read reconciles
+  // (a lost mirror degrades to showing the pad).
+  const [biometricGate, setBiometricGate] = useState(() => isBiometricGateEnabledSync());
+  // With the biometric gate on, the pad stays hidden until the OS
+  // prompt settles: it only appears when the user cancels or biometrics
+  // are unavailable.
+  const [padVisible, setPadVisible] = useState(() => !isBiometricGateEnabledSync());
+  // Auto-fire the biometric only once per mount; the pad's fingerprint
+  // button re-fires it manually after a cancel.
+  const bioFiredRef = useRef(false);
+
+  // Face vs fingerprint icon for the pad's biometric slot.
+  const [biometryKind, setBiometryKind] = useState<BiometryKind | undefined>(undefined);
+  useEffect(() => {
+    let cancelled = false;
+    void getBiometryInfo().then((info) => {
+      if (!cancelled && info) setBiometryKind(info.kind);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Hardware back is absorbed while the gate is up, matching the
+  // LockScreen. The page header's close button stays as the way out.
+  useBackButton(useCallback(() => true, []), true);
+
+  const runBiometric = useCallback(async () => {
+    try {
+      await authenticateBiometric(reason);
+      onUnlocked();
+    } catch {
+      // Cancelled or unavailable: fall back to the PIN pad.
+      setPadVisible(true);
+    }
+  }, [reason, onUnlocked]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void isBiometricGateEnabled().then((enabled) => {
+      if (cancelled) return;
+      setBiometricGate(enabled);
+      if (!enabled) setPadVisible(true);
+      else if (!bioFiredRef.current) {
+        bioFiredRef.current = true;
+        void runBiometric();
+      }
+    });
+    return () => { cancelled = true; };
+  }, [runBiometric]);
+
+  // Biometric pending: keep the page body empty under the OS prompt.
+  // The logo-and-pad composition only appears once the user cancels
+  // into the PIN fallback.
+  if (!padVisible) return null;
+
+  return (
+    // pt-8 aligns the composition with the (app-bar-less) lock screen.
+    <PinScreenLayout
+      className="pt-8 pb-14"
+      prompt={
+        <p className="text-sm text-spark-text-secondary">Enter your PIN to continue</p>
+      }
+    >
+      <PinEntry
+        onSubmit={async (pin) => {
+          if (await verifyPin(pin)) {
+            onUnlocked();
+            return null;
+          }
+          return 'Incorrect PIN';
+        }}
+        // Gate flag AND live availability: with Face ID denied /
+        // locked out / not enrolled, a biometric button would be a
+        // dead control, so the slot stays empty and the pad's
+        // delete button carries the row.
+        onBiometric={biometricGate && biometryKind ? () => { void runBiometric(); } : undefined}
+        biometryKind={biometryKind}
+      />
+    </PinScreenLayout>
   );
 };

--- a/src/components/PinEntry.tsx
+++ b/src/components/PinEntry.tsx
@@ -1,0 +1,125 @@
+/**
+ * PIN entry UI (native app lock) — Misty Breez's lock-screen pattern in
+ * Glow's visual language: a row of masked digit dots above a 3×4
+ * numeric pad. One component file for the dots, the pad, and the
+ * self-contained entry flow so every consumer (create, change, gate,
+ * lock screen) renders identically.
+ */
+
+import React, { useState } from 'react';
+import { PIN_LENGTH } from '@/services/appLock';
+import { BackspaceIcon, FingerprintIcon } from './Icons';
+
+export const PinDots: React.FC<{ filled: number; error?: boolean }> = ({ filled, error = false }) => (
+  <div className="flex justify-center gap-4" role="status" aria-label={`${filled} of ${PIN_LENGTH} digits entered`}>
+    {Array.from({ length: PIN_LENGTH }, (_, i) => (
+      <div
+        key={i}
+        className={`w-4 h-4 rounded-full border transition-colors ${
+          error
+            ? 'border-spark-error bg-spark-error/60'
+            : i < filled
+              ? 'border-spark-primary bg-spark-primary'
+              : 'border-spark-border bg-transparent'
+        }`}
+      />
+    ))}
+  </div>
+);
+
+const PadButton: React.FC<{
+  onClick: () => void;
+  disabled?: boolean;
+  'aria-label'?: string;
+  children: React.ReactNode;
+}> = ({ onClick, disabled, children, 'aria-label': ariaLabel }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    aria-label={ariaLabel}
+    className="h-16 rounded-2xl font-display text-2xl text-spark-text-primary flex items-center justify-center hover:bg-white/5 active:bg-white/10 transition-colors disabled:opacity-40"
+  >
+    {children}
+  </button>
+);
+
+export const PinPad: React.FC<{
+  onDigit: (d: string) => void;
+  onBackspace: () => void;
+  disabled?: boolean;
+  /** Renders a biometric button in the bottom-left pad slot. */
+  onBiometric?: () => void;
+}> = ({ onDigit, onBackspace, disabled = false, onBiometric }) => (
+  <div className="grid grid-cols-3 gap-2 max-w-xs mx-auto w-full">
+    {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((d) => (
+      <PadButton key={d} onClick={() => onDigit(d)} disabled={disabled}>
+        {d}
+      </PadButton>
+    ))}
+    {onBiometric ? (
+      <PadButton onClick={onBiometric} disabled={disabled} aria-label="Use biometrics">
+        <FingerprintIcon size="lg" className="text-spark-primary" />
+      </PadButton>
+    ) : (
+      <div />
+    )}
+    <PadButton onClick={() => onDigit('0')} disabled={disabled}>
+      0
+    </PadButton>
+    <PadButton onClick={onBackspace} disabled={disabled} aria-label="Delete digit">
+      <BackspaceIcon size="lg" />
+    </PadButton>
+  </div>
+);
+
+/**
+ * Self-contained PIN collection: dots + pad + error line. Calls
+ * `onSubmit` once PIN_LENGTH digits are in; a returned error string is
+ * shown and the input clears for another attempt. To clear the input
+ * from outside (e.g. moving from "enter" to "verify"), remount with a
+ * new React `key`.
+ */
+export const PinEntry: React.FC<{
+  onSubmit: (pin: string) => Promise<string | null> | string | null;
+  disabled?: boolean;
+  onBiometric?: () => void;
+}> = ({ onSubmit, disabled = false, onBiometric }) => {
+  const [pin, setPin] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const handleDigit = async (d: string) => {
+    if (busy || pin.length >= PIN_LENGTH) return;
+    setError(null);
+    const next = pin + d;
+    setPin(next);
+    if (next.length === PIN_LENGTH) {
+      setBusy(true);
+      try {
+        const result = await onSubmit(next);
+        if (result != null) {
+          setError(result);
+          setPin('');
+        }
+      } finally {
+        setBusy(false);
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <PinDots filled={pin.length} error={error != null} />
+      <p className={`text-center text-sm min-h-5 ${error ? 'text-spark-error' : 'text-transparent'}`}>
+        {error ?? ' '}
+      </p>
+      <PinPad
+        onDigit={(d) => { void handleDigit(d); }}
+        onBackspace={() => { setError(null); setPin((p) => p.slice(0, -1)); }}
+        disabled={disabled || busy}
+        onBiometric={onBiometric}
+      />
+    </div>
+  );
+};

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import { Transition, TransitionChild } from '@headlessui/react';
 import { isPasskeyMode } from '@/services/passkeyService';
-import { RefundIcon, BackupIcon, SettingsIcon, LogoutIcon, CloseIcon, AlertTriangleIcon } from './Icons';
+import { RefundIcon, BackupIcon, SettingsIcon, LogoutIcon, CloseIcon, AlertTriangleIcon, LockIcon } from './Icons';
+import { isAppLockSupported } from '@/services/appLock';
 import { safeAreaTop, safeAreaBottom } from '../utils/safeAreaInsets';
 import { useStatusBarColor } from '../hooks/useStatusBarColor';
 import { STATUS_BAR_SURFACE, STATUS_BAR_DIALOG_SCRIM } from '../utils/statusBarManager';
@@ -49,11 +50,12 @@ interface SideMenuProps {
   onLogout: () => void;
   onOpenSettings: () => void;
   onOpenBackup: () => void;
+  onOpenSecurity: () => void;
   onOpenRefund?: () => void;
   hasRejectedDeposits?: boolean;
 }
 
-const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSettings, onOpenBackup, onOpenRefund, hasRejectedDeposits = false }) => {
+const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSettings, onOpenBackup, onOpenSecurity, onOpenRefund, hasRejectedDeposits = false }) => {
   // While the drawer is open, push the solid spark-surface tone over
   // the wallet page's glass tint so the status bar matches the drawer
   // panel's solid bg. Tied to isOpen so popping happens on close.
@@ -128,6 +130,13 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
       label: 'Backup',
       onClick: () => closeDrawerThen(onOpenBackup)
     },
+    // Security (app lock) is native-only; the PWA keeps its
+    // passkey-per-launch flow and has nothing to configure here.
+    ...(isAppLockSupported() ? [{
+      icon: <LockIcon />,
+      label: 'Security',
+      onClick: () => closeDrawerThen(onOpenSecurity)
+    }] : []),
     {
       icon: <SettingsIcon />,
       label: 'Settings',

--- a/src/hooks/useAppLock.ts
+++ b/src/hooks/useAppLock.ts
@@ -1,0 +1,96 @@
+/**
+ * App-lock lifecycle (native only). Locked when a PIN is set and either
+ * the app cold-starts or returns to the foreground after sitting in the
+ * background past the auto-lock timeout (0 = lock on any background).
+ * Settings are re-read at each lifecycle event, never cached, so a PIN
+ * created or deactivated mid-session takes effect immediately.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { App } from '@capacitor/app';
+import type { PluginListenerHandle } from '@capacitor/core';
+import {
+  getAutoLockSeconds,
+  isAppLockSupported,
+  isBiometricGateEnabled,
+  isPinEnabled,
+  verifyPin,
+} from '@/services/appLock';
+import { authenticateBiometric } from '@/services/secureStorage';
+
+export interface AppLockState {
+  locked: boolean;
+  /** True when the biometric gate is on: the lock screen auto-fires the
+   *  OS prompt and offers a retry button; PIN stays as fallback. */
+  biometricGate: boolean;
+  unlockWithPin: (pin: string) => Promise<boolean>;
+  unlockWithBiometric: () => Promise<void>;
+}
+
+export function useAppLock(): AppLockState {
+  const [locked, setLocked] = useState(false);
+  const [biometricGate, setBiometricGate] = useState(false);
+  const backgroundedAtRef = useRef<number | null>(null);
+
+  // Cold start: lock immediately when a PIN is set.
+  useEffect(() => {
+    if (!isAppLockSupported()) return;
+    let cancelled = false;
+    void (async () => {
+      const [pin, gate] = await Promise.all([isPinEnabled(), isBiometricGateEnabled()]);
+      if (cancelled) return;
+      setBiometricGate(gate);
+      if (pin) setLocked(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Background/foreground: stamp on exit, compare on return.
+  useEffect(() => {
+    if (!isAppLockSupported()) return;
+    let handle: PluginListenerHandle | null = null;
+    let cancelled = false;
+    void App.addListener('appStateChange', ({ isActive }) => {
+      if (!isActive) {
+        backgroundedAtRef.current = Date.now();
+        return;
+      }
+      const backgroundedAt = backgroundedAtRef.current;
+      backgroundedAtRef.current = null;
+      if (backgroundedAt == null) return;
+      void (async () => {
+        if (!(await isPinEnabled())) return;
+        const [timeoutSeconds, gate] = await Promise.all([
+          getAutoLockSeconds(),
+          isBiometricGateEnabled(),
+        ]);
+        if (Date.now() - backgroundedAt >= timeoutSeconds * 1000) {
+          setBiometricGate(gate);
+          setLocked(true);
+        }
+      })();
+    }).then((h) => {
+      if (cancelled) h.remove();
+      else handle = h;
+    });
+    return () => {
+      cancelled = true;
+      handle?.remove();
+    };
+  }, []);
+
+  const unlockWithPin = useCallback(async (pin: string) => {
+    const ok = await verifyPin(pin);
+    if (ok) setLocked(false);
+    return ok;
+  }, []);
+
+  const unlockWithBiometric = useCallback(async () => {
+    await authenticateBiometric('Unlock Glow');
+    setLocked(false);
+  }, []);
+
+  return { locked, biometricGate, unlockWithPin, unlockWithBiometric };
+}

--- a/src/hooks/useAppLock.ts
+++ b/src/hooks/useAppLock.ts
@@ -1,22 +1,29 @@
 /**
- * App-lock lifecycle (native only). Locked when a PIN is set and either
- * the app cold-starts or returns to the foreground after sitting in the
- * background past the auto-lock timeout (0 = lock on any background).
- * Settings are re-read at each lifecycle event, never cached, so a PIN
- * created or deactivated mid-session takes effect immediately.
+ * App-lock lifecycle (native only). Locked when a PIN is set and the
+ * app cold-starts or returns from the background past the auto-lock
+ * timeout (0 = lock the moment it backgrounds). Lock decisions use the
+ * synchronous appLock mirrors so no unlocked frame renders while a
+ * bridge read is in flight; the mount effect reconciles against the
+ * durable Preferences truth.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { App } from '@capacitor/app';
-import type { PluginListenerHandle } from '@capacitor/core';
 import {
-  getAutoLockSeconds,
+  clearPin,
+  getAutoLockSecondsSync,
   isAppLockSupported,
   isBiometricGateEnabled,
   isPinEnabled,
+  isPinEnabledSync,
   verifyPin,
 } from '@/services/appLock';
-import { authenticateBiometric } from '@/services/secureStorage';
+import {
+  authenticateBiometric,
+  deviceOnlyStorage,
+  secureStorage,
+} from '@/services/secureStorage';
+import { isPasskeyMode } from '@/services/passkeyService';
+import { logger, LogCategory } from '@/services/logger';
 
 export interface AppLockState {
   locked: boolean;
@@ -28,57 +35,81 @@ export interface AppLockState {
 }
 
 export function useAppLock(): AppLockState {
-  const [locked, setLocked] = useState(false);
+  // Synchronous first-render decision: a PIN user never paints an
+  // unlocked wallet frame on cold start.
+  const [locked, setLocked] = useState(() => isPinEnabledSync());
   const [biometricGate, setBiometricGate] = useState(false);
-  const backgroundedAtRef = useRef<number | null>(null);
+  const hiddenAtRef = useRef<number | null>(null);
 
-  // Cold start: lock immediately when a PIN is set.
+  // Reconcile the mirror against Preferences, load the gate flag, and
+  // drop a PIN that outlived its wallet (vault wiped by KEY_INVALIDATED
+  // or restore to a new device where Preferences survived but the
+  // Keychain entry didn't): a lock over onboarding would have no
+  // escape hatch, protecting nothing.
   useEffect(() => {
     if (!isAppLockSupported()) return;
     let cancelled = false;
     void (async () => {
       const [pin, gate] = await Promise.all([isPinEnabled(), isBiometricGateEnabled()]);
       if (cancelled) return;
+      if (!pin) {
+        setLocked(false);
+        return;
+      }
+      const [deviceSeed, legacySeed] = await Promise.all([
+        deviceOnlyStorage.hasStoredSeed().catch(() => false),
+        secureStorage.hasStoredSeed().catch(() => false),
+      ]);
+      if (cancelled) return;
+      const hasWallet =
+        deviceSeed || legacySeed || isPasskeyMode() || localStorage.getItem('walletMnemonic') != null;
+      if (!hasWallet) {
+        logger.warn(LogCategory.AUTH, 'appLock: clearing PIN with no wallet behind it');
+        await clearPin().catch(() => undefined);
+        if (!cancelled) setLocked(false);
+        return;
+      }
       setBiometricGate(gate);
-      if (pin) setLocked(true);
+      setLocked(true);
     })();
     return () => {
       cancelled = true;
     };
   }, []);
 
-  // Background/foreground: stamp on exit, compare on return.
+  // Backgrounding signal: visibilitychange 'hidden', NOT @capacitor/app's
+  // appStateChange. On iOS the latter fires on willResignActive, which
+  // the Face ID sheet itself triggers, so with timeout 0 every OS prompt
+  // would relock the app the moment it closes. 'hidden' fires only on
+  // real backgrounding (iOS didEnterBackground / Android activity stop).
   useEffect(() => {
     if (!isAppLockSupported()) return;
-    let handle: PluginListenerHandle | null = null;
-    let cancelled = false;
-    void App.addListener('appStateChange', ({ isActive }) => {
-      if (!isActive) {
-        backgroundedAtRef.current = Date.now();
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        if (!isPinEnabledSync()) return;
+        if (getAutoLockSecondsSync() === 0) {
+          // 'Immediately' locks at background time so the OS
+          // task-switcher snapshot captures the lock screen, not the
+          // wallet.
+          setLocked(true);
+          void isBiometricGateEnabled().then(setBiometricGate);
+        } else {
+          hiddenAtRef.current = Date.now();
+        }
         return;
       }
-      const backgroundedAt = backgroundedAtRef.current;
-      backgroundedAtRef.current = null;
-      if (backgroundedAt == null) return;
-      void (async () => {
-        if (!(await isPinEnabled())) return;
-        const [timeoutSeconds, gate] = await Promise.all([
-          getAutoLockSeconds(),
-          isBiometricGateEnabled(),
-        ]);
-        if (Date.now() - backgroundedAt >= timeoutSeconds * 1000) {
-          setBiometricGate(gate);
-          setLocked(true);
-        }
-      })();
-    }).then((h) => {
-      if (cancelled) h.remove();
-      else handle = h;
-    });
-    return () => {
-      cancelled = true;
-      handle?.remove();
+      const hiddenAt = hiddenAtRef.current;
+      hiddenAtRef.current = null;
+      if (hiddenAt == null || !isPinEnabledSync()) return;
+      // Synchronous mirror reads: the lock commits before the resumed
+      // wallet frame can paint.
+      if (Date.now() - hiddenAt >= getAutoLockSecondsSync() * 1000) {
+        setLocked(true);
+        void isBiometricGateEnabled().then(setBiometricGate);
+      }
     };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
   }, []);
 
   const unlockWithPin = useCallback(async (pin: string) => {

--- a/src/hooks/useAppLock.ts
+++ b/src/hooks/useAppLock.ts
@@ -13,14 +13,15 @@ import {
   getAutoLockSecondsSync,
   isAppLockSupported,
   isBiometricGateEnabled,
+  isBiometricGateEnabledSync,
   isPinEnabled,
   isPinEnabledSync,
   verifyPin,
 } from '@/services/appLock';
 import {
-  authenticateBiometric,
   deviceOnlyStorage,
   secureStorage,
+  tryAuthenticateBiometric,
 } from '@/services/secureStorage';
 import { isPasskeyMode } from '@/services/passkeyService';
 import { logger, LogCategory } from '@/services/logger';
@@ -31,6 +32,8 @@ export interface AppLockState {
    *  OS prompt and offers a retry button; PIN stays as fallback. */
   biometricGate: boolean;
   unlockWithPin: (pin: string) => Promise<boolean>;
+  /** Never rejects: cancel / unavailable leaves the lock in place and
+   *  the PIN pad as fallback. */
   unlockWithBiometric: () => Promise<void>;
 }
 
@@ -38,7 +41,9 @@ export function useAppLock(): AppLockState {
   // Synchronous first-render decision: a PIN user never paints an
   // unlocked wallet frame on cold start.
   const [locked, setLocked] = useState(() => isPinEnabledSync());
-  const [biometricGate, setBiometricGate] = useState(false);
+  // Sync-seeded like `locked`: the lock screen must know at first paint
+  // whether to hold the PIN pad back for the biometric auto-prompt.
+  const [biometricGate, setBiometricGate] = useState(() => isBiometricGateEnabledSync());
   const hiddenAtRef = useRef<number | null>(null);
 
   // Reconcile the mirror against Preferences, load the gate flag, and
@@ -92,7 +97,7 @@ export function useAppLock(): AppLockState {
           // task-switcher snapshot captures the lock screen, not the
           // wallet.
           setLocked(true);
-          void isBiometricGateEnabled().then(setBiometricGate);
+          setBiometricGate(isBiometricGateEnabledSync());
         } else {
           hiddenAtRef.current = Date.now();
         }
@@ -119,8 +124,7 @@ export function useAppLock(): AppLockState {
   }, []);
 
   const unlockWithBiometric = useCallback(async () => {
-    await authenticateBiometric('Unlock Glow');
-    setLocked(false);
+    if (await tryAuthenticateBiometric('Unlock Glow')) setLocked(false);
   }, []);
 
   return { locked, biometricGate, unlockWithPin, unlockWithBiometric };

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -462,13 +462,15 @@ export function useBreezSdk(
 
       // Write the seed to the right tier for this mode. Skip entirely
       // when the seed was just retrieved from secure storage. Storage
-      // tiers: passkey native => biometric-bound `secureStorage`,
-      // non-passkey native => `deviceOnlyStorage` (no biometric gate),
-      // web passkey => no cache, web non-passkey => plaintext fallback.
-      // Failures are non-fatal: the wallet is already connected, and
-      // the storage layer emits its own typed breadcrumb.
+      // tiers: native => `deviceOnlyStorage` by default (silent launch),
+      // or biometric-bound `secureStorage` when the user opted into
+      // biometric unlock in Security settings (the occupied tier is the
+      // setting, see secureStorage.ts). Web passkey => no cache, web
+      // non-passkey => plaintext fallback. Failures are non-fatal: the
+      // wallet is already connected, and the storage layer emits its
+      // own typed breadcrumb.
       if (source !== 'secureStorage') {
-        if (passkeyLabel != null && secureStorage.isSupported()) {
+        if (secureStorage.isSupported() && (await secureStorage.hasStoredSeed())) {
           // Defer the loading-copy flip so a fast Keystore write
           // doesn't flash the "Setting up biometric unlock…" label.
           const labelDeferMs = 250;
@@ -1047,32 +1049,17 @@ export function useBreezSdk(
       // (A) Legacy plaintext-mnemonic migration (native only).
       await migrateLegacyMnemonicIfNeeded();
 
-      // (B) 0.0.3 regression recovery: that release wrote every seed
-      //     into the biometric-bound tier, including non-passkey users.
-      //     Wipe the orphan silently so they re-onboard via mnemonic
-      //     into the right tier. `clearSeed` is unauthenticated.
-      if (
-        secureStorage.isSupported()
-        && !isPasskeyMode()
-        && (await secureStorage.hasStoredSeed())
-      ) {
-        logger.warn(
-          LogCategory.AUTH,
-          'Clearing orphaned biometric-bound seed from 0.0.3 regression',
-        );
-        await secureStorage.clearSeed().catch(() => { /* best-effort */ });
-      }
-
-      // (C) Passkey biometric unlock. Order matters so the OS prompt
-      //     lands over a fully-painted UnlockingPage, not a black
-      //     splash: flushSync commits the route change before
-      //     hideSplash() awaits the WAAPI fade on the compositor, then
-      //     retryUnlock fires. CSS-transition-based fades janked the
-      //     main thread on Android WebView; WAAPI sidesteps that.
+      // (B) Biometric unlock (opt-in via Security settings; a seed in
+      //     the biometric-bound tier means the user enabled it, for any
+      //     wallet mode). Order matters so the OS prompt lands over a
+      //     fully-painted UnlockingPage, not a black splash: flushSync
+      //     commits the route change before hideSplash() awaits the
+      //     WAAPI fade on the compositor, then retryUnlock fires.
+      //     CSS-transition-based fades janked the main thread on
+      //     Android WebView; WAAPI sidesteps that.
       let useLegacy = true;
       if (
-        isPasskeyMode()
-        && secureStorage.isSupported()
+        secureStorage.isSupported()
         && (await secureStorage.hasStoredSeed())
       ) {
         logger.info(LogCategory.AUTH, 'unlock:start');
@@ -1094,7 +1081,7 @@ export function useBreezSdk(
         deviceOnlyStorage.isSupported()
         && (await deviceOnlyStorage.hasStoredSeed())
       ) {
-        // (D) Non-passkey native silent reconnect. Plain decrypt, no
+        // (C) Native default silent reconnect. Plain decrypt, no
         //     biometric prompt. `source: 'secureStorage'` skips the
         //     redundant re-write.
         useLegacy = false;
@@ -1112,7 +1099,7 @@ export function useBreezSdk(
         }
       }
 
-      // (E) Legacy flow: web, or native with no stored seed.
+      // (D) Legacy flow: web, or native with no stored seed.
       if (useLegacy) {
         if (isPasskeyMode()) {
           // Passkey mode always re-derives via PRF on launch.

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -41,6 +41,7 @@ import {
 } from '../services/passkeyService';
 import { LEGACY_RP_ID, SHARED_RP_ID, rpId as defaultRpId } from '../services/passkeyPrfProvider';
 import { secureStorage, deviceOnlyStorage, SecureStorageError } from '../services/secureStorage';
+import { clearPin, isAppLockSupported } from '../services/appLock';
 
 
 // ============================================
@@ -157,14 +158,6 @@ export interface BreezSdkState {
    */
   isFreshInstallRestore: boolean;
   startupState: StartupState;
-  /**
-   * True while `secureStorage.storeSeed` is in flight during
-   * onboarding so the UI can swap "Starting Glow…" for "Setting up
-   * biometric unlock…", explaining the second biometric prompt right
-   * after the passkey ceremony. Only set by `connectWallet`'s
-   * onboarding path; the retrieve path has its own loading copy.
-   */
-  isSecuringSeed: boolean;
 }
 
 export type SdkEventHandler = (event: SdkEvent) => void;
@@ -261,7 +254,6 @@ export function useBreezSdk(
   const [needsPasskeyMigration, setNeedsPasskeyMigration] = useState(false);
   const [prfAvailable, setPrfAvailable] = useState(false);
   const [startupState, setStartupState] = useState<StartupState>('loading');
-  const [isSecuringSeed, setIsSecuringSeed] = useState(false);
 
   // Refs
   const isInitialLoadRef = useRef(true);
@@ -460,34 +452,14 @@ export function useBreezSdk(
         );
       }
 
-      // Write the seed to the right tier for this mode. Skip entirely
-      // when the seed was just retrieved from secure storage. Storage
-      // tiers: native => `deviceOnlyStorage` by default (silent launch),
-      // or biometric-bound `secureStorage` when the user opted into
-      // biometric unlock in Security settings (the occupied tier is the
-      // setting, see secureStorage.ts). Web passkey => no cache, web
-      // non-passkey => plaintext fallback. Failures are non-fatal: the
-      // wallet is already connected, and the storage layer emits its
-      // own typed breadcrumb.
+      // Persist the seed. Skip entirely when it was just retrieved from
+      // the native vault. Native => device-only tier, always (silent
+      // launch; PIN/biometric gating is app-level, see appLock.ts).
+      // Web passkey => no cache, web non-passkey => plaintext fallback.
+      // Failures are non-fatal: the wallet is already connected, and
+      // the storage layer emits its own typed breadcrumb.
       if (source !== 'secureStorage') {
-        if (secureStorage.isSupported() && (await secureStorage.hasStoredSeed())) {
-          // Defer the loading-copy flip so a fast Keystore write
-          // doesn't flash the "Setting up biometric unlock…" label.
-          const labelDeferMs = 250;
-          let flipped = false;
-          const flipTimer = setTimeout(() => {
-            flipped = true;
-            setIsSecuringSeed(true);
-          }, labelDeferMs);
-          try {
-            await secureStorage.storeSeed(seed);
-          } catch {
-            // non-fatal; storage layer logged.
-          } finally {
-            clearTimeout(flipTimer);
-            if (flipped) setIsSecuringSeed(false);
-          }
-        } else if (deviceOnlyStorage.isSupported()) {
+        if (deviceOnlyStorage.isSupported()) {
           try {
             await deviceOnlyStorage.storeSeed(seed);
           } catch {
@@ -572,6 +544,11 @@ export function useBreezSdk(
     }
     if (deviceOnlyStorage.isSupported()) {
       try { await deviceOnlyStorage.clearSeed(); } catch { /* non-fatal */ }
+    }
+    // Drop the app lock with the wallet it protected, so onboarding
+    // for the next wallet doesn't start behind the old wallet's PIN.
+    if (isAppLockSupported()) {
+      try { await clearPin(); } catch { /* non-fatal */ }
     }
 
     // Always reset all state, even if disconnect threw.
@@ -902,6 +879,18 @@ export function useBreezSdk(
       const seed = await secureStorage.retrieveSeed();
       await connectWallet(seed, false, undefined, 'secureStorage');
       // connectWallet sets startupState='connected' on success.
+      // Legacy migration: pre-app-lock builds kept the seed
+      // biometric-bound. Move it to the device-only tier (this prompt
+      // was the last mandatory one; PIN/biometric gating is app-level
+      // now, see appLock.ts). Write-then-clear so a crash mid-move
+      // can only duplicate the seed, never lose it.
+      try {
+        await deviceOnlyStorage.storeSeed(seed);
+        await secureStorage.clearSeed();
+        logger.info(LogCategory.AUTH, 'Migrated biometric-bound seed to device-only tier');
+      } catch {
+        // Best-effort; the next successful unlock retries.
+      }
     } catch (e) {
       setIsLoading(false);
       if (e instanceof SecureStorageError) {
@@ -1049,9 +1038,10 @@ export function useBreezSdk(
       // (A) Legacy plaintext-mnemonic migration (native only).
       await migrateLegacyMnemonicIfNeeded();
 
-      // (B) Biometric unlock (opt-in via Security settings; a seed in
-      //     the biometric-bound tier means the user enabled it, for any
-      //     wallet mode). Order matters so the OS prompt lands over a
+      // (B) Legacy biometric-bound seed (pre-app-lock builds). One last
+      //     OS-prompted unlock, after which retryUnlock migrates the
+      //     seed to the device-only tier and this branch never runs
+      //     again. Order matters so the OS prompt lands over a
       //     fully-painted UnlockingPage, not a black splash: flushSync
       //     commits the route change before hideSplash() awaits the
       //     WAAPI fade on the compositor, then retryUnlock fires.
@@ -1252,7 +1242,6 @@ export function useBreezSdk(
     hasPasskeyBefore: hasPasskeyHistory(),
     isFreshInstallRestore: freshInstallRestore,
     startupState,
-    isSecuringSeed,
     // Actions
     connectWallet,
     refreshWalletData,

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -700,11 +700,13 @@ export function useBreezSdk(
       setSdk(connectedSdk);
       setPasskeyMode(wallet.label, rpId);
 
-      if (secureStorage.isSupported()) {
+      if (deviceOnlyStorage.isSupported()) {
         try {
-          await secureStorage.storeSeed(wallet.seed);
+          await deviceOnlyStorage.storeSeed(wallet.seed);
         } catch {
-          // In-memory seed keeps the session alive; relaunch re-prompts.
+          // In-memory seed keeps the session alive. The old label's
+          // cached seed may survive; next launch reconnects it and the
+          // user can switch again.
         }
       }
 
@@ -1038,6 +1040,24 @@ export function useBreezSdk(
       // (A) Legacy plaintext-mnemonic migration (native only).
       await migrateLegacyMnemonicIfNeeded();
 
+      // (B0) Stale bound-tier residue. A live seed one tier down (or a
+      //     saved mnemonic) means the bound-tier entry is a 0.0.3
+      //     orphan or a half-finished migration duplicate, not the
+      //     active wallet. Clear it so it can't hijack startup with a
+      //     biometric prompt for the wrong seed, or wipe a working
+      //     wallet via the KEY_INVALIDATED path below.
+      let staleBoundTierCleared = false;
+      if (secureStorage.isSupported() && (await secureStorage.hasStoredSeed())) {
+        const hasLiveSeedBelow =
+          (await deviceOnlyStorage.hasStoredSeed())
+          || (!isPasskeyMode() && getSavedMnemonic() != null);
+        if (hasLiveSeedBelow) {
+          await secureStorage.clearSeed().catch(() => { /* best-effort */ });
+          staleBoundTierCleared = true;
+          logger.warn(LogCategory.AUTH, 'Cleared stale biometric-bound seed');
+        }
+      }
+
       // (B) Legacy biometric-bound seed (pre-app-lock builds). One last
       //     OS-prompted unlock, after which retryUnlock migrates the
       //     seed to the device-only tier and this branch never runs
@@ -1049,7 +1069,8 @@ export function useBreezSdk(
       //     Android WebView; WAAPI sidesteps that.
       let useLegacy = true;
       if (
-        secureStorage.isSupported()
+        !staleBoundTierCleared
+        && secureStorage.isSupported()
         && (await secureStorage.hasStoredSeed())
       ) {
         logger.info(LogCategory.AUTH, 'unlock:start');

--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,7 @@
   --animate-shimmer: shimmer 2s linear infinite;
   --animate-spin-slow: spin 3s linear infinite;
   --animate-bounce-subtle: bounce-subtle 2s ease-in-out infinite;
+  --animate-pin-shake: pin-shake 0.4s cubic-bezier(0.36, 0.07, 0.19, 0.97);
 
   --backdrop-blur-xs: 2px;
 
@@ -108,6 +109,14 @@
     50% {
       transform: translateY(-5px);
     }
+  }
+  /* Wrong-PIN feedback: the dots row shudders horizontally, iOS
+     passcode style. */
+  @keyframes pin-shake {
+    10%, 90% { transform: translateX(-2px); }
+    20%, 80% { transform: translateX(4px); }
+    30%, 50%, 70% { transform: translateX(-6px); }
+    40%, 60% { transform: translateX(6px); }
   }
 }
 

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -29,6 +29,11 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
 
   const isPasskey = isPasskeyMode();
 
+  // Non-passkey wallet whose seed sits in the biometric-bound tier
+  // (biometric unlock enabled in Security settings). Reveal requires
+  // an OS biometric prompt instead of the silent device-only read.
+  const [biometricSeedPresent, setBiometricSeedPresent] = useState(false);
+
   useEffect(() => {
     if (isPasskey) return;
     let cancelled = false;
@@ -48,6 +53,14 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
         }
       }
       if (cancelled) return;
+      // Biometric unlock enabled: the seed lives in the biometric-bound
+      // tier. Don't read it here (that would fire an OS prompt at page
+      // mount) — flag it so the reveal tile triggers the prompt on tap.
+      if (secureStorage.isSupported() && (await secureStorage.hasStoredSeed())) {
+        if (!cancelled) setBiometricSeedPresent(true);
+        return;
+      }
+      if (cancelled) return;
       setMnemonic(localStorage.getItem('walletMnemonic'));
     })();
     return () => {
@@ -62,6 +75,18 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
   // available. Auto-fallback would mask passkey deletion / corruption
   // from users who care about the distinction.
   const [passkeyAttemptFailed, setPasskeyAttemptFailed] = useState(false);
+
+  // Passkey mode: once the passkey attempt fails, probe which vault
+  // tier holds the cached seed so the fallback tile can say whether
+  // the reveal will prompt for biometrics or read silently.
+  useEffect(() => {
+    if (!isPasskey || !passkeyAttemptFailed || !secureStorage.isSupported()) return;
+    let cancelled = false;
+    void secureStorage.hasStoredSeed().then((stored) => {
+      if (!cancelled) setBiometricSeedPresent(stored);
+    });
+    return () => { cancelled = true; };
+  }, [isPasskey, passkeyAttemptFailed]);
 
   // Resolved at mount: 'Face ID', 'Touch ID', 'fingerprint', etc.
   // Used to label the biometric fallback button so iOS users see
@@ -108,20 +133,27 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
     }
   };
 
-  // Fallback path: read the seed directly from biometric-bound
-  // secureStorage. Only surfaced after the passkey path failed, so
-  // users with intact passkeys never bypass the passkey ceremony.
-  // Useful when the passkey was deleted from Settings -> Passwords:
-  // the cached seed survives there and can be revealed via Face ID.
+  // Fallback path: read the cached seed from the native vault —
+  // biometric-bound tier when biometric unlock is enabled (OS prompt),
+  // device-only tier otherwise (silent). For passkey wallets this is
+  // only surfaced after the passkey path failed, so users with intact
+  // passkeys never bypass the passkey ceremony. Useful when the passkey
+  // was deleted from Settings -> Passwords: the cached seed survives
+  // there and can still be revealed.
   const handleRevealWithBiometric = async () => {
     setIsLoading(true);
     setError(null);
     try {
-      if (!secureStorage.isSupported() || !(await secureStorage.hasStoredSeed())) {
+      const store = secureStorage.isSupported() && (await secureStorage.hasStoredSeed())
+        ? secureStorage
+        : deviceOnlyStorage.isSupported() && (await deviceOnlyStorage.hasStoredSeed())
+          ? deviceOnlyStorage
+          : null;
+      if (!store) {
         setError('No recovery phrase available on this device');
         return;
       }
-      const seed = await secureStorage.retrieveSeed();
+      const seed = await store.retrieveSeed();
       if (seed.type === 'mnemonic' && seed.mnemonic) {
         setMnemonic(seed.mnemonic);
         setIsRevealed(true);
@@ -208,17 +240,34 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </button>
           )}
 
-          {/* Reveal button (mnemonic mode) */}
-          {!isPasskey && !isRevealed && mnemonic && (
+          {/* Reveal button (mnemonic mode). When biometric unlock is
+              enabled the seed is in the biometric-bound tier, so the
+              tap triggers an OS prompt before revealing. */}
+          {!isPasskey && !isRevealed && (mnemonic || biometricSeedPresent) && (
             <button
-              onClick={() => setIsRevealed(true)}
-              className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors"
+              onClick={mnemonic ? () => setIsRevealed(true) : handleRevealWithBiometric}
+              disabled={isLoading}
+              className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
             >
               <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-                <EyeIcon size="xl" className="text-spark-primary" />
+                {isLoading ? (
+                  <SpinnerIcon size="xl" className="text-spark-primary" />
+                ) : mnemonic ? (
+                  <EyeIcon size="xl" className="text-spark-primary" />
+                ) : (
+                  <FingerprintIcon size="xl" className="text-spark-primary" />
+                )}
               </div>
-              <span className="font-display font-semibold text-spark-text-primary">Tap to reveal phrase</span>
-              <span className="text-sm text-spark-text-muted">Make sure no one is watching</span>
+              <span className="font-display font-semibold text-spark-text-primary">
+                {isLoading ? 'Authenticating...' : 'Tap to reveal phrase'}
+              </span>
+              <span className="text-sm text-spark-text-muted">
+                {mnemonic
+                  ? 'Make sure no one is watching'
+                  : isLoading
+                    ? `Complete ${biometryLabel ?? 'biometric'} authentication`
+                    : `Requires ${biometryLabel ?? 'biometric authentication'}`}
+              </span>
             </button>
           )}
 
@@ -255,9 +304,11 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
                 {isLoading ? 'Authenticating...' : 'Tap to reveal phrase'}
               </span>
               <span className="text-sm text-spark-text-muted">
-                {isLoading
-                  ? `Complete ${biometryLabel ?? 'biometric'} authentication`
-                  : `Requires ${biometryLabel ?? 'biometric authentication'}`}
+                {!biometricSeedPresent
+                  ? 'Stored securely on this device'
+                  : isLoading
+                    ? `Complete ${biometryLabel ?? 'biometric'} authentication`
+                    : `Requires ${biometryLabel ?? 'biometric authentication'}`}
               </span>
             </button>
           )}
@@ -327,7 +378,7 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
           )}
 
           {/* No backup found (mnemonic mode only) */}
-          {!isPasskey && !mnemonic && (
+          {!isPasskey && !mnemonic && !biometricSeedPresent && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-8 text-center">
               <div className="w-16 h-16 rounded-2xl bg-spark-error/20 flex items-center justify-center mx-auto mb-4">
                 <WarningIcon size="xl" className="text-spark-error" />

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { WarningIcon, SpinnerIcon, EyeIcon, FingerprintIcon, PasskeyIcon } from '../components/Icons';
+import { WarningIcon, SpinnerIcon, EyeIcon, FaceIdIcon, FingerprintIcon, PasskeyIcon } from '../components/Icons';
 import SlideInPage from '../components/layout/SlideInPage';
 import {
   isPasskeyMode,
   signInPinnedToActiveCredential,
 } from '@/services/passkeyService';
-import { deviceOnlyStorage, secureStorage, getBiometryLabel } from '@/services/secureStorage';
+import { deviceOnlyStorage, secureStorage, getBiometryInfo, BiometryInfo } from '@/services/secureStorage';
+import { isPinEnabled, isPinEnabledSync } from '@/services/appLock';
+import { PinGate } from '../components/PinEntry';
 import { logger, LogCategory } from '@/services/logger';
 import { copyToClipboard } from '@/utils/clipboard';
 import { useScreenCaptureProtection } from '@/utils/screenSecurity';
@@ -33,6 +35,23 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
   // (biometric unlock enabled in Security settings). Reveal requires
   // an OS biometric prompt instead of the silent device-only read.
   const [biometricSeedPresent, setBiometricSeedPresent] = useState(false);
+
+  // App-lock gate before the silent-tier reveal (Misty gates its
+  // mnemonics page behind the app lock). Only the device-only /
+  // localStorage path needs it: the passkey and biometric-tier paths
+  // already run their own OS auth ceremony on reveal. No PIN set =>
+  // plain tap, matching the "no login by default" decision.
+  // Seeded from the sync mirror so a tap before the async read lands
+  // can't slip past the gate; the Preferences read stays authoritative.
+  const [pinRequired, setPinRequired] = useState(isPinEnabledSync());
+  const [showPinGate, setShowPinGate] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void isPinEnabled().then((enabled) => {
+      if (!cancelled) setPinRequired(enabled);
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     if (isPasskey) return;
@@ -96,16 +115,15 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
     return () => { cancelled = true; };
   }, [isPasskey, passkeyAttemptFailed]);
 
-  // Resolved at mount: 'Face ID', 'Touch ID', 'fingerprint', etc.
-  // Used to label the biometric fallback button so iOS users see
-  // "Reveal with Face ID" while Android fingerprint users see
-  // "Reveal with fingerprint", etc. Null on web or when no biometry
-  // is enrolled; the button label degrades gracefully to "Reveal".
-  const [biometryLabel, setBiometryLabel] = useState<string | null>(null);
+  // Resolved at mount: label ('Face ID', 'Touch ID', 'fingerprint'…)
+  // for the fallback tiles' copy, kind ('face' | 'fingerprint') for
+  // their icon. Null on web or when no biometry is enrolled; the copy
+  // degrades gracefully and the icon falls back to fingerprint.
+  const [biometry, setBiometry] = useState<BiometryInfo | null>(null);
   useEffect(() => {
     let cancelled = false;
-    getBiometryLabel().then((label) => {
-      if (!cancelled) setBiometryLabel(label);
+    getBiometryInfo().then((info) => {
+      if (!cancelled) setBiometry(info);
     });
     return () => { cancelled = true; };
   }, []);
@@ -193,8 +211,11 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
 
   return (
     <SlideInPage title="Backup" onClose={onBack} slideFrom="left">
-      <div className="p-4">
-        <div className="max-w-xl mx-auto w-full space-y-6">
+      {/* min-h-full + flexed chain so the PIN gate (the sole child
+          while it shows) can split the viewport 1/3 header / 2/3
+          input; the card views flow from the top as before. */}
+      <div className="p-4 min-h-full flex flex-col">
+        <div className="max-w-xl mx-auto w-full space-y-6 flex-1 flex flex-col">
           {/* Passkey info card */}
           {isPasskey && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-6">
@@ -237,12 +258,27 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </button>
           )}
 
+          {/* App-lock gate (mnemonic mode): shown in place of the
+              reveal tile once it is tapped with a PIN set. */}
+          {!isPasskey && !isRevealed && showPinGate && (
+            <PinGate
+              reason="Reveal recovery phrase"
+              onUnlocked={() => {
+                setShowPinGate(false);
+                setIsRevealed(true);
+              }}
+            />
+          )}
+
           {/* Reveal button (mnemonic mode). When biometric unlock is
               enabled the seed is in the biometric-bound tier, so the
-              tap triggers an OS prompt before revealing. */}
-          {!isPasskey && !isRevealed && (mnemonic || biometricSeedPresent) && (
+              tap triggers an OS prompt before revealing. With the
+              app-lock PIN set, the tap opens the PIN gate instead. */}
+          {!isPasskey && !isRevealed && !showPinGate && (mnemonic || biometricSeedPresent) && (
             <button
-              onClick={mnemonic ? () => setIsRevealed(true) : () => { void revealFromVault('biometric'); }}
+              onClick={mnemonic
+                ? () => { (pinRequired ? setShowPinGate : setIsRevealed)(true); }
+                : () => { void revealFromVault('biometric'); }}
               disabled={isLoading}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
             >
@@ -251,6 +287,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
                   <SpinnerIcon size="xl" className="text-spark-primary" />
                 ) : mnemonic ? (
                   <EyeIcon size="xl" className="text-spark-primary" />
+                ) : biometry?.kind === 'face' ? (
+                  <FaceIdIcon size="xl" className="text-spark-primary" />
                 ) : (
                   <FingerprintIcon size="xl" className="text-spark-primary" />
                 )}
@@ -260,10 +298,10 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
               </span>
               <span className="text-sm text-spark-text-muted">
                 {mnemonic
-                  ? 'Make sure no one is watching'
+                  ? pinRequired ? 'Requires PIN' : 'Make sure no one is watching'
                   : isLoading
-                    ? `Complete ${biometryLabel ?? 'biometric'} authentication`
-                    : `Requires ${biometryLabel ?? 'biometric authentication'}`}
+                    ? `Complete ${biometry?.label ?? 'biometric'} authentication`
+                    : `Requires ${biometry?.label ?? 'biometric authentication'}`}
               </span>
             </button>
           )}
@@ -294,6 +332,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
               <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
                 {isLoading ? (
                   <SpinnerIcon size="xl" className="text-spark-primary" />
+                ) : biometry?.kind === 'face' && fallbackTier === 'biometric' ? (
+                  <FaceIdIcon size="xl" className="text-spark-primary" />
                 ) : (
                   <FingerprintIcon size="xl" className="text-spark-primary" />
                 )}
@@ -305,8 +345,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
                 {fallbackTier === 'device'
                   ? 'Stored securely on this device'
                   : isLoading
-                    ? `Complete ${biometryLabel ?? 'biometric'} authentication`
-                    : `Requires ${biometryLabel ?? 'biometric authentication'}`}
+                    ? `Complete ${biometry?.label ?? 'biometric'} authentication`
+                    : `Requires ${biometry?.label ?? 'biometric authentication'}`}
               </span>
             </button>
           )}

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -53,9 +53,9 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
         }
       }
       if (cancelled) return;
-      // Biometric unlock enabled: the seed lives in the biometric-bound
-      // tier. Don't read it here (that would fire an OS prompt at page
-      // mount) — flag it so the reveal tile triggers the prompt on tap.
+      // Legacy biometric-bound seed (pre-migration install). Don't read
+      // it here (that would fire an OS prompt at page mount); flag it
+      // so the reveal tile triggers the prompt on tap.
       if (secureStorage.isSupported() && (await secureStorage.hasStoredSeed())) {
         if (!cancelled) setBiometricSeedPresent(true);
         return;
@@ -76,15 +76,23 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
   // from users who care about the distinction.
   const [passkeyAttemptFailed, setPasskeyAttemptFailed] = useState(false);
 
-  // Passkey mode: once the passkey attempt fails, probe which vault
-  // tier holds the cached seed so the fallback tile can say whether
-  // the reveal will prompt for biometrics or read silently.
+  // Passkey mode: once the passkey attempt fails, resolve which vault
+  // tier holds the cached seed. Drives the fallback tile's copy
+  // (biometric prompt vs silent read) and its very existence: with
+  // no cached seed in either tier the tile would be a dead button.
+  // null = still probing.
+  const [fallbackTier, setFallbackTier] = useState<'biometric' | 'device' | 'none' | null>(null);
   useEffect(() => {
     if (!isPasskey || !passkeyAttemptFailed || !secureStorage.isSupported()) return;
     let cancelled = false;
-    void secureStorage.hasStoredSeed().then((stored) => {
-      if (!cancelled) setBiometricSeedPresent(stored);
-    });
+    void (async () => {
+      const tier = (await secureStorage.hasStoredSeed().catch(() => false))
+        ? 'biometric' as const
+        : (await deviceOnlyStorage.hasStoredSeed().catch(() => false))
+          ? 'device' as const
+          : 'none' as const;
+      if (!cancelled) setFallbackTier(tier);
+    })();
     return () => { cancelled = true; };
   }, [isPasskey, passkeyAttemptFailed]);
 
@@ -133,26 +141,15 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
     }
   };
 
-  // Fallback path: read the cached seed from the native vault —
-  // biometric-bound tier when biometric unlock is enabled (OS prompt),
-  // device-only tier otherwise (silent). For passkey wallets this is
-  // only surfaced after the passkey path failed, so users with intact
-  // passkeys never bypass the passkey ceremony. Useful when the passkey
-  // was deleted from Settings -> Passwords: the cached seed survives
-  // there and can still be revealed.
-  const handleRevealWithBiometric = async () => {
+  // Fallback path: read the cached seed from the given vault tier
+  // (legacy biometric-bound prompts, device-only is silent). For
+  // passkey wallets this only surfaces after the passkey path failed,
+  // so intact passkeys never bypass the ceremony.
+  const revealFromVault = async (tier: 'biometric' | 'device') => {
     setIsLoading(true);
     setError(null);
     try {
-      const store = secureStorage.isSupported() && (await secureStorage.hasStoredSeed())
-        ? secureStorage
-        : deviceOnlyStorage.isSupported() && (await deviceOnlyStorage.hasStoredSeed())
-          ? deviceOnlyStorage
-          : null;
-      if (!store) {
-        setError('No recovery phrase available on this device');
-        return;
-      }
+      const store = tier === 'biometric' ? secureStorage : deviceOnlyStorage;
       const seed = await store.retrieveSeed();
       if (seed.type === 'mnemonic' && seed.mnemonic) {
         setMnemonic(seed.mnemonic);
@@ -245,7 +242,7 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
               tap triggers an OS prompt before revealing. */}
           {!isPasskey && !isRevealed && (mnemonic || biometricSeedPresent) && (
             <button
-              onClick={mnemonic ? () => setIsRevealed(true) : handleRevealWithBiometric}
+              onClick={mnemonic ? () => setIsRevealed(true) : () => { void revealFromVault('biometric'); }}
               disabled={isLoading}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
             >
@@ -287,9 +284,10 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
               "Requires passkey authentication" subtitle for "Requires
               {biometric}". The label-driven biometric naming matches
               the convention used elsewhere (UnlockPage). */}
-          {isPasskey && passkeyAttemptFailed && !isRevealed && !mnemonic && secureStorage.isSupported() && (
+          {isPasskey && passkeyAttemptFailed && !isRevealed && !mnemonic
+            && (fallbackTier === 'biometric' || fallbackTier === 'device') && (
             <button
-              onClick={handleRevealWithBiometric}
+              onClick={() => { void revealFromVault(fallbackTier); }}
               disabled={isLoading}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
             >
@@ -304,7 +302,7 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
                 {isLoading ? 'Authenticating...' : 'Tap to reveal phrase'}
               </span>
               <span className="text-sm text-spark-text-muted">
-                {!biometricSeedPresent
+                {fallbackTier === 'device'
                   ? 'Stored securely on this device'
                   : isLoading
                     ? `Complete ${biometryLabel ?? 'biometric'} authentication`
@@ -313,14 +311,12 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </button>
           )}
 
-          {/* Web fallback (passkey mode, no native secure storage). On
-              web the seed is derived from the passkey PRF only: there
-              is no device-bound copy to read with biometrics. If the
-              passkey attempt failed, the recovery phrase cannot be
-              retrieved here. Mirror the "No Backup Found" tile used
-              for non-passkey mode so the user gets a clear dead-end
-              message instead of a button that always errors. */}
-          {isPasskey && passkeyAttemptFailed && !isRevealed && !mnemonic && !secureStorage.isSupported() && (
+          {/* Dead-end card (passkey mode): web has no cached copy at
+              all, and a native install can lack one too (persist
+              failed, vault cleared). Without it the fallback tile
+              would be a button that always errors. */}
+          {isPasskey && passkeyAttemptFailed && !isRevealed && !mnemonic
+            && (!secureStorage.isSupported() || fallbackTier === 'none') && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-8 text-center">
               <div className="w-16 h-16 rounded-2xl bg-spark-error/20 flex items-center justify-center mx-auto mb-4">
                 <WarningIcon size="xl" className="text-spark-error" />

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -56,14 +56,6 @@ interface PasskeyPageProps {
   onWalletRestored: (seed: Seed, label: string) => void;
   onBack: () => void;
   sdkConnected?: boolean;
-  /**
-   * True while `secureStorage.storeSeed` is in flight during
-   * onboarding so the `initializing` phase can swap "Starting Glow…"
-   * for "Setting up biometric unlock…". iOS effectively never sees
-   * this (SecAccessControl gates retrieval only); Android's
-   * CryptoObject path blocks at the sensor and surfaces it.
-   */
-  isSecuringSeed?: boolean;
   onFlowComplete?: () => void;
   /** Skip discovery; start the create flow directly. */
   skipDetection?: boolean;
@@ -95,7 +87,6 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
   onWalletRestored,
   onBack,
   sdkConnected,
-  isSecuringSeed,
   onFlowComplete,
   skipDetection = false,
   consumeFreshInstallSignal,
@@ -930,11 +921,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
         if (error) return null;
         return renderSpinner('Starting Glow...');
       case 'initializing':
-        // `secureStorage.storeSeed` triggers a second biometric prompt
-        // to bind the seed; swap the label so it has visible context.
-        return renderSpinner(
-          isSecuringSeed ? 'Setting up biometric unlock...' : 'Starting Glow...',
-        );
+        return renderSpinner('Starting Glow...');
     }
   })();
 

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -6,11 +6,11 @@
  * change PIN, enable <biometry>.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import SlideInPage from '../components/layout/SlideInPage';
-import { PinEntry } from '../components/PinEntry';
+import { PinEntry, PinGate, PinScreenLayout } from '../components/PinEntry';
 import { Switch, LoadingSpinner } from '../components/ui';
-import { ChevronRightIcon, FingerprintIcon, LockIcon, ShieldCheckIcon } from '../components/Icons';
+import { ChevronRightIcon, FaceIdIcon, FingerprintIcon, ShieldCheckIcon } from '../components/Icons';
 import {
   AUTO_LOCK_OPTIONS_SECONDS,
   formatAutoLockOption,
@@ -20,10 +20,14 @@ import {
   setBiometricGateEnabled,
   isPinEnabled,
   setPin,
-  verifyPin,
   clearPin,
 } from '@/services/appLock';
-import { authenticateBiometric, getBiometryLabel } from '@/services/secureStorage';
+import {
+  authenticateBiometric,
+  getBiometryStatus,
+  recoverBiometryWithPasscode,
+  BiometryInfo,
+} from '@/services/secureStorage';
 import { logger, LogCategory } from '@/services/logger';
 
 type View =
@@ -42,52 +46,36 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
   const [view, setView] = useState<View>('loading');
   const [autoLock, setAutoLock] = useState<number>(120);
   const [biometricGate, setBiometricGate] = useState(false);
-  const [biometryLabel, setBiometryLabel] = useState<string | null>(null);
+  const [biometry, setBiometry] = useState<BiometryInfo | null>(null);
+  // iOS biometry lockout: recoverable via passcode, so the options view
+  // shows a recovery row instead of silently dropping the biometric one.
+  const [biometryLockedOut, setBiometryLockedOut] = useState(false);
   const [optionsError, setOptionsError] = useState<string | null>(null);
 
   // Two-step PIN flow state (shared by create + change).
   const [pinStep, setPinStep] = useState<'enter' | 'verify'>('enter');
   const firstPinRef = useRef<string | null>(null);
 
-  // Auto-fire the biometric gate only once per page entry; the pad's
-  // fingerprint button re-fires it manually after a cancel.
-  const bioFiredRef = useRef(false);
-
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const [pin, gate, seconds, label] = await Promise.all([
+      const [pin, gate, seconds, biometryStatus] = await Promise.all([
         isPinEnabled(),
         isBiometricGateEnabled(),
         getAutoLockSeconds(),
-        getBiometryLabel(),
+        getBiometryStatus(),
       ]);
       if (cancelled) return;
       setBiometricGate(gate);
       setAutoLock(seconds);
-      setBiometryLabel(label);
+      setBiometry(biometryStatus.info);
+      setBiometryLockedOut(biometryStatus.lockedOut);
       setView(pin ? 'gate' : 'no-pin');
     })();
     return () => {
       cancelled = true;
     };
   }, []);
-
-  const runBiometricGate = useCallback(async () => {
-    try {
-      await authenticateBiometric('Unlock Security settings');
-      setView('options');
-    } catch {
-      // Cancelled or unavailable: the PIN pad stays as fallback.
-    }
-  }, []);
-
-  useEffect(() => {
-    if (view === 'gate' && biometricGate && !bioFiredRef.current) {
-      bioFiredRef.current = true;
-      void runBiometricGate();
-    }
-  }, [view, biometricGate, runBiometricGate]);
 
   // Mismatch feedback lives here, not in PinEntry: the step flip back
   // to 'enter' remounts PinEntry (key={pinStep}) and would eat it.
@@ -134,7 +122,7 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
     try {
       // Confirm the user can actually pass the prompt before enabling,
       // mirroring Misty's enable flow.
-      await authenticateBiometric(`Enable ${biometryLabel ?? 'biometric'} unlock`);
+      await authenticateBiometric(`Enable ${biometry?.label ?? 'biometric'} unlock`);
       await setBiometricGateEnabled(true);
       setBiometricGate(true);
     } catch (e) {
@@ -142,6 +130,23 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
       logger.warn(LogCategory.AUTH, 'Enable biometric gate failed', { code });
       if (code !== 'USER_CANCELLED') {
         setOptionsError('Biometric authentication is not available. Check your device settings.');
+      }
+    }
+  };
+
+  const handleRecoverBiometry = async () => {
+    setOptionsError(null);
+    try {
+      // Passcode-allowed prompt: succeeding clears the OS lockout.
+      await recoverBiometryWithPasscode('Re-enable biometric unlock');
+      const status = await getBiometryStatus();
+      setBiometry(status.info);
+      setBiometryLockedOut(status.lockedOut);
+    } catch (e) {
+      const code = (e as { code?: string }).code;
+      logger.warn(LogCategory.AUTH, 'Biometry lockout recovery failed', { code });
+      if (code !== 'USER_CANCELLED') {
+        setOptionsError('Could not unlock biometrics. Check your device settings.');
       }
     }
   };
@@ -156,30 +161,12 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
         );
 
       case 'gate':
-        return (
-          <div className="pt-8 space-y-8">
-            <div className="flex flex-col items-center gap-3">
-              <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
-                <LockIcon size="xl" className="text-spark-primary" />
-              </div>
-              <p className="text-sm text-spark-text-secondary">Enter your PIN to continue</p>
-            </div>
-            <PinEntry
-              onSubmit={async (pin) => {
-                if (await verifyPin(pin)) {
-                  setView('options');
-                  return null;
-                }
-                return 'Incorrect PIN';
-              }}
-              onBiometric={biometricGate ? () => { void runBiometricGate(); } : undefined}
-            />
-          </div>
-        );
+        return <PinGate reason="Unlock Security settings" onUnlocked={() => setView('options')} />;
 
       case 'no-pin':
         return (
           <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+            <h3 className="font-display font-semibold text-spark-text-primary mb-3">App Lock</h3>
             <button
               className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
               type="button"
@@ -202,19 +189,22 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
             ? isChange ? 'Enter your new PIN' : 'Choose a PIN'
             : isChange ? 'Confirm your new PIN' : 'Confirm your PIN';
         return (
-          <div className="pt-8 space-y-8">
-            <p className="text-center text-sm text-spark-text-secondary">{title}</p>
-            {flowError && (
-              <p className="text-center text-sm text-spark-error">{flowError}</p>
-            )}
-            <PinEntry key={pinStep} onSubmit={handlePinFlowSubmit} />
-          </div>
+          <PinScreenLayout
+            className="pt-8 pb-14"
+            prompt={<p className="text-center text-sm text-spark-text-secondary">{title}</p>}
+          >
+            {/* Mismatch feedback rides in PinEntry's own reserved error
+                line (persistentError) so this screen keeps the exact
+                shape of the gate / lock screens. */}
+            <PinEntry key={pinStep} onSubmit={handlePinFlowSubmit} persistentError={flowError} />
+          </PinScreenLayout>
         );
       }
 
       case 'options':
         return (
           <div className="bg-spark-dark border border-spark-border rounded-2xl p-4 space-y-2">
+            <h3 className="font-display font-semibold text-spark-text-primary mb-3">App Lock</h3>
             {/* Deactivate PIN (Misty pattern: an always-on switch whose
                 only action is turning protection off) */}
             <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">
@@ -256,13 +246,38 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
               <ChevronRightIcon size="md" />
             </button>
 
+            {/* Biometry locked out (iOS: too many failed matches).
+                Shown in place of the enable row so the feature doesn't
+                silently vanish; passing the passcode prompt clears the
+                OS lockout and restores the normal toggle. */}
+            {biometry == null && biometryLockedOut && (
+              <button
+                className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+                type="button"
+                onClick={() => { void handleRecoverBiometry(); }}
+              >
+                <div className="flex items-center gap-3 text-left">
+                  <FingerprintIcon size="md" />
+                  <div>
+                    <span className="block text-spark-text-primary">Biometric unlock is locked</span>
+                    <span className="block text-xs text-spark-text-muted">
+                      Too many failed attempts. Tap to unlock with your passcode.
+                    </span>
+                  </div>
+                </div>
+                <ChevronRightIcon size="md" />
+              </button>
+            )}
+
             {/* Enable biometrics (only when the device has them) */}
-            {biometryLabel != null && (
+            {biometry != null && (
               <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">
                 <div className="flex items-center gap-3">
-                  <FingerprintIcon size="md" className="text-spark-text-secondary" />
+                  {biometry.kind === 'face'
+                    ? <FaceIdIcon size="md" className="text-spark-text-secondary" />
+                    : <FingerprintIcon size="md" className="text-spark-text-secondary" />}
                   <span className="text-sm font-medium text-spark-text-primary">
-                    {`Enable ${biometryLabel}`}
+                    {`Enable ${biometry.label}`}
                   </span>
                 </div>
                 <Switch checked={biometricGate} onChange={() => { void handleToggleBiometric(); }} />
@@ -279,8 +294,12 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
 
   return (
     <SlideInPage title="Security" onClose={onBack} slideFrom="left">
-      <div className="p-4">
-        <div className="max-w-xl mx-auto w-full">{renderBody()}</div>
+      {/* min-h-full + flexed chain so the PIN views (gate, create,
+          change) can split the viewport 1/3 header / 2/3 input; the
+          list views just flow from the top as before. p-4 keeps the
+          padding uniform on all sides. */}
+      <div className="p-4 min-h-full flex flex-col">
+        <div className="max-w-xl mx-auto w-full flex-1 flex flex-col">{renderBody()}</div>
       </div>
     </SlideInPage>
   );

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -215,11 +215,12 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
       case 'options':
         return (
           <div className="bg-spark-dark border border-spark-border rounded-2xl p-4 space-y-2">
-            {/* Deactivate PIN */}
+            {/* Deactivate PIN (Misty pattern: an always-on switch whose
+                only action is turning protection off) */}
             <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">
               <div className="flex items-center gap-3">
                 <ShieldCheckIcon size="md" className="text-spark-text-secondary" />
-                <span className="text-sm font-medium text-spark-text-primary">PIN enabled</span>
+                <span className="text-sm font-medium text-spark-text-primary">Deactivate PIN</span>
               </div>
               <Switch checked={true} onChange={() => { void handleDeactivatePin(); }} />
             </div>

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -1,0 +1,288 @@
+/**
+ * SecurityPage (native only): Misty Breez's Security settings minus the
+ * backup options. No PIN set => a single "Create PIN" row. PIN set =>
+ * the page opens behind an auth gate (biometrics first when enabled,
+ * PIN pad as fallback) and offers: deactivate PIN, auto-lock timeout,
+ * change PIN, enable <biometry>.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import SlideInPage from '../components/layout/SlideInPage';
+import { PinEntry } from '../components/PinEntry';
+import { Switch, LoadingSpinner } from '../components/ui';
+import { ChevronRightIcon, FingerprintIcon, LockIcon, ShieldCheckIcon } from '../components/Icons';
+import {
+  AUTO_LOCK_OPTIONS_SECONDS,
+  formatAutoLockOption,
+  getAutoLockSeconds,
+  setAutoLockSeconds,
+  isBiometricGateEnabled,
+  setBiometricGateEnabled,
+  isPinEnabled,
+  setPin,
+  verifyPin,
+  clearPin,
+} from '@/services/appLock';
+import { authenticateBiometric, getBiometryLabel } from '@/services/secureStorage';
+import { logger, LogCategory } from '@/services/logger';
+
+type View =
+  | 'loading'
+  | 'gate'        // PIN/biometric gate before the options are shown
+  | 'no-pin'      // PIN not set: just the Create PIN row
+  | 'options'     // PIN set + gate passed
+  | 'create-pin'  // two-step create flow
+  | 'change-pin'; // two-step change flow
+
+interface SecurityPageProps {
+  onBack: () => void;
+}
+
+const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
+  const [view, setView] = useState<View>('loading');
+  const [autoLock, setAutoLock] = useState<number>(120);
+  const [biometricGate, setBiometricGate] = useState(false);
+  const [biometryLabel, setBiometryLabel] = useState<string | null>(null);
+  const [optionsError, setOptionsError] = useState<string | null>(null);
+
+  // Two-step PIN flow state (shared by create + change).
+  const [pinStep, setPinStep] = useState<'enter' | 'verify'>('enter');
+  const firstPinRef = useRef<string | null>(null);
+
+  // Auto-fire the biometric gate only once per page entry; the pad's
+  // fingerprint button re-fires it manually after a cancel.
+  const bioFiredRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [pin, gate, seconds, label] = await Promise.all([
+        isPinEnabled(),
+        isBiometricGateEnabled(),
+        getAutoLockSeconds(),
+        getBiometryLabel(),
+      ]);
+      if (cancelled) return;
+      setBiometricGate(gate);
+      setAutoLock(seconds);
+      setBiometryLabel(label);
+      setView(pin ? 'gate' : 'no-pin');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const runBiometricGate = useCallback(async () => {
+    try {
+      await authenticateBiometric('Unlock Security settings');
+      setView('options');
+    } catch {
+      // Cancelled or unavailable: the PIN pad stays as fallback.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (view === 'gate' && biometricGate && !bioFiredRef.current) {
+      bioFiredRef.current = true;
+      void runBiometricGate();
+    }
+  }, [view, biometricGate, runBiometricGate]);
+
+  // Mismatch feedback lives here, not in PinEntry: the step flip back
+  // to 'enter' remounts PinEntry (key={pinStep}) and would eat it.
+  const [flowError, setFlowError] = useState<string | null>(null);
+
+  const startPinFlow = (target: 'create-pin' | 'change-pin') => {
+    firstPinRef.current = null;
+    setFlowError(null);
+    setPinStep('enter');
+    setView(target);
+  };
+
+  const handlePinFlowSubmit = async (pin: string): Promise<string | null> => {
+    if (pinStep === 'enter') {
+      firstPinRef.current = pin;
+      setFlowError(null);
+      setPinStep('verify');
+      return null;
+    }
+    if (pin !== firstPinRef.current) {
+      firstPinRef.current = null;
+      setFlowError('PINs do not match. Try again.');
+      setPinStep('enter');
+      return null;
+    }
+    await setPin(pin);
+    setView('options');
+    return null;
+  };
+
+  const handleDeactivatePin = async () => {
+    await clearPin();
+    setBiometricGate(false);
+    setView('no-pin');
+  };
+
+  const handleToggleBiometric = async () => {
+    setOptionsError(null);
+    if (biometricGate) {
+      await setBiometricGateEnabled(false);
+      setBiometricGate(false);
+      return;
+    }
+    try {
+      // Confirm the user can actually pass the prompt before enabling,
+      // mirroring Misty's enable flow.
+      await authenticateBiometric(`Enable ${biometryLabel ?? 'biometric'} unlock`);
+      await setBiometricGateEnabled(true);
+      setBiometricGate(true);
+    } catch (e) {
+      const code = (e as { code?: string }).code;
+      logger.warn(LogCategory.AUTH, 'Enable biometric gate failed', { code });
+      if (code !== 'USER_CANCELLED') {
+        setOptionsError('Biometric authentication is not available. Check your device settings.');
+      }
+    }
+  };
+
+  const renderBody = () => {
+    switch (view) {
+      case 'loading':
+        return (
+          <div className="flex justify-center py-16">
+            <LoadingSpinner size="small" />
+          </div>
+        );
+
+      case 'gate':
+        return (
+          <div className="pt-8 space-y-8">
+            <div className="flex flex-col items-center gap-3">
+              <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center">
+                <LockIcon size="xl" className="text-spark-primary" />
+              </div>
+              <p className="text-sm text-spark-text-secondary">Enter your PIN to continue</p>
+            </div>
+            <PinEntry
+              onSubmit={async (pin) => {
+                if (await verifyPin(pin)) {
+                  setView('options');
+                  return null;
+                }
+                return 'Incorrect PIN';
+              }}
+              onBiometric={biometricGate ? () => { void runBiometricGate(); } : undefined}
+            />
+          </div>
+        );
+
+      case 'no-pin':
+        return (
+          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+            <button
+              className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+              type="button"
+              onClick={() => startPinFlow('create-pin')}
+            >
+              <div className="flex items-center gap-3">
+                <ShieldCheckIcon size="md" />
+                <span>Create PIN</span>
+              </div>
+              <ChevronRightIcon size="md" />
+            </button>
+          </div>
+        );
+
+      case 'create-pin':
+      case 'change-pin': {
+        const isChange = view === 'change-pin';
+        const title =
+          pinStep === 'enter'
+            ? isChange ? 'Enter your new PIN' : 'Choose a PIN'
+            : isChange ? 'Confirm your new PIN' : 'Confirm your PIN';
+        return (
+          <div className="pt-8 space-y-8">
+            <p className="text-center text-sm text-spark-text-secondary">{title}</p>
+            {flowError && (
+              <p className="text-center text-sm text-spark-error">{flowError}</p>
+            )}
+            <PinEntry key={pinStep} onSubmit={handlePinFlowSubmit} />
+          </div>
+        );
+      }
+
+      case 'options':
+        return (
+          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4 space-y-2">
+            {/* Deactivate PIN */}
+            <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">
+              <div className="flex items-center gap-3">
+                <ShieldCheckIcon size="md" className="text-spark-text-secondary" />
+                <span className="text-sm font-medium text-spark-text-primary">PIN enabled</span>
+              </div>
+              <Switch checked={true} onChange={() => { void handleDeactivatePin(); }} />
+            </div>
+
+            {/* Lock automatically */}
+            <div className="flex items-center justify-between gap-3 px-4 py-3 border border-spark-border rounded-xl">
+              <span className="text-sm font-medium text-spark-text-primary">Lock automatically</span>
+              <select
+                value={autoLock}
+                onChange={(e) => {
+                  const seconds = parseInt(e.currentTarget.value, 10);
+                  setAutoLock(seconds);
+                  void setAutoLockSeconds(seconds);
+                }}
+                className="bg-spark-surface border border-spark-border rounded-xl px-3 py-2 text-spark-text-primary text-sm focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20"
+                aria-label="Lock automatically"
+              >
+                {AUTO_LOCK_OPTIONS_SECONDS.map((seconds) => (
+                  <option className="bg-spark-surface" key={seconds} value={seconds}>
+                    {formatAutoLockOption(seconds)}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Change PIN */}
+            <button
+              className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+              type="button"
+              onClick={() => startPinFlow('change-pin')}
+            >
+              <span>Change PIN</span>
+              <ChevronRightIcon size="md" />
+            </button>
+
+            {/* Enable biometrics (only when the device has them) */}
+            {biometryLabel != null && (
+              <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">
+                <div className="flex items-center gap-3">
+                  <FingerprintIcon size="md" className="text-spark-text-secondary" />
+                  <span className="text-sm font-medium text-spark-text-primary">
+                    {`Enable ${biometryLabel}`}
+                  </span>
+                </div>
+                <Switch checked={biometricGate} onChange={() => { void handleToggleBiometric(); }} />
+              </div>
+            )}
+
+            {optionsError && (
+              <p className="text-spark-error text-xs px-1 pt-1">{optionsError}</p>
+            )}
+          </div>
+        );
+    }
+  };
+
+  return (
+    <SlideInPage title="Security" onClose={onBack} slideFrom="left">
+      <div className="p-4">
+        <div className="max-w-xl mx-auto w-full">{renderBody()}</div>
+      </div>
+    </SlideInPage>
+  );
+};
+
+export default SecurityPage;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -8,13 +8,6 @@ import SlideInPage from '../components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs, exportDatabaseState } from '@/services/logExport';
 import { useSecretTap } from '@/hooks/useSecretTap';
-import {
-  secureStorage,
-  getBiometryLabel,
-  isBiometricUnlockEnabled,
-  enableBiometricUnlock,
-  disableBiometricUnlock,
-} from '@/services/secureStorage';
 
 const DEV_MODE_STORAGE_KEY = 'spark-dev-mode';
 
@@ -91,58 +84,6 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
 
   const [isDownloadingLogs, setIsDownloadingLogs] = useState<boolean>(false);
   const [isExportingDb, setIsExportingDb] = useState<boolean>(false);
-
-  // Biometric unlock (native only). `null` = still resolving which
-  // storage tier holds the seed; the switch renders disabled until then.
-  const [biometricUnlock, setBiometricUnlock] = useState<boolean | null>(null);
-  const [biometricBusy, setBiometricBusy] = useState<boolean>(false);
-  const [biometricError, setBiometricError] = useState<string | null>(null);
-  const [biometryLabel, setBiometryLabel] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!secureStorage.isSupported()) return;
-    let cancelled = false;
-    void Promise.all([isBiometricUnlockEnabled(), getBiometryLabel()]).then(
-      ([enabled, label]) => {
-        if (cancelled) return;
-        setBiometricUnlock(enabled);
-        setBiometryLabel(label);
-      },
-    );
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const handleToggleBiometricUnlock = async () => {
-    if (biometricUnlock === null || biometricBusy) return;
-    setBiometricBusy(true);
-    setBiometricError(null);
-    try {
-      if (biometricUnlock) {
-        await disableBiometricUnlock();
-        setBiometricUnlock(false);
-      } else {
-        await enableBiometricUnlock();
-        setBiometricUnlock(true);
-      }
-    } catch (e) {
-      logger.error(LogCategory.AUTH, 'Failed to toggle biometric unlock', {
-        error: e instanceof Error ? e.message : String(e),
-      });
-      // User cancelling the confirm prompt is not an error worth showing.
-      const code = (e as { code?: string }).code;
-      if (code !== 'USER_CANCELLED') {
-        setBiometricError(
-          code === 'BIOMETRIC_UNAVAILABLE' || code === 'BIOMETRIC_NOT_ENROLLED'
-            ? 'Biometric authentication is not set up on this device.'
-            : 'Could not update biometric unlock. Please try again.',
-        );
-      }
-    } finally {
-      setBiometricBusy(false);
-    }
-  };
 
   // Async SDK read for sparkPrivateModeEnabled. Stays in an effect
   // because it awaits a Promise; setState happens post-await.
@@ -277,38 +218,6 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
               </button>
             </div>
           </div>
-
-          {/* Security (native only — web keeps its passkey-per-launch flow) */}
-          {secureStorage.isSupported() && (
-            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Security</h3>
-              <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">
-                <div className="flex items-center gap-3 min-w-0">
-                  <ShieldCheckIcon size="md" className="shrink-0 text-spark-text-secondary" />
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium text-spark-text-primary">
-                      Biometric unlock
-                    </div>
-                    <div className="text-xs text-spark-text-muted">
-                      {`Require ${biometryLabel ?? 'biometric authentication'} to open Glow`}
-                    </div>
-                  </div>
-                </div>
-                {biometricBusy ? (
-                  <LoadingSpinner size="small" />
-                ) : (
-                  <Switch
-                    checked={biometricUnlock === true}
-                    disabled={biometricUnlock === null}
-                    onChange={() => { void handleToggleBiometricUnlock(); }}
-                  />
-                )}
-              </div>
-              {biometricError && (
-                <p className="text-spark-error text-xs mt-2 px-1">{biometricError}</p>
-              )}
-            </div>
-          )}
 
           {/* Passkey & Labels */}
           {isDevMode && (

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -8,6 +8,13 @@ import SlideInPage from '../components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs, exportDatabaseState } from '@/services/logExport';
 import { useSecretTap } from '@/hooks/useSecretTap';
+import {
+  secureStorage,
+  getBiometryLabel,
+  isBiometricUnlockEnabled,
+  enableBiometricUnlock,
+  disableBiometricUnlock,
+} from '@/services/secureStorage';
 
 const DEV_MODE_STORAGE_KEY = 'spark-dev-mode';
 
@@ -84,6 +91,58 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
 
   const [isDownloadingLogs, setIsDownloadingLogs] = useState<boolean>(false);
   const [isExportingDb, setIsExportingDb] = useState<boolean>(false);
+
+  // Biometric unlock (native only). `null` = still resolving which
+  // storage tier holds the seed; the switch renders disabled until then.
+  const [biometricUnlock, setBiometricUnlock] = useState<boolean | null>(null);
+  const [biometricBusy, setBiometricBusy] = useState<boolean>(false);
+  const [biometricError, setBiometricError] = useState<string | null>(null);
+  const [biometryLabel, setBiometryLabel] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!secureStorage.isSupported()) return;
+    let cancelled = false;
+    void Promise.all([isBiometricUnlockEnabled(), getBiometryLabel()]).then(
+      ([enabled, label]) => {
+        if (cancelled) return;
+        setBiometricUnlock(enabled);
+        setBiometryLabel(label);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggleBiometricUnlock = async () => {
+    if (biometricUnlock === null || biometricBusy) return;
+    setBiometricBusy(true);
+    setBiometricError(null);
+    try {
+      if (biometricUnlock) {
+        await disableBiometricUnlock();
+        setBiometricUnlock(false);
+      } else {
+        await enableBiometricUnlock();
+        setBiometricUnlock(true);
+      }
+    } catch (e) {
+      logger.error(LogCategory.AUTH, 'Failed to toggle biometric unlock', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      // User cancelling the confirm prompt is not an error worth showing.
+      const code = (e as { code?: string }).code;
+      if (code !== 'USER_CANCELLED') {
+        setBiometricError(
+          code === 'BIOMETRIC_UNAVAILABLE' || code === 'BIOMETRIC_NOT_ENROLLED'
+            ? 'Biometric authentication is not set up on this device.'
+            : 'Could not update biometric unlock. Please try again.',
+        );
+      }
+    } finally {
+      setBiometricBusy(false);
+    }
+  };
 
   // Async SDK read for sparkPrivateModeEnabled. Stays in an effect
   // because it awaits a Promise; setState happens post-await.
@@ -218,6 +277,38 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
               </button>
             </div>
           </div>
+
+          {/* Security (native only — web keeps its passkey-per-launch flow) */}
+          {secureStorage.isSupported() && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Security</h3>
+              <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">
+                <div className="flex items-center gap-3 min-w-0">
+                  <ShieldCheckIcon size="md" className="shrink-0 text-spark-text-secondary" />
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-spark-text-primary">
+                      Biometric unlock
+                    </div>
+                    <div className="text-xs text-spark-text-muted">
+                      {`Require ${biometryLabel ?? 'biometric authentication'} to open Glow`}
+                    </div>
+                  </div>
+                </div>
+                {biometricBusy ? (
+                  <LoadingSpinner size="small" />
+                ) : (
+                  <Switch
+                    checked={biometricUnlock === true}
+                    disabled={biometricUnlock === null}
+                    onChange={() => { void handleToggleBiometricUnlock(); }}
+                  />
+                )}
+              </div>
+              {biometricError && (
+                <p className="text-spark-error text-xs mt-2 px-1">{biometricError}</p>
+              )}
+            </div>
+          )}
 
           {/* Passkey & Labels */}
           {isDevMode && (

--- a/src/pages/UnlockPage.tsx
+++ b/src/pages/UnlockPage.tsx
@@ -17,9 +17,9 @@
 
 import React, { useEffect, useState } from 'react';
 import { PrimaryButton, SecondaryButton } from '../components/ui';
-import { FingerprintIcon, PasskeyIcon } from '../components/Icons';
+import { FaceIdIcon, FingerprintIcon, PasskeyIcon } from '../components/Icons';
 import { AlertCard } from '../components/AlertCard';
-import { getBiometryLabel, secureStorage } from '../services/secureStorage';
+import { getBiometryInfo, BiometryInfo, secureStorage } from '../services/secureStorage';
 
 interface UnlockPageProps {
   isLoading: boolean;
@@ -37,13 +37,13 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
   // Web hosts use passkey terminology; native uses biometric.
   const isWebPasskey = !secureStorage.isSupported();
 
-  const [biometryLabel, setBiometryLabel] = useState<string | null>(null);
+  const [biometry, setBiometry] = useState<BiometryInfo | null>(null);
 
   useEffect(() => {
     if (isWebPasskey) return;
     let cancelled = false;
-    getBiometryLabel().then((label) => {
-      if (!cancelled) setBiometryLabel(label);
+    getBiometryInfo().then((info) => {
+      if (!cancelled) setBiometry(info);
     });
     return () => {
       cancelled = true;
@@ -52,11 +52,13 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
 
   const unlockLabel = isWebPasskey
     ? 'Unlock with passkey'
-    : biometryLabel ? `Unlock with ${biometryLabel}` : 'Unlock';
+    : biometry ? `Unlock with ${biometry.label}` : 'Unlock';
   const unlockDescription = isWebPasskey
     ? 'Your wallet is locked. Unlock with your passkey to continue.'
     : 'Your wallet is locked. Unlock with your biometric to continue.';
-  const UnlockIcon = isWebPasskey ? PasskeyIcon : FingerprintIcon;
+  const UnlockIcon = isWebPasskey
+    ? PasskeyIcon
+    : biometry?.kind === 'face' ? FaceIdIcon : FingerprintIcon;
 
   return (
     <div className="min-h-dvh h-dvh w-full flex flex-col bg-spark-surface relative">

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -34,6 +34,7 @@ interface WalletPageProps {
   onOpenGetRefund: (source?: 'menu' | 'icon') => void;
   onOpenSettings: () => void;
   onOpenBackup: () => void;
+  onOpenSecurity: () => void;
   onOpenBuyProviders: () => void;
   onBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
   network?: Network;
@@ -51,6 +52,7 @@ const WalletPage: React.FC<WalletPageProps> = ({
   onOpenGetRefund,
   onOpenSettings,
   onOpenBackup,
+  onOpenSecurity,
   onOpenBuyProviders,
   onBuyBitcoin,
   network,
@@ -364,6 +366,7 @@ const WalletPage: React.FC<WalletPageProps> = ({
         onLogout={onLogout}
         onOpenSettings={onOpenSettings}
         onOpenBackup={onOpenBackup}
+        onOpenSecurity={onOpenSecurity}
         onOpenRefund={() => onOpenGetRefund('menu')}
         hasRejectedDeposits={hasRejectedDeposits}
       />

--- a/src/services/appLock.test.ts
+++ b/src/services/appLock.test.ts
@@ -74,6 +74,18 @@ describe('appLock PIN', () => {
     expect(await appLock.isBiometricGateEnabled()).toBe(false);
     expect(await appLock.verifyPin('123456')).toBe(false);
   });
+
+  it('mirrors the biometric gate flag for synchronous reads', async () => {
+    const appLock = await loadAppLock(true);
+    expect(appLock.isBiometricGateEnabledSync()).toBe(false);
+    await appLock.setBiometricGateEnabled(true);
+    expect(appLock.isBiometricGateEnabledSync()).toBe(true);
+    await appLock.setBiometricGateEnabled(false);
+    expect(appLock.isBiometricGateEnabledSync()).toBe(false);
+    await appLock.setBiometricGateEnabled(true);
+    await appLock.clearPin();
+    expect(appLock.isBiometricGateEnabledSync()).toBe(false);
+  });
 });
 
 describe('appLock auto-lock timeout', () => {

--- a/src/services/appLock.test.ts
+++ b/src/services/appLock.test.ts
@@ -16,6 +16,7 @@ function makePreferencesMock() {
 
 async function loadAppLock(native: boolean) {
   vi.resetModules();
+  localStorage.clear();
   vi.doMock('@capacitor/core', () => ({
     Capacitor: {
       isNativePlatform: () => native,
@@ -54,6 +55,15 @@ describe('appLock PIN', () => {
     expect(await appLock.verifyPin('123456')).toBe(true);
   });
 
+  it('mirrors the enabled flag for synchronous lock gating', async () => {
+    const appLock = await loadAppLock(true);
+    expect(appLock.isPinEnabledSync()).toBe(false);
+    await appLock.setPin('123456');
+    expect(appLock.isPinEnabledSync()).toBe(true);
+    await appLock.clearPin();
+    expect(appLock.isPinEnabledSync()).toBe(false);
+  });
+
   it('clearPin disables the PIN and the biometric gate with it', async () => {
     const appLock = await loadAppLock(true);
     await appLock.setPin('123456');
@@ -67,11 +77,13 @@ describe('appLock PIN', () => {
 });
 
 describe('appLock auto-lock timeout', () => {
-  it('defaults to 120s and roundtrips a chosen value', async () => {
+  it('defaults to 120s and roundtrips a chosen value, mirror included', async () => {
     const appLock = await loadAppLock(true);
     expect(await appLock.getAutoLockSeconds()).toBe(120);
+    expect(appLock.getAutoLockSecondsSync()).toBe(120);
     await appLock.setAutoLockSeconds(600);
     expect(await appLock.getAutoLockSeconds()).toBe(600);
+    expect(appLock.getAutoLockSecondsSync()).toBe(600);
   });
 
   it('formats every dropdown option', async () => {

--- a/src/services/appLock.test.ts
+++ b/src/services/appLock.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// appLock guards on Capacitor.isNativePlatform() at import-call time, so
+// each case mocks the platform + an in-memory Preferences and re-imports.
+function makePreferencesMock() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    Preferences: {
+      get: async ({ key }: { key: string }) => ({ value: store.get(key) ?? null }),
+      set: async ({ key, value }: { key: string; value: string }) => { store.set(key, value); },
+      remove: async ({ key }: { key: string }) => { store.delete(key); },
+    },
+  };
+}
+
+async function loadAppLock(native: boolean) {
+  vi.resetModules();
+  vi.doMock('@capacitor/core', () => ({
+    Capacitor: {
+      isNativePlatform: () => native,
+      getPlatform: () => (native ? 'android' : 'web'),
+    },
+  }));
+  const prefs = makePreferencesMock();
+  vi.doMock('@capacitor/preferences', () => ({ Preferences: prefs.Preferences }));
+  const mod = await import('./appLock');
+  return { ...mod, store: prefs.store };
+}
+
+afterEach(() => {
+  vi.doUnmock('@capacitor/core');
+  vi.doUnmock('@capacitor/preferences');
+});
+
+describe('appLock PIN', () => {
+  it('set/verify roundtrip, wrong PIN rejected', async () => {
+    const appLock = await loadAppLock(true);
+    expect(await appLock.isPinEnabled()).toBe(false);
+    await appLock.setPin('123456');
+    expect(await appLock.isPinEnabled()).toBe(true);
+    expect(await appLock.verifyPin('123456')).toBe(true);
+    expect(await appLock.verifyPin('654321')).toBe(false);
+  });
+
+  it('stores a salted hash, never the PIN, with a fresh salt per set', async () => {
+    const appLock = await loadAppLock(true);
+    await appLock.setPin('123456');
+    const firstValues = [...appLock.store.values()];
+    expect(firstValues).not.toContain('123456');
+    await appLock.setPin('123456');
+    // Same PIN, rotated salt => different stored hash.
+    expect([...appLock.store.values()].sort()).not.toEqual(firstValues.sort());
+    expect(await appLock.verifyPin('123456')).toBe(true);
+  });
+
+  it('clearPin disables the PIN and the biometric gate with it', async () => {
+    const appLock = await loadAppLock(true);
+    await appLock.setPin('123456');
+    await appLock.setBiometricGateEnabled(true);
+    expect(await appLock.isBiometricGateEnabled()).toBe(true);
+    await appLock.clearPin();
+    expect(await appLock.isPinEnabled()).toBe(false);
+    expect(await appLock.isBiometricGateEnabled()).toBe(false);
+    expect(await appLock.verifyPin('123456')).toBe(false);
+  });
+});
+
+describe('appLock auto-lock timeout', () => {
+  it('defaults to 120s and roundtrips a chosen value', async () => {
+    const appLock = await loadAppLock(true);
+    expect(await appLock.getAutoLockSeconds()).toBe(120);
+    await appLock.setAutoLockSeconds(600);
+    expect(await appLock.getAutoLockSeconds()).toBe(600);
+  });
+
+  it('formats every dropdown option', async () => {
+    const appLock = await loadAppLock(true);
+    const labels = appLock.AUTO_LOCK_OPTIONS_SECONDS.map(appLock.formatAutoLockOption);
+    expect(labels).toEqual([
+      'Immediately', '30 seconds', '2 minutes', '5 minutes',
+      '10 minutes', '30 minutes', '1 hour',
+    ]);
+  });
+});
+
+describe('appLock on web', () => {
+  it('reports unsupported and disabled everywhere', async () => {
+    const appLock = await loadAppLock(false);
+    expect(appLock.isAppLockSupported()).toBe(false);
+    expect(await appLock.isPinEnabled()).toBe(false);
+    expect(await appLock.isBiometricGateEnabled()).toBe(false);
+  });
+});

--- a/src/services/appLock.ts
+++ b/src/services/appLock.ts
@@ -1,0 +1,146 @@
+/**
+ * App-level lock (native only), the Misty Breez model: an opt-in 6-digit
+ * PIN gates the UI, with biometrics as the preferred gate on top
+ * (PIN stays the fallback). Deliberately app-level, not crypto binding:
+ * the seed lives in the vault's device-only tier because a
+ * biometric-bound seed could never be released by a PIN entry. Only a
+ * salted PBKDF2 hash of the PIN is persisted; web is always unlocked.
+ */
+
+import { Capacitor } from '@capacitor/core';
+import { Preferences } from '@capacitor/preferences';
+import { logger, LogCategory } from './logger';
+
+const PIN_HASH_KEY = 'glow.appLock.pinHash';
+const PIN_SALT_KEY = 'glow.appLock.pinSalt';
+const AUTO_LOCK_KEY = 'glow.appLock.autoLockSeconds';
+const BIOMETRIC_KEY = 'glow.appLock.biometricEnabled';
+
+export const PIN_LENGTH = 6;
+
+/** Misty parity: {0 = immediately, 30s, 2m (default), 5m, 10m, 30m, 1h}. */
+export const AUTO_LOCK_OPTIONS_SECONDS = [0, 30, 120, 300, 600, 1800, 3600];
+export const DEFAULT_AUTO_LOCK_SECONDS = 120;
+
+const PBKDF2_ITERATIONS = 100_000;
+
+export function isAppLockSupported(): boolean {
+  return Capacitor.isNativePlatform();
+}
+
+// ============================================
+// PIN hashing
+// ============================================
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+async function derivePinHash(pin: string, salt: Uint8Array): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(pin),
+    'PBKDF2',
+    false,
+    ['deriveBits'],
+  );
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      salt: salt as BufferSource,
+      iterations: PBKDF2_ITERATIONS,
+    },
+    key,
+    256,
+  );
+  return toHex(new Uint8Array(bits));
+}
+
+// ============================================
+// PIN management
+// ============================================
+
+export async function isPinEnabled(): Promise<boolean> {
+  if (!isAppLockSupported()) return false;
+  const { value } = await Preferences.get({ key: PIN_HASH_KEY });
+  return value != null;
+}
+
+/** Create or replace the PIN. Caller is responsible for the verify step. */
+export async function setPin(pin: string): Promise<void> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const hash = await derivePinHash(pin, salt);
+  await Preferences.set({ key: PIN_SALT_KEY, value: toHex(salt) });
+  await Preferences.set({ key: PIN_HASH_KEY, value: hash });
+  logger.info(LogCategory.AUTH, 'appLock: PIN set');
+}
+
+export async function verifyPin(pin: string): Promise<boolean> {
+  const [{ value: hash }, { value: saltHex }] = await Promise.all([
+    Preferences.get({ key: PIN_HASH_KEY }),
+    Preferences.get({ key: PIN_SALT_KEY }),
+  ]);
+  if (hash == null || saltHex == null) return false;
+  return (await derivePinHash(pin, fromHex(saltHex))) === hash;
+}
+
+/** Deactivate PIN protection. Also disables the biometric gate: it is
+ *  only offered on top of a PIN, matching Misty. */
+export async function clearPin(): Promise<void> {
+  await Preferences.remove({ key: PIN_HASH_KEY });
+  await Preferences.remove({ key: PIN_SALT_KEY });
+  await Preferences.remove({ key: BIOMETRIC_KEY });
+  logger.info(LogCategory.AUTH, 'appLock: PIN cleared');
+}
+
+// ============================================
+// Auto-lock timeout
+// ============================================
+
+export async function getAutoLockSeconds(): Promise<number> {
+  const { value } = await Preferences.get({ key: AUTO_LOCK_KEY });
+  const parsed = value == null ? NaN : parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_AUTO_LOCK_SECONDS;
+}
+
+export async function setAutoLockSeconds(seconds: number): Promise<void> {
+  await Preferences.set({ key: AUTO_LOCK_KEY, value: String(seconds) });
+}
+
+/** Human label for a timeout option ("Immediately", "30 seconds", "2 minutes"…). */
+export function formatAutoLockOption(seconds: number): string {
+  if (seconds === 0) return 'Immediately';
+  if (seconds < 60) return `${seconds} seconds`;
+  const minutes = seconds / 60;
+  if (minutes < 60) return minutes === 1 ? '1 minute' : `${minutes} minutes`;
+  const hours = minutes / 60;
+  return hours === 1 ? '1 hour' : `${hours} hours`;
+}
+
+// ============================================
+// Biometric gate flag
+// ============================================
+
+export async function isBiometricGateEnabled(): Promise<boolean> {
+  if (!isAppLockSupported()) return false;
+  const { value } = await Preferences.get({ key: BIOMETRIC_KEY });
+  return value === 'true';
+}
+
+export async function setBiometricGateEnabled(enabled: boolean): Promise<void> {
+  if (enabled) {
+    await Preferences.set({ key: BIOMETRIC_KEY, value: 'true' });
+  } else {
+    await Preferences.remove({ key: BIOMETRIC_KEY });
+  }
+  logger.info(LogCategory.AUTH, `appLock: biometric gate ${enabled ? 'enabled' : 'disabled'}`);
+}

--- a/src/services/appLock.ts
+++ b/src/services/appLock.ts
@@ -5,16 +5,28 @@
  * the seed lives in the vault's device-only tier because a
  * biometric-bound seed could never be released by a PIN entry. Only a
  * salted PBKDF2 hash of the PIN is persisted; web is always unlocked.
+ *
+ * Storage: Preferences is the durable truth (survives WebView storage
+ * eviction); localStorage mirrors the non-secret lock settings so the
+ * lock decision can be made synchronously at first render and on
+ * foreground-return, with no unlocked frame while a bridge read is in
+ * flight. A lost mirror degrades to the async lock path, never to a
+ * wrongly-accepted PIN.
  */
 
 import { Capacitor } from '@capacitor/core';
 import { Preferences } from '@capacitor/preferences';
 import { logger, LogCategory } from './logger';
 
-const PIN_HASH_KEY = 'glow.appLock.pinHash';
-const PIN_SALT_KEY = 'glow.appLock.pinSalt';
+/** Salt + hash in ONE record: a two-key layout could be torn by a
+ *  process kill between writes, leaving a PIN no input could match. */
+const PIN_RECORD_KEY = 'glow.appLock.pin';
 const AUTO_LOCK_KEY = 'glow.appLock.autoLockSeconds';
 const BIOMETRIC_KEY = 'glow.appLock.biometricEnabled';
+/** localStorage mirrors for synchronous reads (booleans/numbers only,
+ *  never the PIN record). */
+const PIN_MIRROR_KEY = 'glow.appLock.pinEnabledMirror';
+const AUTO_LOCK_MIRROR_KEY = 'glow.appLock.autoLockSecondsMirror';
 
 export const PIN_LENGTH = 6;
 
@@ -26,6 +38,21 @@ const PBKDF2_ITERATIONS = 100_000;
 
 export function isAppLockSupported(): boolean {
   return Capacitor.isNativePlatform();
+}
+
+function mirrorSet(key: string, value: string | null): void {
+  try {
+    if (value == null) localStorage.removeItem(key);
+    else localStorage.setItem(key, value);
+  } catch { /* mirror only; Preferences stays authoritative */ }
+}
+
+function mirrorGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
 }
 
 // ============================================
@@ -69,36 +96,55 @@ async function derivePinHash(pin: string, salt: Uint8Array): Promise<string> {
 // PIN management
 // ============================================
 
+interface PinRecord {
+  v: 1;
+  salt: string;
+  hash: string;
+}
+
+async function readPinRecord(): Promise<PinRecord | null> {
+  const { value } = await Preferences.get({ key: PIN_RECORD_KEY });
+  if (value == null) return null;
+  try {
+    const parsed = JSON.parse(value) as PinRecord;
+    return parsed.salt && parsed.hash ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function isPinEnabled(): Promise<boolean> {
   if (!isAppLockSupported()) return false;
-  const { value } = await Preferences.get({ key: PIN_HASH_KEY });
-  return value != null;
+  return (await readPinRecord()) != null;
+}
+
+/** Mirror-backed synchronous check for first-render lock gating. A lost
+ *  mirror only delays the lock until the async read lands. */
+export function isPinEnabledSync(): boolean {
+  return isAppLockSupported() && mirrorGet(PIN_MIRROR_KEY) === 'true';
 }
 
 /** Create or replace the PIN. Caller is responsible for the verify step. */
 export async function setPin(pin: string): Promise<void> {
   const salt = crypto.getRandomValues(new Uint8Array(16));
-  const hash = await derivePinHash(pin, salt);
-  await Preferences.set({ key: PIN_SALT_KEY, value: toHex(salt) });
-  await Preferences.set({ key: PIN_HASH_KEY, value: hash });
+  const record: PinRecord = { v: 1, salt: toHex(salt), hash: await derivePinHash(pin, salt) };
+  await Preferences.set({ key: PIN_RECORD_KEY, value: JSON.stringify(record) });
+  mirrorSet(PIN_MIRROR_KEY, 'true');
   logger.info(LogCategory.AUTH, 'appLock: PIN set');
 }
 
 export async function verifyPin(pin: string): Promise<boolean> {
-  const [{ value: hash }, { value: saltHex }] = await Promise.all([
-    Preferences.get({ key: PIN_HASH_KEY }),
-    Preferences.get({ key: PIN_SALT_KEY }),
-  ]);
-  if (hash == null || saltHex == null) return false;
-  return (await derivePinHash(pin, fromHex(saltHex))) === hash;
+  const record = await readPinRecord();
+  if (record == null) return false;
+  return (await derivePinHash(pin, fromHex(record.salt))) === record.hash;
 }
 
 /** Deactivate PIN protection. Also disables the biometric gate: it is
  *  only offered on top of a PIN, matching Misty. */
 export async function clearPin(): Promise<void> {
-  await Preferences.remove({ key: PIN_HASH_KEY });
-  await Preferences.remove({ key: PIN_SALT_KEY });
+  await Preferences.remove({ key: PIN_RECORD_KEY });
   await Preferences.remove({ key: BIOMETRIC_KEY });
+  mirrorSet(PIN_MIRROR_KEY, null);
   logger.info(LogCategory.AUTH, 'appLock: PIN cleared');
 }
 
@@ -112,8 +158,15 @@ export async function getAutoLockSeconds(): Promise<number> {
   return Number.isFinite(parsed) ? parsed : DEFAULT_AUTO_LOCK_SECONDS;
 }
 
+/** Mirror-backed synchronous read for the foreground-return decision. */
+export function getAutoLockSecondsSync(): number {
+  const parsed = parseInt(mirrorGet(AUTO_LOCK_MIRROR_KEY) ?? '', 10);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_AUTO_LOCK_SECONDS;
+}
+
 export async function setAutoLockSeconds(seconds: number): Promise<void> {
   await Preferences.set({ key: AUTO_LOCK_KEY, value: String(seconds) });
+  mirrorSet(AUTO_LOCK_MIRROR_KEY, String(seconds));
 }
 
 /** Human label for a timeout option ("Immediately", "30 seconds", "2 minutes"…). */

--- a/src/services/appLock.ts
+++ b/src/services/appLock.ts
@@ -16,6 +16,7 @@
 
 import { Capacitor } from '@capacitor/core';
 import { Preferences } from '@capacitor/preferences';
+import { bytesToHex, hexToBytes } from '../utils/hex';
 import { logger, LogCategory } from './logger';
 
 /** Salt + hash in ONE record: a two-key layout could be torn by a
@@ -27,6 +28,7 @@ const BIOMETRIC_KEY = 'glow.appLock.biometricEnabled';
  *  never the PIN record). */
 const PIN_MIRROR_KEY = 'glow.appLock.pinEnabledMirror';
 const AUTO_LOCK_MIRROR_KEY = 'glow.appLock.autoLockSecondsMirror';
+const BIOMETRIC_MIRROR_KEY = 'glow.appLock.biometricEnabledMirror';
 
 export const PIN_LENGTH = 6;
 
@@ -59,18 +61,6 @@ function mirrorGet(key: string): string | null {
 // PIN hashing
 // ============================================
 
-function toHex(bytes: Uint8Array): string {
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
-}
-
-function fromHex(hex: string): Uint8Array {
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
-}
-
 async function derivePinHash(pin: string, salt: Uint8Array): Promise<string> {
   const key = await crypto.subtle.importKey(
     'raw',
@@ -89,7 +79,7 @@ async function derivePinHash(pin: string, salt: Uint8Array): Promise<string> {
     key,
     256,
   );
-  return toHex(new Uint8Array(bits));
+  return bytesToHex(new Uint8Array(bits));
 }
 
 // ============================================
@@ -127,7 +117,7 @@ export function isPinEnabledSync(): boolean {
 /** Create or replace the PIN. Caller is responsible for the verify step. */
 export async function setPin(pin: string): Promise<void> {
   const salt = crypto.getRandomValues(new Uint8Array(16));
-  const record: PinRecord = { v: 1, salt: toHex(salt), hash: await derivePinHash(pin, salt) };
+  const record: PinRecord = { v: 1, salt: bytesToHex(salt), hash: await derivePinHash(pin, salt) };
   await Preferences.set({ key: PIN_RECORD_KEY, value: JSON.stringify(record) });
   mirrorSet(PIN_MIRROR_KEY, 'true');
   logger.info(LogCategory.AUTH, 'appLock: PIN set');
@@ -136,7 +126,7 @@ export async function setPin(pin: string): Promise<void> {
 export async function verifyPin(pin: string): Promise<boolean> {
   const record = await readPinRecord();
   if (record == null) return false;
-  return (await derivePinHash(pin, fromHex(record.salt))) === record.hash;
+  return (await derivePinHash(pin, hexToBytes(record.salt))) === record.hash;
 }
 
 /** Deactivate PIN protection. Also disables the biometric gate: it is
@@ -145,6 +135,7 @@ export async function clearPin(): Promise<void> {
   await Preferences.remove({ key: PIN_RECORD_KEY });
   await Preferences.remove({ key: BIOMETRIC_KEY });
   mirrorSet(PIN_MIRROR_KEY, null);
+  mirrorSet(BIOMETRIC_MIRROR_KEY, null);
   logger.info(LogCategory.AUTH, 'appLock: PIN cleared');
 }
 
@@ -186,7 +177,19 @@ export function formatAutoLockOption(seconds: number): string {
 export async function isBiometricGateEnabled(): Promise<boolean> {
   if (!isAppLockSupported()) return false;
   const { value } = await Preferences.get({ key: BIOMETRIC_KEY });
-  return value === 'true';
+  const enabled = value === 'true';
+  // Backfill the mirror for installs that enabled the gate before the
+  // mirror existed (and self-heal an evicted one).
+  mirrorSet(BIOMETRIC_MIRROR_KEY, enabled ? 'true' : null);
+  return enabled;
+}
+
+/** Mirror-backed synchronous read so lock UIs can decide "pad or
+ *  biometric first" at first render, with no pad flash while the
+ *  Preferences read is in flight. A lost mirror degrades to showing
+ *  the pad; the async read reconciles. */
+export function isBiometricGateEnabledSync(): boolean {
+  return isAppLockSupported() && mirrorGet(BIOMETRIC_MIRROR_KEY) === 'true';
 }
 
 export async function setBiometricGateEnabled(enabled: boolean): Promise<void> {
@@ -195,5 +198,6 @@ export async function setBiometricGateEnabled(enabled: boolean): Promise<void> {
   } else {
     await Preferences.remove({ key: BIOMETRIC_KEY });
   }
+  mirrorSet(BIOMETRIC_MIRROR_KEY, enabled ? 'true' : null);
   logger.info(LogCategory.AUTH, `appLock: biometric gate ${enabled ? 'enabled' : 'disabled'}`);
 }

--- a/src/services/secureStorage.ts
+++ b/src/services/secureStorage.ts
@@ -830,8 +830,9 @@ function createDeviceOnlyStorage(): SecureStorage {
 /**
  * Module-level singletons.
  *
- * `secureStorage` — biometric-bound tier (passkey users).
- * `deviceOnlyStorage` — encrypted at rest, no biometric gate (non-passkey users).
+ * `secureStorage` — biometric-bound tier (users who enabled biometric
+ * unlock in Security settings).
+ * `deviceOnlyStorage` — encrypted at rest, no biometric gate (the default).
  *
  * Both resolve to `NoopSecureStorage` on non-native hosts.
  *
@@ -840,3 +841,53 @@ function createDeviceOnlyStorage(): SecureStorage {
  */
 export const secureStorage: SecureStorage = createSecureStorage();
 export const deviceOnlyStorage: SecureStorage = createDeviceOnlyStorage();
+
+// ============================================
+// Biometric unlock setting (native only)
+// ============================================
+
+/**
+ * Biometric unlock is an opt-in user setting. The setting has no flag of
+ * its own: which tier holds the seed IS the setting. Seed in the
+ * biometric-bound tier => enabled (launch shows the OS biometric prompt);
+ * seed in the device-only tier => disabled (silent launch, the default).
+ *
+ * Toggling moves the seed between tiers. The new tier is written before
+ * the old one is cleared so a crash mid-move can only leave the seed in
+ * both tiers, never in neither; startup checks the biometric tier first,
+ * so "both" resolves to enabled.
+ */
+export async function isBiometricUnlockEnabled(): Promise<boolean> {
+  if (!secureStorage.isSupported()) return false;
+  return secureStorage.hasStoredSeed();
+}
+
+/**
+ * Move the seed device-only -> biometric-bound. On Android the Keystore
+ * encrypt itself shows the biometric prompt; on iOS the Keychain write is
+ * silent, so the `checkBiometry` gate is the only guard against enabling
+ * with no enrolled biometrics (which would make the item unreadable).
+ */
+export async function enableBiometricUnlock(): Promise<void> {
+  const biometry = await getNativeVault().checkBiometry();
+  if (!biometry.available) {
+    throw new SecureStorageError(
+      'BIOMETRIC_UNAVAILABLE',
+      'Biometric authentication is not available on this device.',
+    );
+  }
+  const seed = await deviceOnlyStorage.retrieveSeed();
+  await secureStorage.storeSeed(seed);
+  await deviceOnlyStorage.clearSeed();
+}
+
+/**
+ * Move the seed biometric-bound -> device-only. The `retrieveSeed` read
+ * triggers the OS biometric prompt, which doubles as the user confirming
+ * the downgrade.
+ */
+export async function disableBiometricUnlock(): Promise<void> {
+  const seed = await secureStorage.retrieveSeed();
+  await deviceOnlyStorage.storeSeed(seed);
+  await secureStorage.clearSeed();
+}

--- a/src/services/secureStorage.ts
+++ b/src/services/secureStorage.ts
@@ -831,9 +831,9 @@ function createDeviceOnlyStorage(): SecureStorage {
 /**
  * Module-level singletons.
  *
- * `secureStorage` — biometric-bound tier (users who enabled biometric
- * unlock in Security settings).
- * `deviceOnlyStorage` — encrypted at rest, no biometric gate (the default).
+ * `secureStorage`: biometric-bound tier (legacy installs only; migrated
+ * to device-only at first unlock).
+ * `deviceOnlyStorage`: encrypted at rest, no biometric gate (the default).
  *
  * Both resolve to `NoopSecureStorage` on non-native hosts.
  *
@@ -850,11 +850,9 @@ export const deviceOnlyStorage: SecureStorage = createDeviceOnlyStorage();
 /**
  * App-level biometric prompt, no vault involved. Backs the app-lock
  * layer (`services/appLock.ts`): lock screen and Security page gating.
- * The seed itself stays in the device-only tier so a PIN fallback can
- * still start the app — biometrics here gate the UI, not the crypto.
- *
- * Resolves on success; throws `SecureStorageError` (USER_CANCELLED /
- * BIOMETRIC_LOCKOUT / BIOMETRIC_UNAVAILABLE / ...) on failure.
+ * Gates the UI, not the crypto: the seed stays in the device-only tier
+ * so a PIN fallback can still start the app. Resolves on success;
+ * throws `SecureStorageError` (USER_CANCELLED, BIOMETRIC_LOCKOUT, ...).
  */
 export async function authenticateBiometric(reason: string): Promise<void> {
   try {

--- a/src/services/secureStorage.ts
+++ b/src/services/secureStorage.ts
@@ -48,6 +48,7 @@ import { logger, LogCategory } from './logger';
  */
 interface NativeVaultPlugin {
   checkBiometry(): Promise<{ available: boolean; biometryType: string }>;
+  authenticate(options?: { reason?: string }): Promise<void>;
   hasStoredSeed(): Promise<{ stored: boolean }>;
   storeSeed(options: { seed: string }): Promise<void>;
   retrieveSeed(): Promise<{ seed: string }>;
@@ -843,51 +844,27 @@ export const secureStorage: SecureStorage = createSecureStorage();
 export const deviceOnlyStorage: SecureStorage = createDeviceOnlyStorage();
 
 // ============================================
-// Biometric unlock setting (native only)
+// Standalone biometric gate (native only)
 // ============================================
 
 /**
- * Biometric unlock is an opt-in user setting. The setting has no flag of
- * its own: which tier holds the seed IS the setting. Seed in the
- * biometric-bound tier => enabled (launch shows the OS biometric prompt);
- * seed in the device-only tier => disabled (silent launch, the default).
+ * App-level biometric prompt, no vault involved. Backs the app-lock
+ * layer (`services/appLock.ts`): lock screen and Security page gating.
+ * The seed itself stays in the device-only tier so a PIN fallback can
+ * still start the app — biometrics here gate the UI, not the crypto.
  *
- * Toggling moves the seed between tiers. The new tier is written before
- * the old one is cleared so a crash mid-move can only leave the seed in
- * both tiers, never in neither; startup checks the biometric tier first,
- * so "both" resolves to enabled.
+ * Resolves on success; throws `SecureStorageError` (USER_CANCELLED /
+ * BIOMETRIC_LOCKOUT / BIOMETRIC_UNAVAILABLE / ...) on failure.
  */
-export async function isBiometricUnlockEnabled(): Promise<boolean> {
-  if (!secureStorage.isSupported()) return false;
-  return secureStorage.hasStoredSeed();
-}
-
-/**
- * Move the seed device-only -> biometric-bound. On Android the Keystore
- * encrypt itself shows the biometric prompt; on iOS the Keychain write is
- * silent, so the `checkBiometry` gate is the only guard against enabling
- * with no enrolled biometrics (which would make the item unreadable).
- */
-export async function enableBiometricUnlock(): Promise<void> {
-  const biometry = await getNativeVault().checkBiometry();
-  if (!biometry.available) {
+export async function authenticateBiometric(reason: string): Promise<void> {
+  try {
+    await getNativeVault().authenticate({ reason });
+  } catch (err) {
+    const code = mapNativeVaultErrorCode(err);
+    logSecureStorageFailure('authenticate', code);
     throw new SecureStorageError(
-      'BIOMETRIC_UNAVAILABLE',
-      'Biometric authentication is not available on this device.',
+      code,
+      err instanceof Error ? err.message : 'Biometric authentication failed',
     );
   }
-  const seed = await deviceOnlyStorage.retrieveSeed();
-  await secureStorage.storeSeed(seed);
-  await deviceOnlyStorage.clearSeed();
-}
-
-/**
- * Move the seed biometric-bound -> device-only. The `retrieveSeed` read
- * triggers the OS biometric prompt, which doubles as the user confirming
- * the downgrade.
- */
-export async function disableBiometricUnlock(): Promise<void> {
-  const seed = await secureStorage.retrieveSeed();
-  await deviceOnlyStorage.storeSeed(seed);
-  await secureStorage.clearSeed();
 }

--- a/src/services/secureStorage.ts
+++ b/src/services/secureStorage.ts
@@ -47,8 +47,17 @@ import { logger, LogCategory } from './logger';
  * `capacitor-passkey-prf`.
  */
 interface NativeVaultPlugin {
-  checkBiometry(): Promise<{ available: boolean; biometryType: string }>;
+  checkBiometry(): Promise<{
+    available: boolean;
+    biometryType: string;
+    /** Raw platform reason when `available` is false (diagnostic). */
+    unavailabilityReason?: string;
+    /** Mapped SecureStorageErrorCode when `available` is false. */
+    unavailabilityCode?: string;
+  }>;
   authenticate(options?: { reason?: string }): Promise<void>;
+  /** Biometrics-or-passcode prompt (iOS); clears biometry lockout. */
+  authenticateDeviceOwner(options?: { reason?: string }): Promise<void>;
   hasStoredSeed(): Promise<{ stored: boolean }>;
   storeSeed(options: { seed: string }): Promise<void>;
   retrieveSeed(): Promise<{ seed: string }>;
@@ -779,40 +788,97 @@ class NoopSecureStorage implements SecureStorage {
 }
 
 // ============================================
-// Biometry label helper (rewritten to use NativeVault)
+// Biometry info helper (rewritten to use NativeVault)
 // ============================================
 
+/** Icon family for the device's biometry; `iris` maps to `face` (a
+ *  dedicated glyph isn't worth it for Samsung's retired iris sensor). */
+export type BiometryKind = 'face' | 'fingerprint';
+
+export interface BiometryInfo {
+  /** User-facing name, e.g. "Face ID", "Touch ID", "fingerprint". */
+  label: string;
+  kind: BiometryKind;
+}
+
+export interface BiometryStatus {
+  /** Label + icon kind, null when biometry can't currently run. */
+  info: BiometryInfo | null;
+  /** iOS: biometry is disabled until the device passcode is entered
+   *  (too many failed matches). Recoverable in-app via
+   *  `recoverBiometryWithPasscode`. */
+  lockedOut: boolean;
+}
+
 /**
- * Returns a user-facing label for the device's current biometry type, e.g.
- * `"Face ID"`, `"Touch ID"`, `"fingerprint"`. Returns `null` on web or if
- * no biometry is enrolled / available. Used by the Unlock page to set the
- * retry-button label.
+ * Full biometry capability status: label + icon kind when available,
+ * plus a structured lockout flag so UIs can offer recovery instead of
+ * silently hiding their biometric controls.
  *
  * Calls `NativeVault.checkBiometry()` directly — no more TLA workaround
  * is needed because the in-house plugin does not transitively import
  * `@capacitor/app`, so vite-plugin-top-level-await never wraps anything.
  */
-export async function getBiometryLabel(): Promise<string | null> {
-  if (!Capacitor.isNativePlatform()) return null;
+export async function getBiometryStatus(): Promise<BiometryStatus> {
+  if (!Capacitor.isNativePlatform()) return { info: null, lockedOut: false };
   try {
     const result = await getNativeVault().checkBiometry();
-    if (!result.available) return null;
+    if (!result.available) {
+      // Lands in the Share Logs ring buffer: the only way to tell
+      // lockout / permission-denied / not-enrolled apart when the
+      // biometric UI silently disappears.
+      logger.warn(LogCategory.AUTH, 'checkBiometry: unavailable', {
+        biometryType: result.biometryType,
+        reason: result.unavailabilityReason ?? 'unspecified',
+      });
+      return { info: null, lockedOut: result.unavailabilityCode === 'BIOMETRIC_LOCKOUT' };
+    }
     switch (result.biometryType) {
       case 'faceId':
-        return 'Face ID';
+        return { info: { label: 'Face ID', kind: 'face' }, lockedOut: false };
       case 'touchId':
-        return 'Touch ID';
+        return { info: { label: 'Touch ID', kind: 'fingerprint' }, lockedOut: false };
       case 'fingerprint':
-        return 'fingerprint';
+        return { info: { label: 'fingerprint', kind: 'fingerprint' }, lockedOut: false };
       case 'face':
-        return 'face';
+        return { info: { label: 'face', kind: 'face' }, lockedOut: false };
       case 'iris':
-        return 'iris scan';
+        return { info: { label: 'iris scan', kind: 'face' }, lockedOut: false };
       default:
-        return null;
+        logger.warn(LogCategory.AUTH, 'checkBiometry: unrecognized biometryType', {
+          biometryType: result.biometryType,
+        });
+        return { info: null, lockedOut: false };
     }
-  } catch {
-    return null;
+  } catch (e) {
+    logger.warn(LogCategory.AUTH, 'checkBiometry: call failed', {
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return { info: null, lockedOut: false };
+  }
+}
+
+/** `getBiometryStatus().info` for callers that only need label + icon. */
+export async function getBiometryInfo(): Promise<BiometryInfo | null> {
+  return (await getBiometryStatus()).info;
+}
+
+/**
+ * Biometrics-or-passcode prompt (iOS `deviceOwnerAuthentication`).
+ * Succeeding via passcode clears a biometry lockout system-wide, so
+ * this is the in-app recovery for BIOMETRIC_LOCKOUT. Resolves on
+ * success; throws `SecureStorageError` (USER_CANCELLED, ...).
+ */
+export async function recoverBiometryWithPasscode(reason: string): Promise<void> {
+  try {
+    await getNativeVault().authenticateDeviceOwner({ reason });
+  } catch (err) {
+    const code = mapNativeVaultErrorCode(err);
+    logSecureStorageFailure('authenticateDeviceOwner', code);
+    throw new SecureStorageError(
+      code,
+      err instanceof Error ? err.message : 'Device authentication failed',
+    );
   }
 }
 
@@ -864,5 +930,19 @@ export async function authenticateBiometric(reason: string): Promise<void> {
       code,
       err instanceof Error ? err.message : 'Biometric authentication failed',
     );
+  }
+}
+
+/**
+ * `authenticateBiometric` for gates with a PIN fallback: cancel /
+ * unavailable resolves `false` instead of throwing, since the pad
+ * stays on screen either way.
+ */
+export async function tryAuthenticateBiometric(reason: string): Promise<boolean> {
+  try {
+    await authenticateBiometric(reason);
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,0 +1,13 @@
+/** Lowercase hex encoding of a byte array. */
+export function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Inverse of bytesToHex. Assumes well-formed even-length hex. */
+export function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}


### PR DESCRIPTION
## What this does

Biometric unlock is no longer forced on every wallet. The seed now lives in encrypted device storage that opens silently at launch, and protection becomes an opt-in choice, modeled on Misty Breez: a 6-digit PIN as the base layer, with Face ID / fingerprint as a faster way through once enabled.

- New Security page (native only): create, change, or deactivate a PIN, pick an auto-lock timeout, and enable biometric unlock on top. The page itself sits behind the same lock.
- A full-screen lock appears on cold start and when returning from background past the chosen timeout. With biometrics enabled, the prompt fires immediately over a splash-identical frame, so the happy path is one glance, and the PIN pad only appears if the prompt is cancelled.
- Revealing the recovery phrase now requires passing the same lock whenever a PIN is set. Without a PIN, nothing changes, protection stays off by default.
- All PIN screens share one look and position, with careful feedback on wrong entries (no layout shifts, a shake, a short input hold) and payment popups held back while locked.
- If the OS locks biometrics out after too many failed matches, the Security page now says so and offers to re-enable them with the device passcode, instead of the option silently disappearing.

Everything is native-only; the web app's behavior is unchanged.

## Test plan

On an iPhone and an Android device:

1. Create a PIN in Security, kill and reopen the app: the lock screen should require the PIN.
2. Enable biometric unlock, relaunch: the OS prompt should appear over the plain logo; cancelling reveals the PIN pad.
3. Open Backup with a PIN set: revealing the phrase must go through the biometric prompt or PIN; hiding and re-revealing gates again.
4. Enter a wrong PIN: dots shake, message shows, nothing moves or flickers.
5. Fail biometrics repeatedly (iOS) until locked out: Security should show the recovery row, and passing the passcode prompt should restore the toggle.
6. Background and return within the auto-lock window: no lock. Past it: locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)