### PR TITLE
Unify Backup and Security into one gated Security & Backup page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,10 @@ const AppContent: React.FC = () => {
   // 'unlocking', auto-'wallet' on reconnect) are layered in by
   // `currentScreen` below.
   const [userScreen, setUserScreen] = useState<Screen>('home');
+  // Where the open BackupPage was launched from: the side menu (web) or
+  // the Security & Backup page (native). Drives its back target and
+  // whether SecurityPage stays mounted beneath it.
+  const [backupSource, setBackupSource] = useState<'menu' | 'security'>('menu');
   const [refundAnimationDirection, setRefundAnimationDirection] = useState<'left' | 'up'>('left');
   const [buyProvidersSource, setBuyProvidersSource] = useState<'wallet' | 'settings'>('wallet');
   const [passkeySdkConnected, setPasskeySdkConnected] = useState(false);
@@ -325,7 +329,7 @@ const AppContent: React.FC = () => {
             setUserScreen('getRefund');
           }}
           onOpenSettings={() => setUserScreen('settings')}
-          onOpenBackup={() => setUserScreen('backup')}
+          onOpenBackup={() => { setBackupSource('menu'); setUserScreen('backup'); }}
           onOpenSecurity={() => setUserScreen('security')}
           onOpenBuyProviders={() => { setBuyProvidersSource('wallet'); setUserScreen('buyProviders'); }}
           onBuyBitcoin={sdk.handleBuyBitcoin}
@@ -527,21 +531,35 @@ const AppContent: React.FC = () => {
           </>
         );
 
+      // Security & Backup share one branch so SecurityPage stays
+      // mounted (gate passed, options state intact) underneath an
+      // opened BackupPage — returning from Backup must not re-run the
+      // PIN/biometric gate. On web, Backup opens directly from the
+      // menu and SecurityPage never mounts.
       case 'backup':
+      case 'security': {
+        const backupFromSecurity = backupSource === 'security';
         return (
           <>
             {renderWalletPage()}
-            <BackupPage onBack={() => setUserScreen('wallet')} />
+            {(currentScreen === 'security' || backupFromSecurity) && (
+              <SecurityPage
+                onBack={() => setUserScreen('wallet')}
+                onOpenBackup={() => {
+                  setBackupSource('security');
+                  setUserScreen('backup');
+                }}
+              />
+            )}
+            {currentScreen === 'backup' && (
+              <BackupPage
+                closeStyle={backupFromSecurity ? 'back' : 'close'}
+                onBack={() => setUserScreen(backupFromSecurity ? 'security' : 'wallet')}
+              />
+            )}
           </>
         );
-
-      case 'security':
-        return (
-          <>
-            {renderWalletPage()}
-            <SecurityPage onBack={() => setUserScreen('wallet')} />
-          </>
-        );
+      }
 
       case 'restore':
         return (

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -125,18 +125,18 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
       onClick: () => closeDrawerThen(onOpenRefund),
       highlight: true
     }] : []),
-    {
+    // Native folds Backup into a single Security & Backup page (Misty
+    // parity), so the recovery phrase sits behind the same app-lock
+    // gate. The PWA has no app lock and keeps a top-level Backup.
+    ...(isAppLockSupported() ? [{
+      icon: <LockIcon />,
+      label: 'Security & Backup',
+      onClick: () => closeDrawerThen(onOpenSecurity)
+    }] : [{
       icon: <BackupIcon />,
       label: 'Backup',
       onClick: () => closeDrawerThen(onOpenBackup)
-    },
-    // Security (app lock) is native-only; the PWA keeps its
-    // passkey-per-launch flow and has nothing to configure here.
-    ...(isAppLockSupported() ? [{
-      icon: <LockIcon />,
-      label: 'Security',
-      onClick: () => closeDrawerThen(onOpenSecurity)
-    }] : []),
+    }]),
     {
       icon: <SettingsIcon />,
       label: 'Settings',

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -6,17 +6,17 @@ import {
   signInPinnedToActiveCredential,
 } from '@/services/passkeyService';
 import { deviceOnlyStorage, secureStorage, getBiometryInfo, BiometryInfo } from '@/services/secureStorage';
-import { isPinEnabled, isPinEnabledSync } from '@/services/appLock';
-import { PinGate } from '../components/PinEntry';
 import { logger, LogCategory } from '@/services/logger';
 import { copyToClipboard } from '@/utils/clipboard';
 import { useScreenCaptureProtection } from '@/utils/screenSecurity';
 
 interface BackupPageProps {
   onBack: () => void;
+  /** 'back' when opened from the Security & Backup page (native). */
+  closeStyle?: 'close' | 'back';
 }
 
-const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
+const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' }) => {
   const [mnemonic, setMnemonic] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [isRevealed, setIsRevealed] = useState(false);
@@ -35,23 +35,6 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
   // (biometric unlock enabled in Security settings). Reveal requires
   // an OS biometric prompt instead of the silent device-only read.
   const [biometricSeedPresent, setBiometricSeedPresent] = useState(false);
-
-  // App-lock gate before the silent-tier reveal (Misty gates its
-  // mnemonics page behind the app lock). Only the device-only /
-  // localStorage path needs it: the passkey and biometric-tier paths
-  // already run their own OS auth ceremony on reveal. No PIN set =>
-  // plain tap, matching the "no login by default" decision.
-  // Seeded from the sync mirror so a tap before the async read lands
-  // can't slip past the gate; the Preferences read stays authoritative.
-  const [pinRequired, setPinRequired] = useState(isPinEnabledSync());
-  const [showPinGate, setShowPinGate] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    void isPinEnabled().then((enabled) => {
-      if (!cancelled) setPinRequired(enabled);
-    });
-    return () => { cancelled = true; };
-  }, []);
 
   useEffect(() => {
     if (isPasskey) return;
@@ -210,7 +193,7 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
   const words = mnemonic ? mnemonic.split(' ') : [];
 
   return (
-    <SlideInPage title="Backup" onClose={onBack} slideFrom="left">
+    <SlideInPage title="Backup" onClose={onBack} slideFrom="left" closeStyle={closeStyle}>
       {/* min-h-full + flexed chain so the PIN gate (the sole child
           while it shows) can split the viewport 1/3 header / 2/3
           input; the card views flow from the top as before. */}
@@ -258,26 +241,15 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
             </button>
           )}
 
-          {/* App-lock gate (mnemonic mode): shown in place of the
-              reveal tile once it is tapped with a PIN set. */}
-          {!isPasskey && !isRevealed && showPinGate && (
-            <PinGate
-              reason="Reveal recovery phrase"
-              onUnlocked={() => {
-                setShowPinGate(false);
-                setIsRevealed(true);
-              }}
-            />
-          )}
-
           {/* Reveal button (mnemonic mode). When biometric unlock is
               enabled the seed is in the biometric-bound tier, so the
-              tap triggers an OS prompt before revealing. With the
-              app-lock PIN set, the tap opens the PIN gate instead. */}
-          {!isPasskey && !isRevealed && !showPinGate && (mnemonic || biometricSeedPresent) && (
+              tap triggers an OS prompt before revealing. App-lock
+              protection happens at page entry: on native the only way
+              here is through the gated Security & Backup page. */}
+          {!isPasskey && !isRevealed && (mnemonic || biometricSeedPresent) && (
             <button
               onClick={mnemonic
-                ? () => { (pinRequired ? setShowPinGate : setIsRevealed)(true); }
+                ? () => setIsRevealed(true)
                 : () => { void revealFromVault('biometric'); }}
               disabled={isLoading}
               className="w-full bg-spark-dark border border-spark-border rounded-2xl p-8 flex flex-col items-center gap-4 hover:border-spark-border-light transition-colors disabled:opacity-50"
@@ -298,7 +270,7 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack }) => {
               </span>
               <span className="text-sm text-spark-text-muted">
                 {mnemonic
-                  ? pinRequired ? 'Requires PIN' : 'Make sure no one is watching'
+                  ? 'Make sure no one is watching'
                   : isLoading
                     ? `Complete ${biometry?.label ?? 'biometric'} authentication`
                     : `Requires ${biometry?.label ?? 'biometric authentication'}`}

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -1,9 +1,10 @@
 /**
- * SecurityPage (native only): Misty Breez's Security settings minus the
- * backup options. No PIN set => a single "Create PIN" row. PIN set =>
+ * Security & Backup page (native only), Misty Breez's model: the
+ * recovery phrase entry and the app-lock settings live behind one
+ * gate. No PIN set => Backup row + a "Create PIN" row. PIN set =>
  * the page opens behind an auth gate (biometrics first when enabled,
- * PIN pad as fallback) and offers: deactivate PIN, auto-lock timeout,
- * change PIN, enable <biometry>.
+ * PIN pad as fallback) and offers: Backup, deactivate PIN, auto-lock
+ * timeout, change PIN, enable <biometry>.
  */
 
 import React, { useEffect, useRef, useState } from 'react';
@@ -40,9 +41,12 @@ type View =
 
 interface SecurityPageProps {
   onBack: () => void;
+  /** Opens the Backup page. Rendered only past the gate, so the
+   *  recovery phrase inherits the page-entry app-lock (Misty model). */
+  onOpenBackup: () => void;
 }
 
-const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
+const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => {
   const [view, setView] = useState<View>('loading');
   const [autoLock, setAutoLock] = useState<number>(120);
   const [biometricGate, setBiometricGate] = useState(false);
@@ -152,6 +156,22 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
   };
 
   const renderBody = () => {
+    // Shared by the no-pin and options views: the recovery phrase entry
+    // lives here so it inherits the page-entry gate when a PIN is set.
+    const backupCard = (
+      <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+        <h3 className="font-display font-semibold text-spark-text-primary mb-3">Backup</h3>
+        <button
+          className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+          type="button"
+          onClick={onOpenBackup}
+        >
+          <span>Show Recovery Phrase</span>
+          <ChevronRightIcon size="md" />
+        </button>
+      </div>
+    );
+
     switch (view) {
       case 'loading':
         return (
@@ -165,19 +185,22 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
 
       case 'no-pin':
         return (
-          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-            <h3 className="font-display font-semibold text-spark-text-primary mb-3">App Lock</h3>
-            <button
-              className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
-              type="button"
-              onClick={() => startPinFlow('create-pin')}
-            >
-              <div className="flex items-center gap-3">
-                <ShieldCheckIcon size="md" />
-                <span>Create PIN</span>
-              </div>
-              <ChevronRightIcon size="md" />
-            </button>
+          <div className="space-y-4">
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">App Lock</h3>
+              <button
+                className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+                type="button"
+                onClick={() => startPinFlow('create-pin')}
+              >
+                <div className="flex items-center gap-3">
+                  <ShieldCheckIcon size="md" />
+                  <span>Create PIN</span>
+                </div>
+                <ChevronRightIcon size="md" />
+              </button>
+            </div>
+            {backupCard}
           </div>
         );
 
@@ -203,7 +226,8 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
 
       case 'options':
         return (
-          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4 space-y-2">
+          <div className="space-y-4">
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4 space-y-2">
             <h3 className="font-display font-semibold text-spark-text-primary mb-3">App Lock</h3>
             {/* Deactivate PIN (Misty pattern: an always-on switch whose
                 only action is turning protection off) */}
@@ -217,7 +241,7 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
 
             {/* Lock automatically */}
             <div className="flex items-center justify-between gap-3 px-4 py-3 border border-spark-border rounded-xl">
-              <span className="text-sm font-medium text-spark-text-primary">Lock automatically</span>
+              <span className="text-sm font-medium text-spark-text-primary">Lock Automatically</span>
               <select
                 value={autoLock}
                 onChange={(e) => {
@@ -259,7 +283,7 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
                 <div className="flex items-center gap-3 text-left">
                   <FingerprintIcon size="md" />
                   <div>
-                    <span className="block text-spark-text-primary">Biometric unlock is locked</span>
+                    <span className="block text-spark-text-primary">Biometric Unlock Locked</span>
                     <span className="block text-xs text-spark-text-muted">
                       Too many failed attempts. Tap to unlock with your passcode.
                     </span>
@@ -277,7 +301,7 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
                     ? <FaceIdIcon size="md" className="text-spark-text-secondary" />
                     : <FingerprintIcon size="md" className="text-spark-text-secondary" />}
                   <span className="text-sm font-medium text-spark-text-primary">
-                    {`Enable ${biometry.label}`}
+                    {`Enable ${biometry.label.replace(/\b\w/g, (c) => c.toUpperCase())}`}
                   </span>
                 </div>
                 <Switch checked={biometricGate} onChange={() => { void handleToggleBiometric(); }} />
@@ -287,13 +311,15 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
             {optionsError && (
               <p className="text-spark-error text-xs px-1 pt-1">{optionsError}</p>
             )}
+            </div>
+            {backupCard}
           </div>
         );
     }
   };
 
   return (
-    <SlideInPage title="Security" onClose={onBack} slideFrom="left">
+    <SlideInPage title="Security & Backup" onClose={onBack} slideFrom="left">
       {/* min-h-full + flexed chain so the PIN views (gate, create,
           change) can split the viewport 1/3 header / 2/3 input; the
           list views just flow from the top as before. p-4 keeps the


### PR DESCRIPTION
## What this does

Follows up on the optional app-lock (#282) by adopting Misty Breez's page structure on native: Backup and Security merge into a single Security & Backup page, so the recovery phrase entry lives alongside the app-lock settings and both sit behind one gate.

- The side menu shows one Security & Backup item on native instead of separate Backup and Security entries.
- With a PIN set, entering the page requires the biometric prompt or PIN once; the recovery phrase no longer asks again at reveal time, and returning from the phrase view does not re-prompt.
- Without a PIN, the page offers the phrase and PIN setup directly, unchanged protection-off default.
- The web app is untouched: it keeps its top-level Backup with the same behavior as before, verified in the browser.

## Test plan

On a device with a PIN set: open Security & Backup (gate fires once), open the recovery phrase from the Backup section (no second prompt), go back (still no prompt). Repeat without a PIN: everything opens directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)