### PR TITLE
Add passkey onboarding timing diagnostics

### DIFF
--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -399,6 +399,7 @@ export function useBreezSdk(
     source: ConnectSeedSource = 'onboarding',
   ) => {
     let connectedSdk: BreezSdk | undefined;
+    const createStart = performance.now();
     try {
       logger.info(LogCategory.SDK, 'Initiating wallet connection', { restore });
       if (sdk) {
@@ -417,15 +418,18 @@ export function useBreezSdk(
       }
 
       initSdkLogging();
+      logger.info(LogCategory.PERF, '[onboarding] connect.begin', { restore, source });
 
       const cfg = buildConnectConfig();
       setConfig(cfg);
 
-      connectedSdk = await connect({
+      // connect() = Spark auth + initial wallet sync (no Nostr; the label
+      // publish was already kicked off, fire-and-forget, inside register()).
+      connectedSdk = await logger.time('[onboarding] sdk.connect', () => connect({
         config: cfg,
         seed,
         storageDir: 'spark-wallet-example',
-      });
+      }));
       setSdk(connectedSdk);
 
       logger.sdkInitialized();
@@ -481,13 +485,20 @@ export function useBreezSdk(
       setIsConnected(true);
       setStartupState('connected');
       setIsLoading(false);
+      // Total covers connect + persist; getInfo/history load in the
+      // background below. Add the earlier passkey.register/signIn time for
+      // the full button-tap-to-usable figure.
+      logger.info(LogCategory.PERF, '[onboarding] connect.total', {
+        ms: Math.round(performance.now() - createStart),
+      });
 
       void (async () => {
         try {
-          const [info, txns] = await Promise.all([
-            connectedSdk!.getInfo({}),
-            connectedSdk!.listPayments({ offset: 0, limit: 100 }),
-          ]);
+          const [info, txns] = await logger.time('[onboarding] sdk.getInfoAndPayments', () =>
+            Promise.all([
+              connectedSdk!.getInfo({}),
+              connectedSdk!.listPayments({ offset: 0, limit: 100 }),
+            ]));
           setWalletInfo(info);
           setTransactions(filterOngoingConversionPayments(txns.payments));
           logger.info(LogCategory.SDK, 'Connected wallet identity', {
@@ -1004,6 +1015,13 @@ export function useBreezSdk(
     document.body.setAttribute('data-lnurl-enabled', lnurlEnabled);
     return () => { document.body.setAttribute('data-lnurl-enabled', 'false'); };
   }, [config?.lnurlDomain]);
+
+  // Route SDK-internal logs to the ring buffer from app start (not just
+  // from connectWallet), so the passkey register / label-publish phase is
+  // captured in Share Logs. Idempotent, so connectWallet's call no-ops.
+  // Without this the ~30s register() is a black box in exported logs, and
+  // we can't split the WebAuthn ceremony from the Nostr label publish.
+  useEffect(() => { initSdkLogging(); }, []);
 
   // Check PRF availability on mount
   useEffect(() => {

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -597,16 +597,22 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
           // refuses a second Glow passkey (one per device per RP). A
           // match raises PasskeyAlreadyExistsError, handled in the catch.
           const excludeCredentials = await getPasskey().credentials().get();
-          const response = await getPasskey().register({
-            label,
-            excludeCredentials,
-            userName,
-            userDisplayName: userName,
-          });
+          // register() = WebAuthn create + PRF derive + kind:1 label
+          // publish to Nostr. The label publish is awaited inside the SDK
+          // and stalls on dead relays; this timer isolates that cost from
+          // connect(). See useBreezSdk.connectWallet for the rest.
+          const response = await logger.time('[onboarding] passkey.register', () =>
+            getPasskey().register({
+              label,
+              excludeCredentials,
+              userName,
+              userDisplayName: userName,
+            }));
           recordRegisteredCredential(response.credential, userName);
           w = response.wallet;
         } else {
-          const response = await signInPinnedToActiveCredential(label);
+          const response = await logger.time('[onboarding] passkey.signIn', () =>
+            signInPinnedToActiveCredential(label));
           w = response.wallet;
         }
         if (cancelled) return;

--- a/src/services/logger.test.ts
+++ b/src/services/logger.test.ts
@@ -116,4 +116,30 @@ describe('logger', () => {
 
     expect(logger.getLogs()).toHaveLength(0);
   });
+
+  it('time() logs begin + end with elapsed ms and returns the value', async () => {
+    const result = await logger.time('[onboarding] step', async () => 42);
+
+    expect(result).toBe(42);
+    const logs = logger.getLogs();
+    expect(logs.map((l) => l.message)).toEqual([
+      '[onboarding] step.begin',
+      '[onboarding] step.end',
+    ]);
+    expect(logs[1].category).toBe('perf');
+    expect(typeof logs[1].context?.ms).toBe('number');
+  });
+
+  it('time() logs .error and rethrows on failure', async () => {
+    await expect(
+      logger.time('[onboarding] step', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const logs = logger.getLogs();
+    expect(logs[0].message).toBe('[onboarding] step.begin');
+    expect(logs[1].message).toBe('[onboarding] step.error');
+    expect(logs[1].level).toBe('WARN');
+  });
 });

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -40,6 +40,7 @@ export const LogCategory = {
   NETWORK: 'network',
   SESSION: 'session',
   VALIDATION: 'validation',
+  PERF: 'perf', // Timing breadcrumbs (e.g. wallet-create critical path)
 } as const;
 
 export type LogCategoryType = (typeof LogCategory)[keyof typeof LogCategory];
@@ -178,6 +179,27 @@ export const logger = {
 
   error: (category: string, message: string, context?: Record<string, unknown>) =>
     log('ERROR', category, message, context),
+
+  /**
+   * Time an awaited step, emitting `<label>.begin` then `<label>.end`
+   * (with elapsed `ms`) under the PERF category. Used to profile the
+   * wallet-creation critical path; SDK_INTERNAL breadcrumbs (routed via
+   * `initLogging`) interleave between begin/end, so a slow step's
+   * internal cause is visible in Share Logs. On throw, emits
+   * `<label>.error` with the elapsed time and rethrows.
+   */
+  time: async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now();
+    log('INFO', LogCategory.PERF, `${label}.begin`);
+    try {
+      const result = await fn();
+      log('INFO', LogCategory.PERF, `${label}.end`, { ms: Math.round(performance.now() - t0) });
+      return result;
+    } catch (e) {
+      log('WARN', LogCategory.PERF, `${label}.error`, { ms: Math.round(performance.now() - t0) });
+      throw e;
+    }
+  },
 
   // Security event helpers (OWASP logging guidelines)
   authSuccess: (method: string) =>


### PR DESCRIPTION
Adds structured timing marks to the passkey onboarding path so the breakdown shows up in the in-app log export.

It also routes the SDK's own logs from app launch rather than from connect, so the `register` phase is no longer a blind spot.

Diagnostics only, no user-facing change. Useful for catching regressions and attributing the remaining onboarding cost, like the biometric ceremony.
