### PR TITLE
refactor: replace red UI with primary color, fix logout dialog backdrop, align Contact form labels

### DIFF
--- a/src/components/AlertCard.tsx
+++ b/src/components/AlertCard.tsx
@@ -22,34 +22,39 @@ const variantStyles: Record<AlertVariant, {
   container: string;
   iconBg: string;
   title: string;
+  body: string;
 }> = {
   info: {
     container: 'bg-spark-electric/10 border-spark-electric/30',
     iconBg: 'bg-spark-electric/20',
     title: 'text-spark-electric',
+    body: '',
   },
   warning: {
-    container: 'bg-spark-warning/10 border-spark-warning/30',
-    iconBg: 'bg-spark-warning/20',
-    title: 'text-spark-warning',
+    container: 'bg-spark-warn-surface border-spark-warn-border',
+    iconBg: 'bg-spark-primary/20',
+    title: 'text-spark-warn-title',
+    body: 'text-spark-warn-text',
   },
   success: {
     container: 'bg-spark-success/10 border-spark-success/30',
     iconBg: 'bg-spark-success/20',
     title: 'text-spark-success',
+    body: '',
   },
   error: {
-    container: 'bg-spark-error/10 border-spark-error/30',
-    iconBg: 'bg-spark-error/20',
-    title: 'text-spark-error',
+    container: 'bg-spark-warn-surface border-spark-warn-border',
+    iconBg: 'bg-spark-primary/20',
+    title: 'text-spark-warn-title',
+    body: 'text-spark-warn-text',
   },
 };
 
 const defaultIcons: Record<AlertVariant, ReactNode> = {
   info: <InfoIcon size="md" className="text-spark-electric" />,
-  warning: <WarningIcon size="md" className="text-spark-warning" />,
+  warning: <WarningIcon size="md" className="text-spark-primary" />,
   success: <CheckCircleIcon size="md" className="text-spark-success" />,
-  error: <ErrorIcon size="md" className="text-spark-error" />,
+  error: <ErrorIcon size="md" className="text-spark-primary" />,
 };
 
 export interface AlertCardProps {
@@ -85,7 +90,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({
         )}
         <h3 className={`font-display font-bold ${styles.title}`}>{title}</h3>
       </div>
-      <div className="pl-[52px]">
+      <div className={`pl-[52px] ${styles.body}`}>
         {children}
       </div>
     </div>
@@ -110,16 +115,16 @@ export const SimpleAlert: React.FC<SimpleAlertProps> = ({
 }) => {
   const iconColors: Record<AlertVariant, string> = {
     info: 'text-spark-electric',
-    warning: 'text-spark-warning',
+    warning: 'text-spark-primary',
     success: 'text-spark-success',
-    error: 'text-spark-error',
+    error: 'text-spark-primary',
   };
 
   const bgStyles: Record<AlertVariant, string> = {
     info: 'bg-spark-electric/10 border-spark-electric/30 text-spark-electric-light',
-    warning: 'bg-spark-warning/10 border-spark-warning/30 text-spark-warning',
+    warning: 'bg-spark-warn-surface border-spark-warn-border text-spark-warn-text',
     success: 'bg-spark-success/10 border-spark-success/30 text-spark-success',
-    error: 'bg-spark-error/10 border-spark-error/30 text-spark-error',
+    error: 'bg-spark-warn-surface border-spark-warn-border text-spark-warn-text',
   };
 
   const icons: Record<AlertVariant, ReactNode> = {

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -28,7 +28,7 @@ const OfflineBanner: React.FC = () => {
         aria-live="polite"
         className="flex items-center gap-1.5 rounded-full border border-white/10 bg-spark-surface px-3 py-1 text-xs font-medium text-spark-text-secondary shadow-glass-lg"
       >
-        <span className="h-1.5 w-1.5 rounded-full bg-spark-error" />
+        <span className="h-1.5 w-1.5 rounded-full bg-spark-primary" />
         No internet connection
       </div>
     </div>,

--- a/src/components/PinEntry.tsx
+++ b/src/components/PinEntry.tsx
@@ -24,7 +24,7 @@ export const PinDots: React.FC<{ filled: number; error?: boolean }> = ({ filled,
         className={`w-5 h-5 rounded-full border-2 transition-colors ${
           i < filled
             ? error
-              ? 'border-spark-error bg-spark-error/60'
+              ? 'border-spark-primary bg-spark-primary/60'
               : 'border-spark-primary bg-spark-primary'
             : 'border-spark-border-light bg-transparent'
         }`}
@@ -171,7 +171,7 @@ export const PinEntry: React.FC<{
       {/* NBSP placeholder, not a plain space: whitespace-only text
           collapses to a zero-height line box and the row grows 4px
           when real text lands (measured), shifting everything above. */}
-      <p className={`text-center text-sm ${shownError ? 'text-spark-error' : 'text-transparent'}`}>
+      <p className={`text-center text-sm ${shownError ? 'text-spark-primary' : 'text-transparent'}`}>
         {shownError ?? '\u00A0'}
       </p>
       <PinPad

--- a/src/components/QrScannerDialog.tsx
+++ b/src/components/QrScannerDialog.tsx
@@ -173,8 +173,8 @@ const QrScannerDialog: React.FC<QrScannerDialogProps> = ({ isOpen, onClose, onSc
             {!isScanning && !isInitializing && error && (
               <div className="absolute inset-0 flex items-center justify-center bg-spark-surface/80">
                 <div className="text-center text-white p-6 max-w-xs">
-                  <div className="w-16 h-16 rounded-full bg-spark-error/20 flex items-center justify-center mx-auto mb-4">
-                    <AlertTriangleIcon size="xl" className="text-spark-error" />
+                  <div className="w-16 h-16 rounded-full bg-spark-primary/20 flex items-center justify-center mx-auto mb-4">
+                    <AlertTriangleIcon size="xl" className="text-spark-primary" />
                   </div>
                   <p className="text-sm mb-2 font-medium">Camera not available</p>
                   <p className="text-xs text-spark-text-muted">{error}</p>
@@ -215,7 +215,7 @@ const QrScannerDialog: React.FC<QrScannerDialogProps> = ({ isOpen, onClose, onSc
 
           {/* Gallery error toast */}
           {galleryError && (
-            <div className="absolute top-16 left-1/2 -translate-x-1/2 bg-spark-error/90 text-white text-sm px-4 py-2 rounded-lg backdrop-blur-sm z-30">
+            <div className="absolute top-16 left-1/2 -translate-x-1/2 bg-spark-primary/90 text-white text-sm px-4 py-2 rounded-lg backdrop-blur-sm z-30">
               {galleryError}
             </div>
           )}

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -291,7 +291,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
                     </button>
                     <button
                       onClick={handleConfirmLogout}
-                      className="flex-1 px-4 py-3 bg-spark-destructive text-white rounded-xl font-medium hover:bg-spark-destructive-hover transition-colors"
+                      className="flex-1 px-4 py-3 bg-spark-primary text-white rounded-xl font-medium hover:bg-spark-primary/90 transition-colors"
                     >
                       Logout
                     </button>

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -236,7 +236,13 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
               </a>
             </div>
 
-            {/* Logout Confirmation Dialog */}
+            {/* Logout Confirmation Dialog.
+                Scrim is intentionally light (bg-black/50, blur-sm): this
+                dialog is nested inside the drawer, whose own bg-black/60 +
+                blur-sm scrim is already behind it. A standalone-weight
+                bg-black/85 would stack on top and read as ~94% black with
+                doubled blur; bg-black/50 over the drawer lands at the ~80%
+                a normal dialog shows. */}
             <Transition show={showLogoutConfirm} as="div" className="fixed inset-0 z-60">
               <TransitionChild
                 as="div"
@@ -246,7 +252,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
                 leave="transition-opacity ease-in duration-100"
                 leaveFrom="opacity-100"
                 leaveTo="opacity-0"
-                className="fixed inset-0 bg-black/85 backdrop-blur-md"
+                className="fixed inset-0 bg-black/50 backdrop-blur-sm"
                 onClick={() => setShowLogoutConfirm(false)}
               />
               <div className="fixed inset-0 flex items-center justify-center p-4">
@@ -285,7 +291,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
                     </button>
                     <button
                       onClick={handleConfirmLogout}
-                      className="flex-1 px-4 py-3 bg-spark-error text-white rounded-xl font-medium hover:bg-spark-error/90 transition-colors"
+                      className="flex-1 px-4 py-3 bg-spark-destructive text-white rounded-xl font-medium hover:bg-spark-destructive-hover transition-colors"
                     >
                       Logout
                     </button>

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -291,7 +291,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
                     </button>
                     <button
                       onClick={handleConfirmLogout}
-                      className="flex-1 px-4 py-3 bg-spark-primary text-white rounded-xl font-medium hover:bg-spark-primary/90 transition-colors"
+                      className="flex-1 px-4 py-3 bg-spark-primary text-black rounded-xl font-medium hover:bg-spark-primary/90 transition-colors"
                     >
                       Logout
                     </button>

--- a/src/components/StableBalanceFeeConfirm.tsx
+++ b/src/components/StableBalanceFeeConfirm.tsx
@@ -76,7 +76,7 @@ const StableBalanceFeeConfirm: React.FC<StableBalanceFeeConfirmProps> = ({
           )}
 
           {error && (
-            <p className="text-sm text-red-400 mb-4">{error}</p>
+            <p className="text-sm text-spark-primary mb-4">{error}</p>
           )}
 
           <div className="flex gap-3">

--- a/src/components/ToastNotification.tsx
+++ b/src/components/ToastNotification.tsx
@@ -65,7 +65,7 @@ const ToastNotification: React.FC<ToastNotificationProps> = ({
       case 'error':
         return {
           icon: <CloseIcon />,
-          bg: 'bg-spark-error',
+          bg: 'bg-spark-primary',
           progressBg: 'bg-white/30',
           textClass: 'text-white',
           detailClass: 'text-white/80',

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -152,7 +152,7 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions, onPayme
               <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-spark-warning animate-pulse" />
             )}
             {isFailed && (
-              <span className="shrink-0 px-1.5 py-0.5 rounded-sm bg-spark-error/15 text-spark-error text-[10px] font-medium uppercase">
+              <span className="shrink-0 px-1.5 py-0.5 rounded-sm bg-spark-primary/15 text-spark-primary text-[10px] font-medium uppercase">
                 Failed
               </span>
             )}

--- a/src/components/ui/forms/index.tsx
+++ b/src/components/ui/forms/index.tsx
@@ -135,8 +135,8 @@ export const FormError: React.FC<{
 }> = ({ error }) => {
   if (!error) return null;
   return (
-    <div className="flex items-center gap-2 text-spark-primary text-sm mt-2">
-      <ErrorIcon className="shrink-0" />
+    <div className="flex items-center gap-2 text-spark-primary-light text-sm mt-2">
+      <ErrorIcon className="shrink-0 text-spark-primary" />
       <span>{error}</span>
     </div>
   );

--- a/src/components/ui/forms/index.tsx
+++ b/src/components/ui/forms/index.tsx
@@ -135,9 +135,9 @@ export const FormError: React.FC<{
 }> = ({ error }) => {
   if (!error) return null;
   return (
-    <div className="flex items-center gap-2 text-spark-primary-light text-sm mt-2">
-      <ErrorIcon className="shrink-0 text-spark-primary" />
-      <span>{error}</span>
+    <div className="flex items-center gap-2 text-spark-primary text-sm mt-2">
+      <ErrorIcon className="shrink-0" />
+      <span className="text-spark-primary-light">{error}</span>
     </div>
   );
 };

--- a/src/components/ui/forms/index.tsx
+++ b/src/components/ui/forms/index.tsx
@@ -135,7 +135,7 @@ export const FormError: React.FC<{
 }> = ({ error }) => {
   if (!error) return null;
   return (
-    <div className="flex items-center gap-2 text-spark-error text-sm mt-2">
+    <div className="flex items-center gap-2 text-spark-primary text-sm mt-2">
       <ErrorIcon className="shrink-0" />
       <span>{error}</span>
     </div>

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -565,7 +565,7 @@ export const ConfirmDialog: React.FC<{
     if (!isOpen) return null;
 
     const confirmButtonStyles = {
-      danger: 'bg-spark-destructive hover:bg-spark-destructive-hover text-white',
+      danger: 'bg-spark-primary hover:bg-spark-primary/80 text-white',
       warning: 'bg-spark-warning hover:bg-spark-warning/80 text-spark-dark',
       default: 'bg-spark-primary hover:bg-spark-primary-light text-white',
     };

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -120,7 +120,7 @@ export const DialogHeader: React.FC<{
     <button
       onClick={onClose}
       aria-label="Close"
-      className="absolute right-0 top-1/2 -translate-y-1/2 py-2 pl-2 pr-6 -mr-6 text-spark-text-muted hover:text-spark-error transition-colors rounded-lg hover:bg-white/5"
+      className="absolute right-0 top-1/2 -translate-y-1/2 py-2 pl-2 pr-6 -mr-6 text-spark-text-muted hover:text-spark-primary-light transition-colors rounded-lg hover:bg-white/5"
     >
       <CloseIcon />
     </button>
@@ -385,16 +385,16 @@ export const Alert: React.FC<{
 }> = ({ type, children, className = "" }) => {
   const styles = {
     info: 'bg-spark-electric/10 border-spark-electric/30 text-spark-electric-light',
-    warning: 'bg-spark-warning/10 border-spark-warning/30 text-spark-warning',
+    warning: 'bg-spark-warn-surface border-spark-warn-border text-spark-warn-text',
     success: 'bg-spark-success/10 border-spark-success/30 text-spark-success',
-    error: 'bg-spark-error/10 border-spark-error/30 text-spark-error',
+    error: 'bg-spark-warn-surface border-spark-warn-border text-spark-warn-text',
   };
 
   const icons = {
     info: <InfoIcon className="shrink-0" />,
-    warning: <WarningIcon className="shrink-0" />,
+    warning: <WarningIcon className="shrink-0 text-spark-primary" />,
     success: <CheckCircleIcon className="shrink-0" />,
-    error: <ErrorIcon className="shrink-0" size="md" />,
+    error: <ErrorIcon className="shrink-0 text-spark-primary" size="md" />,
   };
 
   return (
@@ -451,15 +451,15 @@ export const ErrorMessageBox: React.FC<{
   }
 
   return (
-    <div className={`bg-spark-error/10 border border-spark-error/30 rounded-2xl p-4 ${className}`}>
+    <div className={`bg-spark-warn-surface border border-spark-warn-border rounded-2xl p-4 ${className}`}>
       <div className="flex items-center gap-3 mb-2">
-        <div className="w-10 h-10 rounded-xl bg-spark-error/20 flex items-center justify-center shrink-0">
-          <AlertTriangleIcon className="text-spark-error" />
+        <div className="w-10 h-10 rounded-xl bg-spark-primary/20 flex items-center justify-center shrink-0">
+          <AlertTriangleIcon className="text-spark-primary" />
         </div>
-        <h3 className="font-display font-bold text-spark-error">{title}</h3>
+        <h3 className="font-display font-bold text-spark-warn-title">{title}</h3>
       </div>
       <div className="pl-[52px]">
-        <p className="text-spark-text-secondary text-sm">{mainMessage}</p>
+        <p className="text-spark-warn-text text-sm">{mainMessage}</p>
         {stackTrace && (
           <div className="mt-3 bg-spark-dark/50 border border-spark-border rounded-xl p-3 max-h-32 overflow-auto">
             <code className="text-xs text-spark-text-muted font-mono whitespace-pre-wrap break-all">
@@ -565,7 +565,7 @@ export const ConfirmDialog: React.FC<{
     if (!isOpen) return null;
 
     const confirmButtonStyles = {
-      danger: 'bg-spark-error hover:bg-spark-error/80 text-white',
+      danger: 'bg-spark-destructive hover:bg-spark-destructive-hover text-white',
       warning: 'bg-spark-warning hover:bg-spark-warning/80 text-spark-dark',
       default: 'bg-spark-primary hover:bg-spark-primary-light text-white',
     };

--- a/src/features/passkey-migration/steps/MigrationProgressStep.tsx
+++ b/src/features/passkey-migration/steps/MigrationProgressStep.tsx
@@ -26,7 +26,7 @@ const MigrationProgressStep: React.FC<MigrationProgressStepProps> = ({ text }) =
         </motion.p>
       </AnimatePresence>
     </div>
-    <div className="mt-3 flex items-center justify-center gap-2 text-xs text-amber-400/80">
+    <div className="mt-3 flex items-center justify-center gap-2 text-xs text-spark-primary">
       <AlertTriangleIcon size="xs" />
       <span>Keep this window open</span>
     </div>

--- a/src/features/passkey-migration/steps/MigrationProgressStep.tsx
+++ b/src/features/passkey-migration/steps/MigrationProgressStep.tsx
@@ -26,8 +26,8 @@ const MigrationProgressStep: React.FC<MigrationProgressStepProps> = ({ text }) =
         </motion.p>
       </AnimatePresence>
     </div>
-    <div className="mt-3 flex items-center justify-center gap-2 text-xs text-spark-primary">
-      <AlertTriangleIcon size="xs" />
+    <div className="mt-3 flex items-center justify-center gap-2 text-xs text-spark-primary-light">
+      <AlertTriangleIcon size="xs" className="text-spark-primary" />
       <span>Keep this window open</span>
     </div>
   </div>

--- a/src/features/passkey-migration/steps/MigrationProgressStep.tsx
+++ b/src/features/passkey-migration/steps/MigrationProgressStep.tsx
@@ -26,9 +26,9 @@ const MigrationProgressStep: React.FC<MigrationProgressStepProps> = ({ text }) =
         </motion.p>
       </AnimatePresence>
     </div>
-    <div className="mt-3 flex items-center justify-center gap-2 text-xs text-spark-primary-light">
-      <AlertTriangleIcon size="xs" className="text-spark-primary" />
-      <span>Keep this window open</span>
+    <div className="mt-3 flex items-center justify-center gap-2 text-xs text-spark-primary">
+      <AlertTriangleIcon size="xs" />
+      <span className="text-spark-primary-light">Keep this window open</span>
     </div>
   </div>
 );

--- a/src/features/send/components/ContactsSubView.tsx
+++ b/src/features/send/components/ContactsSubView.tsx
@@ -227,7 +227,7 @@ const ContactsSubView: React.FC<ContactsSubViewProps> = ({ onSelect, onBack }) =
                   </button>
                   <button
                     onClick={() => setDeletingContact(contact)}
-                    className="p-1.5 text-spark-text-muted hover:text-spark-error rounded-lg hover:bg-white/5 transition-colors"
+                    className="p-1.5 text-spark-text-muted hover:text-spark-primary-light rounded-lg hover:bg-white/5 transition-colors"
                     aria-label={`Delete ${contact.name}`}
                   >
                     <TrashIcon />

--- a/src/features/send/components/ContactsSubView.tsx
+++ b/src/features/send/components/ContactsSubView.tsx
@@ -264,8 +264,8 @@ const ContactsSubView: React.FC<ContactsSubViewProps> = ({ onSelect, onBack }) =
 
         {/* Form fields take the natural content height */}
         <div className="space-y-4">
-          <div className="space-y-1.5">
-            <label htmlFor="subview-contact-name" className="text-sm text-spark-text-secondary font-medium">Name</label>
+          <div>
+            <label htmlFor="subview-contact-name" className="block text-spark-text-secondary text-sm font-medium mb-2">Name</label>
             <input
               id="subview-contact-name"
               value={formName}
@@ -289,8 +289,8 @@ const ContactsSubView: React.FC<ContactsSubViewProps> = ({ onSelect, onBack }) =
               className="w-full bg-spark-dark border border-spark-border rounded-xl px-4 py-3 text-spark-text-primary placeholder-spark-text-muted focus:border-spark-primary focus:ring-0 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             />
           </div>
-          <div className="space-y-1.5">
-            <label htmlFor="subview-contact-address" className="text-sm text-spark-text-secondary font-medium">Lightning Address</label>
+          <div>
+            <label htmlFor="subview-contact-address" className="block text-spark-text-secondary text-sm font-medium mb-2">Lightning Address</label>
             <FormInput
               id="subview-contact-address"
               inputRef={addressInputRef}

--- a/src/features/send/steps/ResultStep.tsx
+++ b/src/features/send/steps/ResultStep.tsx
@@ -66,15 +66,15 @@ const ResultStep: React.FC<ResultStepProps> = ({ result, error, onClose, operati
       <div className="flex flex-col items-center justify-center py-4" data-testid="payment-failure">
         <div className="relative mb-6">
           {/* Error glow */}
-          <div className="absolute inset-0 w-20 h-20 rounded-full blur-xl bg-spark-error/30" />
+          <div className="absolute inset-0 w-20 h-20 rounded-full blur-xl bg-spark-primary/30" />
 
           {/* Error icon */}
-          <div className="relative w-20 h-20 rounded-full flex items-center justify-center bg-spark-error/20 border-2 border-spark-error">
-            <CloseIcon className="w-10 h-10 text-spark-error" />
+          <div className="relative w-20 h-20 rounded-full flex items-center justify-center bg-spark-primary/20 border-2 border-spark-primary">
+            <CloseIcon className="w-10 h-10 text-spark-primary" />
           </div>
         </div>
 
-        <h3 className="font-display text-2xl font-bold mb-2 text-spark-error">
+        <h3 className="font-display text-2xl font-bold mb-2 text-spark-primary">
           {getTitle()}
         </h3>
 

--- a/src/features/send/workflows/CrossChainWorkflow.tsx
+++ b/src/features/send/workflows/CrossChainWorkflow.tsx
@@ -365,7 +365,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
       {step === 'asset' && (
         <div className="flex flex-col" style={{ maxHeight: '60vh' }}>
           {error && (
-            <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-sm text-red-400 shrink-0">
+            <div className="mb-4 p-3 bg-spark-warn-surface border border-spark-warn-border rounded-xl text-sm text-spark-warn-text shrink-0">
               {error}
             </div>
           )}
@@ -410,7 +410,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
       {step === 'chain' && (
         <div className="flex flex-col" style={{ maxHeight: isSheetFull ? '85dvh' : '60dvh' }}>
           {error && (
-            <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-sm text-red-400 shrink-0">
+            <div className="mb-4 p-3 bg-spark-warn-surface border border-spark-warn-border rounded-xl text-sm text-spark-warn-text shrink-0">
               {error}
             </div>
           )}
@@ -484,9 +484,9 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
       {step === 'provider' && (
         <div className="flex flex-col" style={{ maxHeight: '60vh' }}>
           {allProvidersFailed ? (
-            <div className="mb-4 p-4 bg-red-500/10 border border-red-500/20 rounded-xl">
-              <p className="text-sm font-medium text-spark-text-primary mb-1">Couldn’t get a quote</p>
-              <p className="text-sm text-spark-text-secondary">{providerFailureReason}</p>
+            <div className="mb-4 p-4 bg-spark-warn-surface border border-spark-warn-border rounded-xl">
+              <p className="text-sm font-medium text-spark-warn-title mb-1">Couldn’t get a quote</p>
+              <p className="text-sm text-spark-warn-text">{providerFailureReason}</p>
             </div>
           ) : (
             <div className="mb-4 min-h-0 flex flex-col">
@@ -623,7 +623,7 @@ const CrossChainWorkflow: React.FC<CrossChainWorkflowProps> = ({
           />
 
           {error && (
-            <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl text-sm text-red-400">
+            <div className="mb-4 p-3 bg-spark-warn-surface border border-spark-warn-border rounded-xl text-sm text-spark-warn-text">
               {error}
             </div>
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,12 @@
   --color-spark-success: #10b981;
   --color-spark-error: #ef4444;
   --color-spark-warning: var(--spark-primary);
+  --color-spark-destructive: var(--spark-destructive);
+  --color-spark-destructive-hover: var(--spark-destructive-hover);
+  --color-spark-warn-border: var(--spark-warn-border);
+  --color-spark-warn-surface: var(--spark-warn-surface);
+  --color-spark-warn-title: var(--spark-warn-title);
+  --color-spark-warn-text: var(--spark-warn-text);
   --color-spark-text-primary: #ffffff;
   --color-spark-text-secondary: rgba(255, 255, 255, 0.7);
   --color-spark-text-muted: rgba(255, 255, 255, 0.4);
@@ -174,6 +180,16 @@
   --spark-success: #10b981;
   --spark-error: #ef4444;
   --spark-warning: #d4a574;
+
+  /* Destructive actions (logout, delete): calm blue, not alarm red */
+  --spark-destructive: #5c82a9;
+  --spark-destructive-hover: #8ca7c2;
+
+  /* Warning / error boxes: warm amber on dark teal */
+  --spark-warn-border: #8a7154;
+  --spark-warn-surface: #182226;
+  --spark-warn-title: #e8d3ba;
+  --spark-warn-text: #d5cec5;
 
   /* Text */
   --spark-text-primary: #ffffff;

--- a/src/index.css
+++ b/src/index.css
@@ -17,8 +17,6 @@
   --color-spark-success: #10b981;
   --color-spark-error: #ef4444;
   --color-spark-warning: var(--spark-primary);
-  --color-spark-destructive: var(--spark-destructive);
-  --color-spark-destructive-hover: var(--spark-destructive-hover);
   --color-spark-warn-border: var(--spark-warn-border);
   --color-spark-warn-surface: var(--spark-warn-surface);
   --color-spark-warn-title: var(--spark-warn-title);
@@ -180,10 +178,6 @@
   --spark-success: #10b981;
   --spark-error: #ef4444;
   --spark-warning: #d4a574;
-
-  /* Destructive actions (logout, delete): calm blue, not alarm red */
-  --spark-destructive: #5c82a9;
-  --spark-destructive-hover: #8ca7c2;
 
   /* Warning / error boxes: warm amber on dark teal */
   --spark-warn-border: #8a7154;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -209,7 +209,7 @@ async function init() {
     });
     void hideSplash();
     document.getElementById('root')!.innerHTML = `
-      <div style="color: #ef4444; padding: 20px; text-align: center; background: #0a0a0f; min-height: 100vh; display: flex; flex-direction: column; justify-content: center;">
+      <div style="color: #d4a574; padding: 20px; text-align: center; background: #0a0a0f; min-height: 100vh; display: flex; flex-direction: column; justify-content: center;">
         <h2>Failed to load application</h2>
         <p>There was an error starting Glow. Please refresh and try again.</p>
       </div>

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -282,8 +282,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
               into the fallback card below, so this only renders for
               non-passkey edge cases. */}
           {error && !isPasskey && (
-            <div className="bg-spark-error/10 border border-spark-error/30 rounded-xl p-4 text-center">
-              <p className="text-spark-error text-sm">{error}</p>
+            <div className="bg-spark-warn-surface border border-spark-warn-border rounded-xl p-4 text-center">
+              <p className="text-spark-warn-text text-sm">{error}</p>
             </div>
           )}
 
@@ -330,8 +330,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
           {isPasskey && passkeyAttemptFailed && !isRevealed && !mnemonic
             && (!secureStorage.isSupported() || fallbackTier === 'none') && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-8 text-center">
-              <div className="w-16 h-16 rounded-2xl bg-spark-error/20 flex items-center justify-center mx-auto mb-4">
-                <WarningIcon size="xl" className="text-spark-error" />
+              <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center mx-auto mb-4">
+                <WarningIcon size="xl" className="text-spark-primary" />
               </div>
               <h3 className="font-display font-semibold text-spark-text-primary mb-2">Passkey Unavailable</h3>
               <p className="text-spark-text-muted text-sm">
@@ -388,8 +388,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
           {/* No backup found (mnemonic mode only) */}
           {!isPasskey && !mnemonic && !biometricSeedPresent && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-8 text-center">
-              <div className="w-16 h-16 rounded-2xl bg-spark-error/20 flex items-center justify-center mx-auto mb-4">
-                <WarningIcon size="xl" className="text-spark-error" />
+              <div className="w-16 h-16 rounded-2xl bg-spark-primary/20 flex items-center justify-center mx-auto mb-4">
+                <WarningIcon size="xl" className="text-spark-primary" />
               </div>
               <h3 className="font-display font-semibold text-spark-text-primary mb-2">No Backup Found</h3>
               <p className="text-spark-text-muted text-sm">

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -417,15 +417,15 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                 />
 
                 {refundError && (
-                  <div className="bg-spark-warning/10 border border-spark-warning/30 rounded-2xl p-4">
+                  <div className="bg-spark-warn-surface border border-spark-warn-border rounded-2xl p-4">
                     <div className="flex items-center gap-3 mb-2">
-                      <div className="w-10 h-10 rounded-xl bg-spark-warning/20 flex items-center justify-center shrink-0">
-                        <WarningIcon size="md" className="text-spark-warning" />
+                      <div className="w-10 h-10 rounded-xl bg-spark-primary/20 flex items-center justify-center shrink-0">
+                        <WarningIcon size="md" className="text-spark-primary" />
                       </div>
-                      <h3 className="font-display font-bold text-spark-warning">Refund Failed</h3>
+                      <h3 className="font-display font-bold text-spark-warn-title">Refund Failed</h3>
                     </div>
                     <div className="pl-[52px]">
-                      <p className="text-spark-error text-sm">{refundError}</p>
+                      <p className="text-spark-warn-text text-sm">{refundError}</p>
                     </div>
                   </div>
                 )}
@@ -470,13 +470,13 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                     </>
                   ) : (
                     <>
-                      <div className="w-16 h-16 rounded-full bg-spark-error/20 flex items-center justify-center mx-auto mb-4">
-                        <CloseIcon size="xl" className="text-spark-error" />
+                      <div className="w-16 h-16 rounded-full bg-spark-primary/20 flex items-center justify-center mx-auto mb-4">
+                        <CloseIcon size="xl" className="text-spark-primary" />
                       </div>
                       <h3 className="font-display font-semibold text-spark-text-primary text-lg mb-2">
                         Refund Failed
                       </h3>
-                      <p className="text-spark-error text-sm">
+                      <p className="text-spark-primary text-sm">
                         {refundError || 'An error occurred while processing your refund.'}
                       </p>
                     </>

--- a/src/pages/LabelsPage.tsx
+++ b/src/pages/LabelsPage.tsx
@@ -283,7 +283,7 @@ const LabelsPage: React.FC<LabelsPageProps> = ({ onBack, onSwitchLabel }) => {
                     disabled={isSaving}
                   />
                   {isDuplicate && (
-                    <p className="text-spark-error text-xs">
+                    <p className="text-spark-primary text-xs">
                       A label with this name already exists.
                     </p>
                   )}

--- a/src/pages/PasskeyLocalStatePage.tsx
+++ b/src/pages/PasskeyLocalStatePage.tsx
@@ -156,8 +156,8 @@ const PasskeyLocalStatePage: React.FC<PasskeyLocalStatePageProps> = ({ onBack, o
             onClick={() => setConfirm(item.kind)}
             className="w-full flex items-center gap-3 p-4 bg-spark-dark border border-spark-border rounded-2xl text-left hover:border-spark-border-light hover:bg-white/5 transition-colors"
           >
-            <div className="w-10 h-10 rounded-xl bg-spark-error/10 flex items-center justify-center shrink-0">
-              <TrashIcon size="sm" className="text-spark-error" />
+            <div className="w-10 h-10 rounded-xl bg-spark-primary/10 flex items-center justify-center shrink-0">
+              <TrashIcon size="sm" className="text-spark-primary-light" />
             </div>
             <div className="font-display font-semibold text-spark-text-primary">
               {item.title}

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -844,7 +844,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
                 autoFocus
               />
               {isDuplicate && (
-                <p className="text-red-400 text-xs mt-1">
+                <p className="text-spark-primary text-xs mt-1">
                   A label with this name already exists
                 </p>
               )}
@@ -870,8 +870,8 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     // flex parent and making the page horizontally scrollable on mobile.
     <div className="w-full min-w-0 max-w-xl mx-auto space-y-4 py-8">
       <div className="flex justify-center mb-6">
-        <div className="p-4 rounded-full bg-red-500/10">
-          <PasskeyIcon size="lg" className="text-red-500" />
+        <div className="p-4 rounded-full bg-spark-primary/10">
+          <PasskeyIcon size="lg" className="text-spark-primary-light" />
         </div>
       </div>
       <div className="text-center space-y-2">

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -309,7 +309,7 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => 
             )}
 
             {optionsError && (
-              <p className="text-spark-error text-xs px-1 pt-1">{optionsError}</p>
+              <p className="text-spark-primary text-xs px-1 pt-1">{optionsError}</p>
             )}
             </div>
             {backupCard}

--- a/src/pages/UnclaimedDepositDetailsPage.tsx
+++ b/src/pages/UnclaimedDepositDetailsPage.tsx
@@ -153,15 +153,15 @@ const UnclaimedDepositDetailsPage: React.FC<UnclaimedDepositDetailsPageProps> = 
 
           {/* Error message for failed automatic claim (non-fee error) */}
           {claimError && (
-            <div className="bg-spark-warning/10 border border-spark-warning/30 rounded-2xl p-4">
+            <div className="bg-spark-warn-surface border border-spark-warn-border rounded-2xl p-4">
               <div className="flex items-center gap-3 mb-2">
-                <div className="w-10 h-10 rounded-xl bg-spark-warning/20 flex items-center justify-center shrink-0">
-                  <WarningIcon size="md" className="text-spark-warning" />
+                <div className="w-10 h-10 rounded-xl bg-spark-primary/20 flex items-center justify-center shrink-0">
+                  <WarningIcon size="md" className="text-spark-primary" />
                 </div>
-                <h3 className="font-display font-bold text-spark-warning">Claim Failed</h3>
+                <h3 className="font-display font-bold text-spark-warn-title">Claim Failed</h3>
               </div>
               <div className="pl-[52px]">
-                <p className="text-spark-error text-sm">{claimError}</p>
+                <p className="text-spark-warn-text text-sm">{claimError}</p>
                 <p className="text-spark-primary text-sm mt-2">You can reject to process a refund instead.</p>
               </div>
             </div>


### PR DESCRIPTION
This PR removes the remaining red accents from the app and replaces them with the primary color for a consistent visual language.

## Color updates

| Surface | Color |
| -- | -- |
| Destructive buttons (logout, delete) | brand gold `#D4A574` |
| Error text | gold `#D4A574` (text `#E8C9A8` when shown next to an icon) |
| Warning / error cards | dark surface `#182226`, warm border `#8A7154`, gold icon `#D4A574`, cream title `#E8D3BA` |

It also fixes the logout confirmation dialog. Previously, its backdrop was stacking on top of the side menu's dimming layer, making the background appear almost completely black. The dialog now renders over a single, normal backdrop with the intended dimming level.

Additionally, Contact form labels are now properly aligned.