### PR TITLE
fix(android): remove doubled top spacing on notched pre-Android-15 devices

### DIFF
--- a/src/utils/safeAreaInsets.test.ts
+++ b/src/utils/safeAreaInsets.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 // The module resolves its exports at import time from Capacitor platform
-// checks and navigator.userAgent, so each case mocks those and re-imports.
+// checks, so each case mocks those and re-imports.
 async function loadOnAndroidWebView(chromeMajor: number) {
   vi.resetModules();
   vi.doMock('@capacitor/core', () => ({
@@ -22,15 +22,16 @@ afterEach(() => {
 });
 
 describe('safeAreaInsets on Android native', () => {
-  it('consumes Capacitor safe-area vars with env() fallback and a 0.5rem floor on WebView >= 140 (passthrough insets)', async () => {
-    const { safeAreaTop, safeAreaBottom } = await loadOnAndroidWebView(140);
-    expect(safeAreaTop).toBe('max(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)), 0.5rem)');
-    expect(safeAreaBottom).toBe('max(var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)), 0.5rem)');
+  it('consumes only the Capacitor-injected var with a 0.5rem floor, never env()', async () => {
+    const { safeAreaTop, safeAreaBottom } = await loadOnAndroidWebView(150);
+    expect(safeAreaTop).toBe('max(var(--safe-area-inset-top, 0px), 0.5rem)');
+    expect(safeAreaBottom).toBe('max(var(--safe-area-inset-bottom, 0px), 0.5rem)');
   });
 
-  it('keeps the fixed 0.5rem gap on WebView < 140', async () => {
-    const { safeAreaTop, safeAreaBottom } = await loadOnAndroidWebView(139);
-    expect(safeAreaTop).toBe('0.5rem');
-    expect(safeAreaBottom).toBe('0.5rem');
+  it('is independent of the WebView version (env() misreports on both old and new)', async () => {
+    const oldWebView = await loadOnAndroidWebView(139);
+    const newWebView = await loadOnAndroidWebView(150);
+    expect(oldWebView.safeAreaTop).toBe(newWebView.safeAreaTop);
+    expect(oldWebView.safeAreaBottom).toBe(newWebView.safeAreaBottom);
   });
 });

--- a/src/utils/safeAreaInsets.ts
+++ b/src/utils/safeAreaInsets.ts
@@ -6,77 +6,66 @@ import { Capacitor } from '@capacitor/core';
  *
  * Why this exists:
  *
- * On legacy Android Capacitor WebViews (< 140), `env(safe-area-inset-top)`
- * reports a non-zero value even when `StatusBar.setOverlaysWebView(false)`
- * places the WebView below the opaque status bar. The value is populated
- * asynchronously after the first layout pass, which produces a visible
- * top-padding jump right after the initial render: content briefly sits
- * at the top of the WebView, then suddenly shifts down by the status bar
- * height once CSS re-evaluates. On that path we bypass `env()` entirely
- * and use a fixed 0.5rem gap; native already keeps content clear of the
- * system bars.
+ * On Android native builds, raw `env(safe-area-inset-*)` is not a
+ * trustworthy source, on any WebView version:
  *
- * On WebView >= 140 (Android 15/16 edge-to-edge), Capacitor's SystemBars
- * switches to a "passthrough" inset mode: native applies NO system-bar
- * padding and the web layer must consume the insets itself, otherwise
- * content renders under the status bar (breez/glow-app#87). But raw
- * `env(safe-area-inset-*)` is NOT a reliable carrier there: measured on
- * an Android 16 emulator (WebView 141, viewport-fit=cover, WebView drawn
- * edge-to-edge and receiving a 54px top inset), `env()` still computes
- * to 0px; in practice it only reflects display cutouts. Capacitor knows
- * this, which is why SystemBars injects the real values as
- * `--safe-area-inset-*` custom properties on :root (Android 15+, i.e.
- * every OS version where passthrough padding loss actually occurs). So
- * the passthrough path consumes the Capacitor variable first and falls
- * back to `env()` (Android 14 + new WebView, where native still pads or
- * nothing is injected), with a 0.5rem floor either way. Bonus: Capacitor
- * zeroes the injected bottom inset while the keyboard is visible.
+ * - Legacy WebViews (< 140) report a non-zero top inset even when
+ *   `StatusBar.setOverlaysWebView(false)` places the WebView below the
+ *   opaque status bar. The value is populated asynchronously after the
+ *   first layout pass, which produces a visible top-padding jump right
+ *   after the initial render.
+ * - Modern WebViews (>= 140 ship the Chromium safe-area fix, and the
+ *   WebView auto-updates independently of the OS) surface the display
+ *   cutout inset of the root window. On a notched pre-Android-15 device
+ *   the WebView never extends under the status bar (Capacitor only goes
+ *   edge-to-edge where the OS enforces it, Android 15+), yet
+ *   `env(safe-area-inset-top)` still resolves to the cutout height:
+ *   measured 85px on a Huawei P20 (Android 10, WebView 150, EMUI pins
+ *   layoutInDisplayCutoutMode=always), which double-padded every header
+ *   by one status-bar height. The PWA on the same device resolves 0.
+ *
+ * The trustworthy carrier on Android is the `--safe-area-inset-*`
+ * custom property injected by Capacitor's SystemBars plugin. It is
+ * written exactly on the OS versions where the web layer must consume
+ * insets itself (Android 15+): real values in passthrough mode
+ * (WebView >= 140 + viewport-fit=cover, no native padding), zeros when
+ * native pads the WebView parent instead, and the bottom value is
+ * zeroed while the keyboard is visible. On Android < 15 the variable
+ * is never written and native keeps the WebView clear of the system
+ * bars, so a fixed 0.5rem breathing gap is all the page needs. Hence:
+ * consume the variable with a 0px default and a 0.5rem floor, and
+ * never consult `env()` on Android native.
  *
  * On iOS the safe-area insets work correctly and are necessary for the
  * notch / Dynamic Island; on the desktop / PWA web path they resolve
- * to 0 through the CSS fallback. Every path reads the
- * `--safe-area-inset-*` custom property first and falls back to
- * `env()`: the variable is written by Capacitor's SystemBars on
- * Android native and by webViewportManager on iOS native / standalone
- * (as max(latched inset, env()), so it can only raise the bottom
- * inset, never hide a live env() value); everywhere else it is
- * undefined and `env()` behavior is unchanged.
+ * to 0 through the CSS fallback. Both paths read the
+ * `--safe-area-inset-*` custom property first and fall back to
+ * `env()`: the variable is written by webViewportManager on iOS
+ * native / standalone (as max(latched inset, env()), so it can only
+ * raise the bottom inset, never hide a live env() value); everywhere
+ * else it is undefined and `env()` behavior is unchanged.
  */
 const isAndroidNative =
   typeof window !== 'undefined' &&
   Capacitor.isNativePlatform() &&
   Capacitor.getPlatform() === 'android';
 
-// Android WebView versions itself via the Chrome/NNN token in the UA.
-const webViewMajorVersion = isAndroidNative
-  ? Number(navigator.userAgent.match(/Chrome\/(\d+)/)?.[1] ?? 0)
-  : 0;
-
-// Capacitor's passthrough inset mode (no native system-bar padding)
-// applies on WebView >= 140 with viewport-fit=cover.
-const isPassthroughInsets = webViewMajorVersion >= 140;
-
 /**
  * CSS value for top padding that clears the status bar / notch.
  *
  *   style={{ paddingTop: safeAreaTop }}
  *
- * - Android native, WebView >= 140: max(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)), 0.5rem)
- * - Android native, older WebView : 0.5rem (fixed gap below the opaque status bar)
- * - iOS / web                     : var(--safe-area-inset-top, env(safe-area-inset-top, 0px))
+ * - Android native: max(var(--safe-area-inset-top, 0px), 0.5rem)
+ * - iOS / web     : var(--safe-area-inset-top, env(safe-area-inset-top, 0px))
  */
 export const safeAreaTop = isAndroidNative
-  ? isPassthroughInsets
-    ? 'max(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)), 0.5rem)'
-    : '0.5rem'
+  ? 'max(var(--safe-area-inset-top, 0px), 0.5rem)'
   : 'var(--safe-area-inset-top, env(safe-area-inset-top, 0px))';
 
 /**
  * CSS value for bottom padding that clears the home indicator /
- * navigation bar. Mirrors safeAreaTop on the Android paths.
+ * navigation bar. Mirrors safeAreaTop on the Android path.
  */
 export const safeAreaBottom = isAndroidNative
-  ? isPassthroughInsets
-    ? 'max(var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)), 0.5rem)'
-    : '0.5rem'
+  ? 'max(var(--safe-area-inset-bottom, 0px), 0.5rem)'
   : 'var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))';


### PR DESCRIPTION
This PR removes the doubled top spacing that pushed every screen down on notched devices running Android 14 and below.

Addresses:
- https://github.com/breez/glow-web/issues/290

### Problem

* On Android below 15, on a device with a display notch and an up-to-date system WebView, every screen rendered about one status-bar height too low.
* The browser engine reports a notch inset even though the app's content never sits under the status bar, so the layout padded for the status bar twice.
* Measured on a Huawei P20 running Android 10: the home header sat 87 pixels lower in the app than in the PWA, side by side on the same page.

### Fix

* The layout now only trusts the inset values the native shell provides, which exist exactly on the Android versions that actually draw behind the system bars.
* The small fixed breathing gap is kept everywhere else.
* Android 15 and 16, iOS, and the web are unchanged.

### Test plan

* On a notched device running Android 14 or below: the home header should sit just below the status bar, matching the PWA side by side.
* On Android 15 or 16: unchanged; content still clears the status bar and the gesture bar, including with the keyboard open.
