### PR TITLE
Faster cold start

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,18 +76,12 @@
 
   <title>Glow</title>
 
-  <!-- Fonts - Plus Jakarta Sans for premium UI, JetBrains Mono for numbers.
-       Loaded non-render-blocking (media=print, flipped to all on load) so the
-       first paint is not gated on the cross-origin font CSS round-trip; the
-       UI paints immediately in the system fallback and swaps in (display=swap).
-       noscript keeps it working with JS disabled. -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
-  <noscript>
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-  </noscript>
-  
+  <!-- Fonts (Plus Jakarta Sans for UI, JetBrains Mono for numbers) are
+       self-hosted and bundled via @fontsource, imported from src/index.css.
+       They used to load from fonts.googleapis.com here, which put a
+       third-party network round trip on the first-paint path of a native
+       app and broke first paint offline. -->
+
   <!-- Initial loading styles -->
   <style>
     /* Prevent pull-to-refresh on iOS */
@@ -135,19 +129,48 @@
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
   
-  <!-- Service Worker Registration -->
+  <!-- Service Worker Registration. Web only.
+       In the native shell the assets are already on-device and offline-capable,
+       so the service worker buys nothing: its "network" is just the local asset
+       server, yet it still intercepts every request and re-copies the JS bundle
+       and the multi-megabyte WASM into Cache Storage on every cold start. Skip
+       it there, and unregister (plus drop its caches) for installs that picked
+       one up from an earlier build. -->
   <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
+    (function () {
+      if (!('serviceWorker' in navigator)) return;
+
+      // The native bridge injects window.Capacitor before page scripts run.
+      var cap = window.Capacitor;
+      var isNative = !!(cap && (typeof cap.isNativePlatform === 'function'
+        ? cap.isNativePlatform()
+        : (cap.platform && cap.platform !== 'web')));
+
+      if (isNative) {
+        navigator.serviceWorker.getRegistrations()
+          .then(function (regs) { regs.forEach(function (r) { r.unregister(); }); })
+          .catch(function () { /* nothing registered — fine */ });
+        if (window.caches && caches.keys) {
+          caches.keys()
+            .then(function (keys) {
+              keys.filter(function (k) { return k.indexOf('glow-') === 0; })
+                .forEach(function (k) { caches.delete(k); });
+            })
+            .catch(function () { /* no cache storage — fine */ });
+        }
+        return;
+      }
+
+      window.addEventListener('load', function () {
         navigator.serviceWorker.register('/sw.js')
-          .then((registration) => {
+          .then(function (registration) {
             console.log('SW registered:', registration.scope);
           })
-          .catch((error) => {
+          .catch(function (error) {
             console.log('SW registration failed:', error);
           });
       });
-    }
+    })();
   </script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -76,10 +76,17 @@
 
   <title>Glow</title>
 
-  <!-- Fonts - Plus Jakarta Sans for premium UI, JetBrains Mono for numbers -->
+  <!-- Fonts - Plus Jakarta Sans for premium UI, JetBrains Mono for numbers.
+       Loaded non-render-blocking (media=print, flipped to all on load) so the
+       first paint is not gated on the cross-origin font CSS round-trip; the
+       UI paints immediately in the system fallback and swaps in (display=swap).
+       noscript keeps it working with JS disabled. -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+  <noscript>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  </noscript>
   
   <!-- Initial loading styles -->
   <style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "@capacitor/share": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
         "@capgo/capacitor-navigation-bar": "^8.1.3",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/plus-jakarta-sans": "^5.2.8",
         "@headlessui/react": "^2.2.0",
         "@react-aria/overlays": "^3.32.1",
         "bip39": "^3.1.0",
@@ -631,6 +633,24 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.2.11",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/plus-jakarta-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/plus-jakarta-sans/-/plus-jakarta-sans-5.2.8.tgz",
+      "integrity": "sha512-P5qE49fqdeD+7DXH1KBxmMPlB17LTz1zvBhFH0tFzfnYTKVJVyb0pR6plh0ZGXxcB+Oayb54FZZw3V42/DawTw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@headlessui/react": {
       "version": "2.2.10",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@capacitor/share": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
     "@capgo/capacitor-navigation-bar": "^8.1.3",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/plus-jakarta-sans": "^5.2.8",
     "@headlessui/react": "^2.2.0",
     "@react-aria/overlays": "^3.32.1",
     "bip39": "^3.1.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // Glow Service Worker
-const CACHE_NAME = 'glow-v15';
+const CACHE_NAME = 'glow-v16';
 const STATIC_ASSETS = [
   '/',
   '/index.html',
@@ -52,9 +52,33 @@ self.addEventListener('fetch', (event) => {
   if (!event.request.url.startsWith(self.location.origin)) return;
 
   // Skip API calls and WebSocket connections
-  if (event.request.url.includes('/api/') || 
+  if (event.request.url.includes('/api/') ||
       event.request.url.includes('wss://') ||
       event.request.url.includes('ws://')) {
+    return;
+  }
+
+  // Vite emits content-hashed, immutable files under /assets/ (the hash in the
+  // filename changes whenever the content changes). Serve those cache-first so a
+  // warm launch reads the ~11 MB wasm + JS bundle straight from cache instead of
+  // re-fetching over the network. index.html / navigations stay network-first
+  // (below) so a new deploy is always picked up. Non-hashed static assets
+  // (e.g. /assets/Glow_Logo.svg) don't match and keep the network-first path.
+  const path = new URL(event.request.url).pathname;
+  const isHashedAsset = /\/assets\/[^/]+-[A-Za-z0-9_-]{8,}\.(js|mjs|css|wasm|woff2?|ttf)$/.test(path);
+  if (isHashedAsset) {
+    event.respondWith(
+      caches.match(event.request).then((cached) => {
+        if (cached) return cached;
+        return fetch(event.request).then((response) => {
+          if (response.status === 200) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
+          return response;
+        });
+      })
+    );
     return;
   }
 

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -11,6 +11,7 @@ import type {
   Seed,
 } from '@breeztech/breez-sdk-spark';
 import { connect, initLogging } from '@breeztech/breez-sdk-spark';
+import { sdkReady } from '@/services/sdkReady';
 import { Capacitor } from '@capacitor/core';
 import type { PluginListenerHandle } from '@capacitor/core';
 import { App } from '@capacitor/app';
@@ -64,10 +65,19 @@ function filterOngoingConversionPayments(payments: Payment[]): Payment[] {
 
 let sdkLoggerInitialized = false;
 
-function initSdkLogging() {
+async function initSdkLogging() {
   if (sdkLoggerInitialized) return;
   sdkLoggerInitialized = true;
-  initLogging({ log: (entry: LogEntry) => logSdkMessage(entry.level, entry.line) });
+  // initLogging is a WASM call; wait for the module. Runs on mount, so this
+  // must not assume the SDK is already initialized now that boot is deferred.
+  // The logging bridge is non-critical, so a failed SDK init is swallowed here
+  // (the connect path surfaces the real error to the user).
+  try {
+    await sdkReady();
+    initLogging({ log: (entry: LogEntry) => logSdkMessage(entry.level, entry.line) });
+  } catch {
+    /* SDK unavailable; skip the log bridge. */
+  }
 }
 
 // ============================================
@@ -417,9 +427,13 @@ export function useBreezSdk(
         return;
       }
 
-      initSdkLogging();
+      void initSdkLogging();
       logger.info(LogCategory.PERF, '[onboarding] connect.begin', { restore, source });
 
+      // WASM is initialized lazily now (services/sdkReady). connectWallet is the
+      // first guaranteed SDK use (buildConnectConfig -> defaultConfig, then
+      // connect), so wait for the module here. Usually already resolved.
+      await sdkReady();
       const cfg = buildConnectConfig();
       setConfig(cfg);
 
@@ -709,6 +723,7 @@ export function useBreezSdk(
 
     let connectedSdk: BreezSdk | undefined;
     try {
+      await sdkReady();
       const cfg = buildConnectConfig();
       setConfig(cfg);
 
@@ -1021,7 +1036,7 @@ export function useBreezSdk(
   // captured in Share Logs. Idempotent, so connectWallet's call no-ops.
   // Without this the ~30s register() is a black box in exported logs, and
   // we can't split the WebAuthn ceremony from the Nostr label publish.
-  useEffect(() => { initSdkLogging(); }, []);
+  useEffect(() => { void initSdkLogging(); }, []);
 
   // Check PRF availability on mount
   useEffect(() => {

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -24,7 +24,7 @@ import { isDepositRejected, clearRejectedDeposits } from '../services/depositSta
 import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, type BuyBitcoinProvider } from '../services/settings';
 import { hideSplash } from '../main';
 import {
-  isPrfAvailable,
+  prfAvailability,
   isPasskeyMode,
   setPasskeyMode,
   clearPasskeyMode,
@@ -1038,9 +1038,11 @@ export function useBreezSdk(
   // we can't split the WebAuthn ceremony from the Nostr label publish.
   useEffect(() => { void initSdkLogging(); }, []);
 
-  // Check PRF availability on mount
+  // Check PRF availability on mount. Shared promise: the splash waits on this
+  // same check before revealing, so the welcome screen is never shown with the
+  // wrong onboarding flow (prfAvailable defaults to false until it settles).
   useEffect(() => {
-    isPrfAvailable().then(setPrfAvailable).catch(() => setPrfAvailable(false));
+    prfAvailability().then(setPrfAvailable).catch(() => setPrfAvailable(false));
   }, []);
 
   // Set on the first launch after a fresh install (or cross-device

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,82 @@
 @import 'tailwindcss';
 
+/* Self-hosted font faces, bundled from @fontsource's woff2 files.
+   These used to load from fonts.googleapis.com via a render-blocking <link>,
+   which put a third-party network round trip on a native app's first paint and
+   broke first paint offline.
+
+   font-display is `block`, not `swap`, and these are declared by hand rather
+   than importing @fontsource's stylesheets (which hardcode `swap`). `swap`
+   paints text in the fallback first and restyles when the font arrives, which
+   is a visible flash on every cold start. Blocking briefly is only safe because
+   these files are now local: they come off disk in tens of milliseconds, so the
+   wait is imperceptible. Blocking on the old remote fonts would have risked
+   seconds of invisible text, which is exactly why `swap` was right then and is
+   wrong now. Latin subset, only the weights the UI uses. */
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 300;
+  font-display: block;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-300-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-400-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: block;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-500-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: block;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-600-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: block;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-700-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Plus Jakarta Sans';
+  font-style: normal;
+  font-weight: 800;
+  font-display: block;
+  src: url('@fontsource/plus-jakarta-sans/files/plus-jakarta-sans-latin-800-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 500;
+  font-display: block;
+  src: url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-normal.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 600;
+  font-display: block;
+  src: url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-600-normal.woff2') format('woff2');
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import { initWebViewportManager } from '@/utils/webViewportManager';
 import { installUserAgentStrippingFetch } from '@/utils/stripUserAgentFetch';
 import { logStartupDeviceInfo } from '@/utils/deviceInfo';
 import { startSdkInit } from '@/services/sdkReady';
+import { prfAvailability } from '@/services/passkeyService';
 
 // Strip the SDK's custom User-Agent from outgoing requests before the SDK
 // (or anything else) issues one. User-Agent is a forbidden fetch header
@@ -203,11 +204,29 @@ async function fontsSettled(): Promise<void> {
   ]).catch(() => { /* never block the reveal on a font failure */ });
 }
 
+/**
+ * Hold the reveal until the passkey-availability check has settled.
+ *
+ * The welcome screen picks its onboarding flow from that check and defaults to
+ * the non-passkey one until it resolves, so revealing early flashes the wrong
+ * flow — and a first-time user could tap into mnemonic onboarding in that
+ * window. On native this is a quick bridge call. On web it goes through the
+ * SDK's PasskeyProvider and so waits on the WASM module; that is the deliberate
+ * cost of showing the right screen the first time. Bounded, like the fonts.
+ */
+async function passkeyCheckSettled(): Promise<void> {
+  await Promise.race([
+    prfAvailability(),
+    new Promise((resolve) => setTimeout(resolve, 2500)),
+  ]).catch(() => { /* never block the reveal on a failed check */ });
+}
+
 export async function hideSplash(): Promise<void> {
   const splash = document.getElementById('splash');
   if (!splash) return;
 
-  await fontsSettled();
+  // Both gates run concurrently: the reveal waits on the slower of the two.
+  await Promise.all([fontsSettled(), passkeyCheckSettled()]);
 
   const animation = splash.animate(
     [{ opacity: 1 }, { opacity: 0 }],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ import { logger, LogCategory } from '@/services/logger';
 import { initWebViewportManager } from '@/utils/webViewportManager';
 import { installUserAgentStrippingFetch } from '@/utils/stripUserAgentFetch';
 import { logStartupDeviceInfo } from '@/utils/deviceInfo';
-import initBreezSDK from '@breeztech/breez-sdk-spark';
+import { startSdkInit } from '@/services/sdkReady';
 
 // Strip the SDK's custom User-Agent from outgoing requests before the SDK
 // (or anything else) issues one. User-Agent is a forbidden fetch header
@@ -181,10 +181,12 @@ async function init() {
     logger.info(LogCategory.UI, 'Initializing application');
     // Startup debugging breadcrumb: what hardware / OS / build this ran on.
     void logStartupDeviceInfo();
-    // Initialize WASM module
-    logger.info(LogCategory.SDK, 'Initializing WASM module');
-    await initBreezSDK();
-    logger.info(LogCategory.SDK, 'WASM module initialized successfully');
+
+    // Kick off the ~11 MB SDK WASM compile in the BACKGROUND. We no longer
+    // await it before rendering: the welcome / onboarding screen does not
+    // touch the SDK, so blocking first paint on it just delayed cold start.
+    // Every SDK call site awaits sdkReady() instead (see services/sdkReady.ts).
+    startSdkInit();
 
     // Warm up the native KnownCredentialsStore so the iCloud-synced
     // Keychain (iOS) / Block Store (Android) read pays its first-touch

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,9 @@ import { Capacitor } from '@capacitor/core';
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { Keyboard } from '@capacitor/keyboard';
 import App from './App';
+// Font faces are declared in index.css (pointing at @fontsource's woff2 files)
+// rather than importing @fontsource's own stylesheets, which hardcode
+// font-display: swap. See the comment there.
 import './index.css';
 import { logger, LogCategory } from '@/services/logger';
 import { initWebViewportManager } from '@/utils/webViewportManager';
@@ -157,9 +160,54 @@ initWebViewportManager();
  * Promise), and safe to call fire-and-forget from non-paint-sensitive
  * call sites that just want the splash gone.
  */
+/**
+ * Hold the reveal until the bundled font faces have loaded.
+ *
+ * The faces use `font-display: block` (see index.css), so text is invisible
+ * until its font is ready. Revealing first would expose a screen of empty text
+ * that pops in a moment later. The splash is already covering startup, so it
+ * covers this too and the app is revealed fully styled.
+ *
+ * By the time any caller hides the splash, React has already rendered behind
+ * it, so the fonts are in flight and `fonts.ready` waits for them. The race is
+ * a safety bound: a font that never resolves must not strand the splash
+ * forever. The fonts are local, so in practice this resolves in tens of ms.
+ */
+const BUNDLED_FACES = [
+  '300 1rem "Plus Jakarta Sans"',
+  '400 1rem "Plus Jakarta Sans"',
+  '500 1rem "Plus Jakarta Sans"',
+  '600 1rem "Plus Jakarta Sans"',
+  '700 1rem "Plus Jakarta Sans"',
+  '800 1rem "Plus Jakarta Sans"',
+  '400 1rem "JetBrains Mono"',
+  '500 1rem "JetBrains Mono"',
+  '600 1rem "JetBrains Mono"',
+];
+
+async function fontsSettled(): Promise<void> {
+  if (!document.fonts) return;
+  // Request every bundled face, not just the ones the first screen happens to
+  // use. Browsers load faces lazily, so JetBrains Mono (the balance) is not
+  // fetched by the welcome screen and would load later — blanking the balance
+  // for a moment when the home screen first paints, under font-display: block.
+  // These are local and small, so warming all of them costs tens of ms of
+  // splash that is already on screen.
+  const warm = Promise.all(
+    BUNDLED_FACES.map((f) => document.fonts.load(f).catch(() => undefined)),
+  ).then(() => document.fonts.ready);
+
+  await Promise.race([
+    warm,
+    new Promise((resolve) => setTimeout(resolve, 1500)),
+  ]).catch(() => { /* never block the reveal on a font failure */ });
+}
+
 export async function hideSplash(): Promise<void> {
   const splash = document.getElementById('splash');
   if (!splash) return;
+
+  await fontsSettled();
 
   const animation = splash.animate(
     [{ opacity: 1 }, { opacity: 0 }],

--- a/src/services/passkeyMigrationService.ts
+++ b/src/services/passkeyMigrationService.ts
@@ -17,6 +17,7 @@ import {
   type Seed,
 } from '@breeztech/breez-sdk-spark';
 import { buildConnectConfig } from '@/hooks/buildConnectConfig';
+import { sdkReady } from './sdkReady';
 import { logger, LogCategory } from './logger';
 import { buildBrowserPasskeyClient, recordMigratedSharedCredential, recordMigrationCredentialPair, getActivePasskeyCredentialIdBytes, adoptSessionPasskeyClient, setMigrationSharedCredentialId, getMigrationSharedCredentialIdBytes, bytesToBase64 } from './passkeyService';
 import { LEGACY_RP_ID, SHARED_RP_ID, createPasskeyTimestampLabel, PasskeyCredentialNotFoundError } from './passkeyPrfProvider';
@@ -88,6 +89,7 @@ export function isNoCredentialError(e: unknown): boolean {
 
 /** Connect a temporary SDK for a derived seed. */
 export async function connectForSeed(seed: Seed): Promise<BreezSdk> {
+  await sdkReady();
   const cfg = buildConnectConfig();
   return connect({ config: cfg, seed, storageDir: STORAGE_DIR });
 }

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -22,6 +22,7 @@ import {
   PasskeyTimedOutError,
 } from '@breeztech/breez-sdk-spark/passkey-prf-provider';
 import { Capacitor } from '@capacitor/core';
+import { sdkReady } from './sdkReady';
 import { LocalStorageCredentialRegistry } from './localStorageCredentialRegistry';
 import { rpId, rpName, signalUnknownCredentials, LEGACY_RP_ID } from './passkeyPrfProvider';
 import { logger, LogCategory } from './logger';
@@ -381,11 +382,17 @@ class WebPasskey implements PasskeyApi {
     this.cached = client;
   }
 
-  checkAvailability(): Promise<PasskeyAvailability> {
+  async checkAvailability(): Promise<PasskeyAvailability> {
+    // Runs on mount via isPrfAvailable(). client() builds a PasskeyProvider,
+    // a WASM class, so wait for the module now that SDK boot is deferred.
+    await sdkReady();
     return this.client().checkAvailability();
   }
 
   async register(request: PasskeyRegisterRequest): Promise<RegisterResponse> {
+    // buildBrowserPasskeyClient constructs a WASM PasskeyProvider; wait for the
+    // module (a no-op once ready, which it usually is by the time a user taps).
+    await sdkReady();
     // Fresh client per create rotates user.name (Apple Passwords
     // dedupes by `(rpId, user.name)`) and re-evaluates the Nostr
     // identity, which is fine since register publishes the label.
@@ -410,7 +417,8 @@ class WebPasskey implements PasskeyApi {
     } catch (e) { rethrowWasmAsTyped(e); }
   }
 
-  signIn(request: SignInRequest): Promise<SignInResponse> {
+  async signIn(request: SignInRequest): Promise<SignInResponse> {
+    await sdkReady();
     return this.client().signIn(request);
   }
 
@@ -585,6 +593,9 @@ export async function signInPinnedToActiveCredential(
     // Sign in on a client scoped to the session RP, then retain it as the
     // cached client. signIn primes the Nostr identity, so a later labels()/store
     // is a cache hit rather than a cold, unpinned re-derive (the OS picker).
+    // buildBrowserPasskeyClient constructs a WASM PasskeyProvider, and this runs
+    // at mount for returning passkey users, so wait for the module first.
+    await sdkReady();
     const client = buildBrowserPasskeyClient({ rpId: effectiveRpId });
     response = await client.signIn({ label, allowCredentials });
     const api = getPasskey();

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -770,6 +770,24 @@ export async function clearPasskeyHistory(): Promise<void> {
   invalidatePasskey();
 }
 
+let prfAvailablePromise: Promise<boolean> | null = null;
+
+/**
+ * Memoized isPrfAvailable().
+ *
+ * The welcome screen picks its onboarding flow from this, and defaults to the
+ * non-passkey one until it resolves. The splash waits on it (main.tsx) so a
+ * first-time user never sees the wrong flow flash past — or, worse, taps into
+ * mnemonic onboarding during that window. Shared so the check runs once and
+ * both callers observe the same result.
+ */
+export function prfAvailability(): Promise<boolean> {
+  if (!prfAvailablePromise) {
+    prfAvailablePromise = isPrfAvailable().catch(() => false);
+  }
+  return prfAvailablePromise;
+}
+
 /** Collapse the SDK's four availability variants to a single bool. */
 export async function isPrfAvailable(): Promise<boolean> {
   const ua = navigator.userAgent;

--- a/src/services/sdkReady.ts
+++ b/src/services/sdkReady.ts
@@ -1,0 +1,44 @@
+import initBreezSDK from '@breeztech/breez-sdk-spark';
+import { logger, LogCategory } from '@/services/logger';
+
+/**
+ * The Breez SDK ships as a ~11 MB WASM module. We deliberately do NOT block
+ * first paint on it: main.tsx renders <App/> immediately and kicks this off in
+ * the background via startSdkInit(). The welcome / onboarding screen never
+ * touches the SDK, so it can paint and become interactive while the module
+ * compiles.
+ *
+ * Every runtime SDK call (connect, initLogging, defaultConfig, the browser
+ * PasskeyProvider) must `await sdkReady()` first, since a call before the
+ * module is instantiated throws. In the common case the module is ready long
+ * before the user taps, so the await resolves immediately.
+ */
+let readyPromise: Promise<void> | null = null;
+
+/** Begin loading + instantiating the SDK WASM module. Idempotent. */
+export function startSdkInit(): Promise<void> {
+  if (!readyPromise) {
+    readyPromise = (async () => {
+      const t0 = performance.now();
+      logger.info(LogCategory.SDK, 'Initializing WASM module');
+      await initBreezSDK();
+      logger.info(LogCategory.SDK, 'WASM module initialized successfully', {
+        ms: Math.round(performance.now() - t0),
+      });
+    })();
+    // Attach a logging handler so a failed init never surfaces as an unhandled
+    // rejection when nobody happens to be awaiting it yet (e.g. a user just
+    // looking at the welcome screen). Awaiters still observe the rejection.
+    readyPromise.catch((e) => {
+      logger.error(LogCategory.SDK, 'WASM module initialization failed', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    });
+  }
+  return readyPromise;
+}
+
+/** Resolves once the SDK WASM module is instantiated. Starts init if needed. */
+export function sdkReady(): Promise<void> {
+  return startSdkInit();
+}


### PR DESCRIPTION
This PR reduces cold-start time by removing unnecessary work from the critical startup path.

Addresses:
- https://github.com/breez/glow-app/issues/113

### Performance improvements


* **Deferred SDK initialization**

  * The initial screen no longer waits for the SDK to finish initializing.
  * The SDK now initializes in the background, and only flows that require it wait when it's actually needed.
  * This removes the largest startup bottleneck, with greater improvements on slower devices.

* **Self-hosted fonts**

  * Fonts are bundled with the app instead of fetched from Google Fonts, removing a third-party network round trip from first paint and fixing first paint offline.
  * Because the files are local, text waits for them rather than swapping in from a fallback, so there's no flash.
  * The splash stays up until the fonts and the passkey check have settled, so the first screen is revealed fully styled and with the correct onboarding flow.

* **No service worker on native**

  * In the native app it only intercepted local asset requests and re-copied several megabytes into Cache Storage on every launch.
  * It's no longer registered there, and any worker left by an earlier build is removed on startup.

* **Improved web caching**

  * Repeat visits reuse cached static assets instead of downloading several megabytes on every launch.
  * This significantly improves startup time for returning users.
