### PR TITLE
reorganize side menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ const AppContent: React.FC = () => {
   // Where the open BackupPage was launched from: the side menu (web) or
   // the Security & Backup page (native). Drives its back target and
   // whether SecurityPage stays mounted beneath it.
-  const [backupSource, setBackupSource] = useState<'menu' | 'security'>('menu');
+  const [backupSource, setBackupSource] = useState<'settings' | 'security'>('settings');
   const [refundAnimationDirection, setRefundAnimationDirection] = useState<'left' | 'up'>('left');
   const [buyProvidersSource, setBuyProvidersSource] = useState<'wallet' | 'settings'>('wallet');
   const [passkeySdkConnected, setPasskeySdkConnected] = useState(false);
@@ -218,11 +218,13 @@ const AppContent: React.FC = () => {
   useBackButton(useCallback(() => {
     switch (currentScreen) {
       case 'settings':
-      case 'backup':
-      case 'security':
       case 'getRefund':
         setUserScreen('wallet');
         return true;
+      case 'backup':
+        setUserScreen(backupSource === 'security' ? 'security' : 'settings');
+        return true;
+      case 'security':
       case 'fiatCurrencies':
       case 'passkeySettings':
         setUserScreen('settings');
@@ -252,7 +254,7 @@ const AppContent: React.FC = () => {
         // (same as pressing Home). Matches standard Android UX.
         return false;
     }
-  }, [currentScreen, buyProvidersSource]), true);
+  }, [currentScreen, buyProvidersSource, backupSource]), true);
 
   // Render screens
   const renderCurrentScreen = () => {
@@ -329,8 +331,6 @@ const AppContent: React.FC = () => {
             setUserScreen('getRefund');
           }}
           onOpenSettings={() => setUserScreen('settings')}
-          onOpenBackup={() => { setBackupSource('menu'); setUserScreen('backup'); }}
-          onOpenSecurity={() => setUserScreen('security')}
           onOpenBuyProviders={() => { setBuyProvidersSource('wallet'); setUserScreen('buyProviders'); }}
           onBuyBitcoin={sdk.handleBuyBitcoin}
           network={sdk.config?.network}
@@ -351,6 +351,8 @@ const AppContent: React.FC = () => {
         onOpenFiatCurrencies={() => setUserScreen('fiatCurrencies')}
         onOpenBuyProviders={() => { setBuyProvidersSource('settings'); setUserScreen('buyProviders'); }}
         onOpenPasskeySettings={() => setUserScreen('passkeySettings')}
+        onOpenSecurity={() => setUserScreen('security')}
+        onOpenBackup={() => { setBackupSource('settings'); setUserScreen('backup'); }}
       />
     );
 
@@ -534,17 +536,18 @@ const AppContent: React.FC = () => {
       // Security & Backup share one branch so SecurityPage stays
       // mounted (gate passed, options state intact) underneath an
       // opened BackupPage — returning from Backup must not re-run the
-      // PIN/biometric gate. On web, Backup opens directly from the
-      // menu and SecurityPage never mounts.
+      // PIN/biometric gate. On web, Backup opens directly from
+      // Settings and SecurityPage never mounts.
       case 'backup':
       case 'security': {
         const backupFromSecurity = backupSource === 'security';
         return (
           <>
             {renderWalletPage()}
+            {renderSettingsPage()}
             {(currentScreen === 'security' || backupFromSecurity) && (
               <SecurityPage
-                onBack={() => setUserScreen('wallet')}
+                onBack={() => setUserScreen('settings')}
                 onOpenBackup={() => {
                   setBackupSource('security');
                   setUserScreen('backup');
@@ -553,8 +556,8 @@ const AppContent: React.FC = () => {
             )}
             {currentScreen === 'backup' && (
               <BackupPage
-                closeStyle={backupFromSecurity ? 'back' : 'close'}
-                onBack={() => setUserScreen(backupFromSecurity ? 'security' : 'wallet')}
+                closeStyle="back"
+                onBack={() => setUserScreen(backupFromSecurity ? 'security' : 'settings')}
               />
             )}
           </>

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import { Transition, TransitionChild } from '@headlessui/react';
 import { isPasskeyMode } from '@/services/passkeyService';
-import { RefundIcon, BackupIcon, SettingsIcon, LogoutIcon, CloseIcon, AlertTriangleIcon, LockIcon } from './Icons';
-import { isAppLockSupported } from '@/services/appLock';
+import { RefundIcon, SettingsIcon, LogoutIcon, CloseIcon, AlertTriangleIcon } from './Icons';
 import { safeAreaTop, safeAreaBottom } from '../utils/safeAreaInsets';
 import { useStatusBarColor } from '../hooks/useStatusBarColor';
 import { STATUS_BAR_SURFACE, STATUS_BAR_DIALOG_SCRIM } from '../utils/statusBarManager';
@@ -49,13 +48,11 @@ interface SideMenuProps {
   onClose: () => void;
   onLogout: () => void;
   onOpenSettings: () => void;
-  onOpenBackup: () => void;
-  onOpenSecurity: () => void;
   onOpenRefund?: () => void;
   hasRejectedDeposits?: boolean;
 }
 
-const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSettings, onOpenBackup, onOpenSecurity, onOpenRefund, hasRejectedDeposits = false }) => {
+const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSettings, onOpenRefund, hasRejectedDeposits = false }) => {
   // While the drawer is open, push the solid spark-surface tone over
   // the wallet page's glass tint so the status bar matches the drawer
   // panel's solid bg. Tied to isOpen so popping happens on close.
@@ -125,18 +122,6 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
       onClick: () => closeDrawerThen(onOpenRefund),
       highlight: true
     }] : []),
-    // Native folds Backup into a single Security & Backup page (Misty
-    // parity), so the recovery phrase sits behind the same app-lock
-    // gate. The PWA has no app lock and keeps a top-level Backup.
-    ...(isAppLockSupported() ? [{
-      icon: <LockIcon />,
-      label: 'Security & Backup',
-      onClick: () => closeDrawerThen(onOpenSecurity)
-    }] : [{
-      icon: <BackupIcon />,
-      label: 'Backup',
-      onClick: () => closeDrawerThen(onOpenBackup)
-    }]),
     {
       icon: <SettingsIcon />,
       label: 'Settings',
@@ -274,7 +259,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
                   </div>
 
                   <h3 className="font-display text-lg font-semibold text-spark-text-primary text-center mb-2">
-                    Logout Warning
+                    Logout
                   </h3>
                   <p className="text-spark-text-secondary text-sm text-center mb-6">
                     {isPasskey

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -187,7 +187,7 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => 
         return (
           <div className="space-y-4">
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-              <h3 className="font-display font-semibold text-spark-text-primary mb-3">App Lock</h3>
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Lock Screen</h3>
               <button
                 className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
                 type="button"
@@ -228,7 +228,7 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => 
         return (
           <div className="space-y-4">
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-4 space-y-2">
-            <h3 className="font-display font-semibold text-spark-text-primary mb-3">App Lock</h3>
+            <h3 className="font-display font-semibold text-spark-text-primary mb-3">Lock Screen</h3>
             {/* Deactivate PIN (Misty pattern: an always-on switch whose
                 only action is turning protection off) */}
             <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable } from '
 import type { Config, Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '@/contexts/WalletContext';
 import { CurrencyIcon, ChevronRightIcon, DownloadIcon, ShieldCheckIcon } from '../components/Icons';
+import { isAppLockSupported } from '@/services/appLock';
 import SlideInPage from '../components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs, exportDatabaseState } from '@/services/logExport';
@@ -17,6 +18,8 @@ interface SettingsPageProps {
   onOpenFiatCurrencies: () => void;
   onOpenBuyProviders: () => void;
   onOpenPasskeySettings: () => void;
+  onOpenSecurity: () => void;
+  onOpenBackup: () => void;
 }
 
 const SettingsPage: React.FC<SettingsPageProps> = ({
@@ -25,6 +28,8 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   onOpenFiatCurrencies,
   onOpenBuyProviders,
   onOpenPasskeySettings,
+  onOpenSecurity,
+  onOpenBackup,
 }) => {
   const wallet = useWallet();
   const {
@@ -189,6 +194,22 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
           {/* Order: page nav, exports, reconnect, toggles, inputs.
               The "Save Changes" footer applies the toggles + inputs;
               everything above it commits on tap. */}
+
+          {/* Backup. Native routes through the Security & Backup page
+              (Misty parity) so the recovery phrase sits behind the
+              app-lock gate. The PWA has no app lock, so it opens
+              Backup directly. */}
+          <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+            <h3 className="font-display font-semibold text-spark-text-primary mb-3">Backup</h3>
+            <button
+              className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+              type="button"
+              onClick={isAppLockSupported() ? onOpenSecurity : onOpenBackup}
+            >
+              <span>Show Recovery Phrase</span>
+              <ChevronRightIcon size="md" />
+            </button>
+          </div>
 
           {/* Display */}
           <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -33,8 +33,6 @@ interface WalletPageProps {
   hasRejectedDeposits: boolean;
   onOpenGetRefund: (source?: 'menu' | 'icon') => void;
   onOpenSettings: () => void;
-  onOpenBackup: () => void;
-  onOpenSecurity: () => void;
   onOpenBuyProviders: () => void;
   onBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
   network?: Network;
@@ -51,8 +49,6 @@ const WalletPage: React.FC<WalletPageProps> = ({
   hasRejectedDeposits,
   onOpenGetRefund,
   onOpenSettings,
-  onOpenBackup,
-  onOpenSecurity,
   onOpenBuyProviders,
   onBuyBitcoin,
   network,
@@ -365,8 +361,6 @@ const WalletPage: React.FC<WalletPageProps> = ({
         onClose={() => setIsMenuOpen(false)}
         onLogout={onLogout}
         onOpenSettings={onOpenSettings}
-        onOpenBackup={onOpenBackup}
-        onOpenSecurity={onOpenSecurity}
         onOpenRefund={() => onOpenGetRefund('menu')}
         hasRejectedDeposits={hasRejectedDeposits}
       />


### PR DESCRIPTION
This PR moves Backup under Settings and removes the alarm from the logout dialog title.

### Changes
- Move Backup out of the side menu into Settings, as a single "Show Recovery Phrase" entry.
  - On native it opens behind the lock gate, as before.
  - On web it opens the recovery phrase directly.
- Leave the side menu with Settings and Logout, plus Get Refund when there are deposits to refund.
- Return to Settings when leaving Backup, instead of the home screen. The Android back button follows the same path.
- Retitle the logout dialog from "Logout Warning" to "Logout". The icon and message below it are unchanged.
- Rename the "App Lock" headings to "Lock Screen".

### Test plan
Native only, since the lock gate does not exist on web:
- With a PIN set, Settings then Show Recovery Phrase asks for the PIN or biometrics before revealing anything.
- Leaving Backup lands on Settings, and leaving Settings lands on the home screen.
- The Android back button follows the same path in reverse.
- Creating and changing a PIN still works under the renamed Lock Screen heading.