### PR TITLE
Preserve Stable Balance setting across app upgrades

### DIFF
--- a/src/contexts/StableBalanceContext.test.ts
+++ b/src/contexts/StableBalanceContext.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { resolveStableLabel } from './StableBalanceContext';
+
+describe('resolveStableLabel', () => {
+  it('uses the SDK label when the SDK has one', () => {
+    expect(resolveStableLabel('USDB', null)).toEqual({ activeLabel: 'USDB', recoverToSdk: false });
+  });
+
+  it('lets the SDK win over a stale native backup', () => {
+    expect(resolveStableLabel('USDB', 'EUR')).toEqual({ activeLabel: 'USDB', recoverToSdk: false });
+  });
+
+  it('recovers from the native backup when the SDK comes up empty (the wipe case)', () => {
+    expect(resolveStableLabel(null, 'USDB')).toEqual({ activeLabel: 'USDB', recoverToSdk: true });
+  });
+
+  it('stays inactive when neither has a label (genuine deactivation)', () => {
+    expect(resolveStableLabel(null, null)).toEqual({ activeLabel: null, recoverToSdk: false });
+  });
+});

--- a/src/contexts/StableBalanceContext.tsx
+++ b/src/contexts/StableBalanceContext.tsx
@@ -10,7 +10,7 @@ import {
   getTokenAmountFromPayment,
 } from '../utils/tokenFormatting';
 import { logger, LogCategory } from '../services/logger';
-import { getCachedStableTicker, setCachedStableTicker } from '../services/settings';
+import { getCachedStableTicker, setCachedStableTicker, getNativeStableTicker, setNativeStableTicker } from '../services/settings';
 import { formatWithSpaces } from '@/utils/formatNumber';
 
 interface StableBalanceContextValue {
@@ -30,6 +30,30 @@ interface StableBalanceProviderProps {
   children: React.ReactNode;
 }
 
+export interface StableLabelResolution {
+  /** The label to display, or null for BTC mode. */
+  activeLabel: string | null;
+  /** True when the label came from the native backup and must be re-applied to the SDK. */
+  recoverToSdk: boolean;
+}
+
+/**
+ * Reconcile the SDK's active-label read with the durable native backup.
+ *
+ * The SDK wins when it has a value. When it reports null but the native backup
+ * still holds a label, the SDK's local store was wiped (app upgrade / cleared
+ * WebView data) — recover by re-applying that label to the SDK rather than
+ * treating the null as an intentional deactivation.
+ */
+export function resolveStableLabel(
+  sdkLabel: string | null,
+  nativeLabel: string | null
+): StableLabelResolution {
+  if (sdkLabel) return { activeLabel: sdkLabel, recoverToSdk: false };
+  if (nativeLabel) return { activeLabel: nativeLabel, recoverToSdk: true };
+  return { activeLabel: null, recoverToSdk: false };
+}
+
 export const StableBalanceProvider: React.FC<StableBalanceProviderProps> = ({ children }) => {
   const { sdk, isConnected } = useWalletConnection();
   const { fiatRates, fiatCurrencies } = useFiatData();
@@ -46,9 +70,16 @@ export const StableBalanceProvider: React.FC<StableBalanceProviderProps> = ({ ch
     return null;
   }, [activeLabel]);
 
-  // Load active label from SDK on connect. activeLabel is cache-seeded
-  // so the UI shows the correct mode instantly on reload; the SDK read
-  // here corrects any drift.
+  // Resolve the active label on connect. activeLabel is localStorage-seeded so
+  // the UI shows the correct mode instantly on reload; this read reconciles it
+  // against the SDK and the durable native backup.
+  //
+  // The SDK stores the label in its local IndexedDB, which shares the WebView
+  // storage partition with the localStorage cache — an app upgrade / cleared
+  // WebView data wipes both, and the SDK then reports inactive. So a null from
+  // the SDK is not authoritative on its own: if the native backup (which
+  // survives that wipe) still holds a label, the SDK's store was reset and we
+  // recover by re-applying the label to it, rather than clobbering the backup.
   useEffect(() => {
     if (!isConnected || !sdk) return;
 
@@ -58,9 +89,44 @@ export const StableBalanceProvider: React.FC<StableBalanceProviderProps> = ({ ch
       try {
         const settings = await sdk.getUserSettings();
         if (cancelled) return;
-        const label = settings.stableBalanceActiveLabel ?? null;
-        setActiveLabel(label);
-        setCachedStableTicker(label);
+        const sdkLabel = settings.stableBalanceActiveLabel ?? null;
+        // Only read the native backup when the SDK has nothing — the SDK wins
+        // whenever it has a value, so there's no need to touch Preferences.
+        const nativeLabel = sdkLabel ? null : await getNativeStableTicker();
+        if (cancelled) return;
+
+        const { activeLabel: resolved, recoverToSdk } = resolveStableLabel(sdkLabel, nativeLabel);
+
+        if (recoverToSdk && resolved) {
+          logger.info(LogCategory.SDK, 'Recovering stable balance from native backup after empty SDK settings', {
+            label: resolved,
+          });
+          try {
+            await sdk.updateUserSettings({ stableBalanceActiveLabel: { type: 'set', label: resolved } });
+          } catch (e) {
+            // The SDK rejects a label that isn't in its configured token list.
+            // Stay inactive rather than display a mode the SDK isn't actually
+            // in — the same rule the SDK applies to an unknown cached label.
+            // The native backup is deliberately left alone: a label that's
+            // invalid under this build may be valid again under the next, and
+            // clearing it here would destroy the setting for good.
+            logger.error(LogCategory.SDK, 'Failed to re-apply stable balance label to SDK', {
+              error: e instanceof Error ? e.message : String(e),
+            });
+            if (cancelled) return;
+            setActiveLabel(null);
+            setCachedStableTicker(null);
+            return;
+          }
+          if (cancelled) return;
+        }
+
+        setActiveLabel(resolved);
+        setCachedStableTicker(resolved);
+        // Backfill the durable native backup from the SDK's value (covers
+        // installs that predate native persistence). Never write it from a
+        // null SDK read — that would clobber a backup we may need to recover.
+        if (sdkLabel) await setNativeStableTicker(sdkLabel);
       } catch (e) {
         logger.warn(LogCategory.SDK, 'Failed to load user settings for stable balance', {
           error: e instanceof Error ? e.message : String(e),
@@ -122,12 +188,14 @@ export const StableBalanceProvider: React.FC<StableBalanceProviderProps> = ({ ch
         });
         setActiveLabel(label);
         setCachedStableTicker(label);
+        await setNativeStableTicker(label);
       } else {
         await sdk.updateUserSettings({
           stableBalanceActiveLabel: { type: 'unset' },
         });
         setActiveLabel(null);
         setCachedStableTicker(null);
+        await setNativeStableTicker(null);
       }
     } catch (e) {
       logger.error(LogCategory.SDK, 'Failed to toggle stable balance', {

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,6 +1,7 @@
 import { MaxFee } from "@breeztech/breez-sdk-spark/web";
 import type { Network } from "@breeztech/breez-sdk-spark";
 import { Capacitor } from "@capacitor/core";
+import { Preferences } from "@capacitor/preferences";
 /** Provider identifiers matching the SDK's BuyBitcoinRequest tagged union */
 export type BuyBitcoinProvider = 'moonpay' | 'cashApp';
 
@@ -158,6 +159,38 @@ export function setCachedStableTicker(ticker: string | null): void {
     setCachedItem(STABLE_TICKER_KEY, ticker);
   } else {
     removeCachedItem(STABLE_TICKER_KEY);
+  }
+}
+
+/**
+ * Durable native mirror of the active stable ticker.
+ *
+ * The localStorage cache above is a same-partition value: on native it lives
+ * in the WebView storage that shares fate with the SDK's IndexedDB, so an app
+ * upgrade / cleared WebView data wipes both and the mode silently reverts to
+ * BTC. Preferences writes to the native tier (Android SharedPreferences / iOS
+ * UserDefaults, the same tier as the seed vault), which survives a WebView-
+ * storage wipe — so it's the recovery source when the SDK comes up empty.
+ * On web, Preferences falls back to localStorage (no durability gain, no harm).
+ */
+export async function getNativeStableTicker(): Promise<string | null> {
+  try {
+    const { value } = await Preferences.get({ key: STABLE_TICKER_KEY });
+    return value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setNativeStableTicker(ticker: string | null): Promise<void> {
+  try {
+    if (ticker) {
+      await Preferences.set({ key: STABLE_TICKER_KEY, value: ticker });
+    } else {
+      await Preferences.remove({ key: STABLE_TICKER_KEY });
+    }
+  } catch {
+    // Best-effort: the localStorage cache still covers the non-wipe path.
   }
 }
 


### PR DESCRIPTION
This PR prevents Stable Balance from being disabled if WebView storage is cleared during an app upgrade.

### Changes
- Persist the Stable Balance setting in native storage.
- On startup:
  - Use the label from WebView storage when available.
  - If WebView storage is empty but native storage contains a label, restore it to WebView storage.
  - If the restored label is rejected, leave Stable Balance disabled and keep the native copy.
  - If neither storage contains a label, leave Stable Balance disabled.
- Preserve existing web behavior, where browser storage remains the backing store.
- Add unit tests covering all startup scenarios.