### PR TITLE
Hand the native launch splash off to the DOM splash at first paint

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom/client';
-import { Capacitor } from '@capacitor/core';
+import { Capacitor, registerPlugin } from '@capacitor/core';
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { Keyboard } from '@capacitor/keyboard';
 import App from './App';
@@ -243,8 +243,36 @@ export async function hideSplash(): Promise<void> {
   }
 }
 
+// The native launch splash (@capacitor/splash-screen) is pinned up for a
+// fixed `launchShowDuration` (2s, capacitor.config.ts) before it auto-hides.
+// That floor is a holdover — the in-HTML `#splash` (same #0f0f18 bg + centred
+// logo) is already painted by the time this module runs, so we can hand the
+// native splash off to it as soon as the WebView is up instead of waiting out
+// the timer. This is the same native→DOM handoff that used to happen at the 2s
+// mark, just moved to first-paint, so it removes ~1.3s of fixed splash from a
+// cold start without introducing a new visual seam. Accessed via registerPlugin
+// (the plugin is a native-shell dependency, not bundled into the web build), so
+// on web the proxy call simply rejects and the catch swallows it. The
+// launchShowDuration auto-hide still stands as the fallback if JS never runs.
+const NativeSplashScreen = registerPlugin<{
+  hide(options?: { fadeOutDuration?: number }): Promise<void>;
+}>('SplashScreen');
+
+function handOffNativeSplash(): void {
+  if (!Capacitor.isNativePlatform()) return;
+  // One frame's grace so the DOM #splash is guaranteed painted before the
+  // native splash lifts off it (belt-and-braces; the module running already
+  // implies index.html parsed).
+  requestAnimationFrame(() => {
+    void NativeSplashScreen.hide({ fadeOutDuration: 200 }).catch(() => {
+      /* web (no native plugin) or already hidden — nothing to do */
+    });
+  });
+}
+
 async function init() {
   try {
+    handOffNativeSplash();
     logger.info(LogCategory.UI, 'Initializing application');
     // Startup debugging breadcrumb: what hardware / OS / build this ran on.
     void logStartupDeviceInfo();


### PR DESCRIPTION
This PR speeds up cold start on native by removing a fixed delay before the launch splash hands off to the app.

### Background

The native launch splash is held for a fixed two seconds before it fades, regardless of how fast the app is ready. Underneath it, the in-app splash (identical dark background and centred logo) is already on screen by the time the app starts running. So for the first two seconds the app is just waiting out a timer behind a splash it could already replace.

### Changes

- Hide the native launch splash as soon as the WebView is up, so it hands off to the identical in-app splash immediately instead of waiting out the fixed duration. This removes roughly 1.3 seconds of fixed splash from a cold start.
- Keep the existing fixed-duration auto-hide as a fallback for the case where the app never starts.
- No change on web, where there is no native splash.

### Scope

This helps first launches (onboarding), where the app is ready well before the two-second timer. It does not change the wait for returning users, whose cold start is dominated by the SDK connect step (tracked separately).

### Test plan

Needs a device pass on both platforms, since the launch splash only exists on native:

- Cold launch on iOS and Android: the splash gives way to the app noticeably sooner, with no flash of a blank or differently-coloured frame at the handoff, and no visible jump of the logo.
- First-run onboarding: the welcome screen appears sooner than before.
- Force-quit and relaunch a few times to confirm the handoff is consistent.