### PR TITLE
Fix stale wallet data when the iOS PWA resumes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -322,6 +322,7 @@ const AppContent: React.FC = () => {
           unclaimedDeposits={sdk.unclaimedDeposits}
           refreshWalletData={sdk.refreshWalletData}
           isSyncing={sdk.isSyncing}
+          lastSyncedAt={sdk.lastSyncedAt}
           error={sdk.error}
           onClearError={sdk.clearError}
           onLogout={handleLogout}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -322,7 +322,6 @@ const AppContent: React.FC = () => {
           unclaimedDeposits={sdk.unclaimedDeposits}
           refreshWalletData={sdk.refreshWalletData}
           isSyncing={sdk.isSyncing}
-          lastSyncedAt={sdk.lastSyncedAt}
           error={sdk.error}
           onClearError={sdk.clearError}
           onLogout={handleLogout}

--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -22,7 +22,6 @@ interface CollapsingWalletHeaderProps {
   onOpenBuyBitcoin?: () => void;
   isBuyLoading?: boolean;
   isSyncing?: boolean;
-  lastSyncedAt?: number | null;
   refreshWalletData?: () => Promise<void>;
   hasRejectedDeposits?: boolean;
   onOpenGetRefund?: () => void;
@@ -35,7 +34,6 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
   onOpenBuyBitcoin,
   isBuyLoading,
   isSyncing,
-  lastSyncedAt,
   refreshWalletData,
   hasRejectedDeposits,
   onOpenGetRefund,
@@ -240,23 +238,6 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
     ? stableBalance.displayConfig.symbol
     : '₿';
 
-  // Coarse tick so the stale-data hint appears/ages without a re-render
-  // being triggered by anything else.
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 30_000);
-    return () => clearInterval(id);
-  }, []);
-  // A resumed iOS PWA can fail its resync silently, so past 3 minutes we
-  // say how old the data is instead of implying it is live.
-  const staleMins = lastSyncedAt != null ? Math.floor((now - lastSyncedAt) / 60_000) : null;
-  const staleLabel = staleMins != null && staleMins >= 3
-    ? staleMins >= 1440 ? `${Math.floor(staleMins / 1440)}d`
-      : staleMins >= 60 ? `${Math.floor(staleMins / 60)}h`
-        : `${staleMins}m`
-    : null;
-  const showStale = !isSyncing && staleLabel != null;
-
   if (!walletInfo) return null;
 
   const balanceSuffix = stableBalance.isActive ? 'USD' : 'sats';
@@ -351,15 +332,9 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
               <span className="w-1.5 h-1.5 rounded-full bg-spark-primary animate-pulse" />
               Syncing
             </span>
-            {showStale && (
-              <span className="absolute text-spark-primary/80 text-xs font-display font-medium tracking-widest uppercase inline-flex items-center gap-1.5">
-                <span className="w-1.5 h-1.5 rounded-full bg-spark-primary animate-pulse" />
-                Updated {staleLabel} ago
-              </span>
-            )}
             <span
               className={`absolute text-spark-text-muted text-xs font-display font-medium tracking-widest uppercase transition-opacity duration-300 ${
-                isSyncing || showStale ? 'opacity-0 pointer-events-none' : 'opacity-100'
+                isSyncing ? 'opacity-0' : 'opacity-100'
               }`}
             >
               Balance

--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -22,7 +22,7 @@ interface CollapsingWalletHeaderProps {
   onOpenBuyBitcoin?: () => void;
   isBuyLoading?: boolean;
   isSyncing?: boolean;
-  refreshWalletData?: () => Promise<void>;
+  refreshWalletData?: () => Promise<boolean>;
   hasRejectedDeposits?: boolean;
   onOpenGetRefund?: () => void;
 }

--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -22,6 +22,7 @@ interface CollapsingWalletHeaderProps {
   onOpenBuyBitcoin?: () => void;
   isBuyLoading?: boolean;
   isSyncing?: boolean;
+  lastSyncedAt?: number | null;
   refreshWalletData?: () => Promise<void>;
   hasRejectedDeposits?: boolean;
   onOpenGetRefund?: () => void;
@@ -34,6 +35,7 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
   onOpenBuyBitcoin,
   isBuyLoading,
   isSyncing,
+  lastSyncedAt,
   refreshWalletData,
   hasRejectedDeposits,
   onOpenGetRefund,
@@ -238,6 +240,23 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
     ? stableBalance.displayConfig.symbol
     : '₿';
 
+  // Coarse tick so the stale-data hint appears/ages without a re-render
+  // being triggered by anything else.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+  // A resumed iOS PWA can fail its resync silently, so past 3 minutes we
+  // say how old the data is instead of implying it is live.
+  const staleMins = lastSyncedAt != null ? Math.floor((now - lastSyncedAt) / 60_000) : null;
+  const staleLabel = staleMins != null && staleMins >= 3
+    ? staleMins >= 1440 ? `${Math.floor(staleMins / 1440)}d`
+      : staleMins >= 60 ? `${Math.floor(staleMins / 60)}h`
+        : `${staleMins}m`
+    : null;
+  const showStale = !isSyncing && staleLabel != null;
+
   if (!walletInfo) return null;
 
   const balanceSuffix = stableBalance.isActive ? 'USD' : 'sats';
@@ -332,9 +351,15 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
               <span className="w-1.5 h-1.5 rounded-full bg-spark-primary animate-pulse" />
               Syncing
             </span>
+            {showStale && (
+              <span className="absolute text-spark-primary/80 text-xs font-display font-medium tracking-widest uppercase inline-flex items-center gap-1.5">
+                <span className="w-1.5 h-1.5 rounded-full bg-spark-primary animate-pulse" />
+                Updated {staleLabel} ago
+              </span>
+            )}
             <span
               className={`absolute text-spark-text-muted text-xs font-display font-medium tracking-widest uppercase transition-opacity duration-300 ${
-                isSyncing ? 'opacity-0' : 'opacity-100'
+                isSyncing || showStale ? 'opacity-0 pointer-events-none' : 'opacity-100'
               }`}
             >
               Balance

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -1306,12 +1306,23 @@ export function useBreezSdk(
         const s = sdkRef.current;
         if (!s) return;
         try {
-          await s.syncWallet({});
-          // The fetchers absorb their SDK errors and report them as
-          // `false`, so a failed read falls through to the retry pass
-          // the same way a syncWallet throw does.
-          const refreshed = await Promise.all([refreshWalletData(false), fetchUnclaimedDeposits()]);
-          if (refreshed.every(Boolean)) return;
+          // 30s cap so a hung SDK call cannot wedge resyncInFlightRef
+          // forever (the PWA page never reloads, so nothing else would
+          // clear it). The race releases the guard without cancelling
+          // the call; a zombie sync finishing late is harmless.
+          await Promise.race([
+            (async () => {
+              await s.syncWallet({});
+              // The fetchers absorb their SDK errors and report them as
+              // `false`, so a failed read retries the same way a
+              // syncWallet throw does.
+              const refreshed = await Promise.all([refreshWalletData(false), fetchUnclaimedDeposits()]);
+              if (!refreshed.every(Boolean)) throw new Error('refresh incomplete');
+            })(),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('foreground resync timeout')), 30000)),
+          ]);
+          return;
         } catch (e) {
           logger.warn(LogCategory.SDK, 'Foreground resync failed', { attempt, error: formatError(e) });
         }

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -151,8 +151,6 @@ export interface BreezSdkState {
   error: string | null;
   hasRejectedDeposits: boolean;
   celebrationPayment: Payment | null;
-  /** Epoch ms of the last known-fresh wallet data; null before the first sync. */
-  lastSyncedAt: number | null;
   /**
    * True when the connected wallet is on the legacy RP ID while a distinct shared
    * RP ID is configured and migration hasn't been done/skipped. Drives the
@@ -270,7 +268,6 @@ export function useBreezSdk(
   const [config, setConfig] = useState<Config | null>(null);
   const [hasRejectedDeposits, setHasRejectedDeposits] = useState(false);
   const [celebrationPayment, setCelebrationPayment] = useState<Payment | null>(null);
-  const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   const [needsPasskeyMigration, setNeedsPasskeyMigration] = useState(false);
   const [prfAvailable, setPrfAvailable] = useState(false);
   const [startupState, setStartupState] = useState<StartupState>('loading');
@@ -354,7 +351,6 @@ export function useBreezSdk(
         setIsSyncing(false);
       }
       document.body.setAttribute('data-wallet-synced', 'true');
-      setLastSyncedAt(Date.now());
       refreshWalletData(false);
       fetchUnclaimedDeposits();
     } else if (event.type === 'paymentSucceeded') {
@@ -508,8 +504,6 @@ export function useBreezSdk(
       // background: the balance header waits for walletInfo (renders nothing
       // until then, never a stale zero) and isSyncing drives the indicator.
       setIsConnected(true);
-      // connect() already ran the initial wallet sync, so data is fresh here.
-      setLastSyncedAt(Date.now());
       setStartupState('connected');
       setIsLoading(false);
       // Total covers connect + persist; getInfo/history load in the
@@ -620,7 +614,6 @@ export function useBreezSdk(
     setWalletInfo(null);
     setTransactions([]);
     setUnclaimedDeposits([]);
-    setLastSyncedAt(null);
     setConfig(null);
     setError(null);
     setHasRejectedDeposits(false);
@@ -1309,7 +1302,6 @@ export function useBreezSdk(
         try {
           await s.syncWallet({});
           await Promise.all([refreshWalletData(false), fetchUnclaimedDeposits()]);
-          setLastSyncedAt(Date.now());
           return;
         } catch (e) {
           logger.warn(LogCategory.SDK, 'Foreground resync failed', { attempt, error: formatError(e) });
@@ -1372,7 +1364,6 @@ export function useBreezSdk(
     error,
     hasRejectedDeposits,
     celebrationPayment,
-    lastSyncedAt,
     needsPasskeyMigration,
     prfAvailable,
     hasPasskeyBefore: hasPasskeyHistory(),

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -189,8 +189,9 @@ export interface BreezSdkActions {
     passkeyLabel?: string,
     source?: ConnectSeedSource,
   ) => Promise<void>;
-  refreshWalletData: (showLoading?: boolean) => Promise<void>;
-  fetchUnclaimedDeposits: () => Promise<void>;
+  /** Resolve false when the SDK read failed; both log internally and keep last-known state. */
+  refreshWalletData: (showLoading?: boolean) => Promise<boolean>;
+  fetchUnclaimedDeposits: () => Promise<boolean>;
   /**
    * Logs out and erases all on-device data: SDK databases, Preferences,
    * localStorage, the device credential-id registry, and the in-memory
@@ -306,7 +307,7 @@ export function useBreezSdk(
 
   const refreshWalletData = useCallback(async (showLoading = true) => {
     const s = sdkRef.current;
-    if (!s) return;
+    if (!s) return false;
     try {
       if (showLoading) setIsLoading(true);
       const [info, txns] = await Promise.all([
@@ -315,9 +316,11 @@ export function useBreezSdk(
       ]);
       setWalletInfo(info);
       setTransactions(filterOngoingConversionPayments(txns.payments));
+      return true;
     } catch (e) {
       logger.error(LogCategory.SDK, 'Error refreshing wallet data', { error: formatError(e) });
       setError('Failed to refresh wallet data.');
+      return false;
     } finally {
       if (showLoading) setIsLoading(false);
     }
@@ -325,16 +328,18 @@ export function useBreezSdk(
 
   const fetchUnclaimedDeposits = useCallback(async () => {
     const s = sdkRef.current;
-    if (!s) return;
+    if (!s) return false;
     try {
       const result = await s.listUnclaimedDeposits({});
       const deposits = result.deposits;
       setUnclaimedDeposits(deposits);
       setHasRejectedDeposits(deposits.some(d => isDepositRejected(d.txid, d.vout)));
+      return true;
     } catch (e) {
       // Keep the last known list: clearing on a transient failure (common
       // on iOS PWA resume) hides a real pending deposit from the UI.
       logger.warn(LogCategory.SDK, 'Failed to fetch unclaimed deposits', { error: formatError(e) });
+      return false;
     }
   }, [sdkRef]);
 
@@ -1282,10 +1287,11 @@ export function useBreezSdk(
     };
   }, [startupStateRef, retryUnlockRef]);
 
-  // Force a sync when the app returns to the foreground. iOS standalone
-  // PWAs resume a days-old page instead of reloading, and a failed
-  // background sync is silent (synced never fires), so without this the
-  // UI keeps showing cached data (support case: invisible on-chain deposit).
+  // Force a sync when the app returns to the foreground: any tab/window
+  // visibility return, not just PWA resume. The motivating case is iOS
+  // standalone PWAs, which resume a days-old page instead of reloading;
+  // a failed background sync is silent (synced never fires), so without
+  // this the UI keeps showing cached data.
   const resyncInFlightRef = useRef(false);
   const foregroundResync = useCallback(async () => {
     if (resyncInFlightRef.current) return;
@@ -1301,8 +1307,11 @@ export function useBreezSdk(
         if (!s) return;
         try {
           await s.syncWallet({});
-          await Promise.all([refreshWalletData(false), fetchUnclaimedDeposits()]);
-          return;
+          // The fetchers absorb their SDK errors and report them as
+          // `false`, so a failed read falls through to the retry pass
+          // the same way a syncWallet throw does.
+          const refreshed = await Promise.all([refreshWalletData(false), fetchUnclaimedDeposits()]);
+          if (refreshed.every(Boolean)) return;
         } catch (e) {
           logger.warn(LogCategory.SDK, 'Foreground resync failed', { attempt, error: formatError(e) });
         }

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -151,6 +151,8 @@ export interface BreezSdkState {
   error: string | null;
   hasRejectedDeposits: boolean;
   celebrationPayment: Payment | null;
+  /** Epoch ms of the last known-fresh wallet data; null before the first sync. */
+  lastSyncedAt: number | null;
   /**
    * True when the connected wallet is on the legacy RP ID while a distinct shared
    * RP ID is configured and migration hasn't been done/skipped. Drives the
@@ -268,6 +270,7 @@ export function useBreezSdk(
   const [config, setConfig] = useState<Config | null>(null);
   const [hasRejectedDeposits, setHasRejectedDeposits] = useState(false);
   const [celebrationPayment, setCelebrationPayment] = useState<Payment | null>(null);
+  const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   const [needsPasskeyMigration, setNeedsPasskeyMigration] = useState(false);
   const [prfAvailable, setPrfAvailable] = useState(false);
   const [startupState, setStartupState] = useState<StartupState>('loading');
@@ -332,9 +335,9 @@ export function useBreezSdk(
       setUnclaimedDeposits(deposits);
       setHasRejectedDeposits(deposits.some(d => isDepositRejected(d.txid, d.vout)));
     } catch (e) {
+      // Keep the last known list: clearing on a transient failure (common
+      // on iOS PWA resume) hides a real pending deposit from the UI.
       logger.warn(LogCategory.SDK, 'Failed to fetch unclaimed deposits', { error: formatError(e) });
-      setUnclaimedDeposits([]);
-      setHasRejectedDeposits(false);
     }
   }, [sdkRef]);
 
@@ -351,6 +354,7 @@ export function useBreezSdk(
         setIsSyncing(false);
       }
       document.body.setAttribute('data-wallet-synced', 'true');
+      setLastSyncedAt(Date.now());
       refreshWalletData(false);
       fetchUnclaimedDeposits();
     } else if (event.type === 'paymentSucceeded') {
@@ -504,6 +508,8 @@ export function useBreezSdk(
       // background: the balance header waits for walletInfo (renders nothing
       // until then, never a stale zero) and isSyncing drives the indicator.
       setIsConnected(true);
+      // connect() already ran the initial wallet sync, so data is fresh here.
+      setLastSyncedAt(Date.now());
       setStartupState('connected');
       setIsLoading(false);
       // Total covers connect + persist; getInfo/history load in the
@@ -614,6 +620,7 @@ export function useBreezSdk(
     setWalletInfo(null);
     setTransactions([]);
     setUnclaimedDeposits([]);
+    setLastSyncedAt(null);
     setConfig(null);
     setError(null);
     setHasRejectedDeposits(false);
@@ -1282,6 +1289,51 @@ export function useBreezSdk(
     };
   }, [startupStateRef, retryUnlockRef]);
 
+  // Force a sync when the app returns to the foreground. iOS standalone
+  // PWAs resume a days-old page instead of reloading, and a failed
+  // background sync is silent (synced never fires), so without this the
+  // UI keeps showing cached data (support case: invisible on-chain deposit).
+  const resyncInFlightRef = useRef(false);
+  const foregroundResync = useCallback(async () => {
+    if (resyncInFlightRef.current) return;
+    resyncInFlightRef.current = true;
+    try {
+      // Two passes = one retry; the delay doubles as retry backoff.
+      for (let attempt = 0; attempt < 2; attempt++) {
+        // 1.5s delay: on iOS 18+ WebKit, network requests started directly
+        // on visibilitychange fail with "TypeError: Load failed".
+        await new Promise(r => setTimeout(r, 1500));
+        if (document.visibilityState !== 'visible') return;
+        const s = sdkRef.current;
+        if (!s) return;
+        try {
+          await s.syncWallet({});
+          await Promise.all([refreshWalletData(false), fetchUnclaimedDeposits()]);
+          setLastSyncedAt(Date.now());
+          return;
+        } catch (e) {
+          logger.warn(LogCategory.SDK, 'Foreground resync failed', { attempt, error: formatError(e) });
+        }
+      }
+    } finally {
+      resyncInFlightRef.current = false;
+    }
+  }, [sdkRef, refreshWalletData, fetchUnclaimedDeposits]);
+
+  useEffect(() => {
+    if (!isConnected) return;
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') void foregroundResync();
+    };
+    // pageshow catches bfcache restores, which skip visibilitychange.
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('pageshow', onVisible);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('pageshow', onVisible);
+    };
+  }, [isConnected, foregroundResync]);
+
   // Event listener lifecycle
   useEffect(() => {
     if (isConnected && sdk) {
@@ -1320,6 +1372,7 @@ export function useBreezSdk(
     error,
     hasRejectedDeposits,
     celebrationPayment,
+    lastSyncedAt,
     needsPasskeyMigration,
     prfAvailable,
     hasPasskeyBefore: hasPasskeyHistory(),

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -25,7 +25,7 @@ interface WalletPageProps {
   walletInfo: GetInfoResponse | null;
   transactions: Payment[];
   unclaimedDeposits: DepositInfo[];
-  refreshWalletData: (showLoading?: boolean) => Promise<void>;
+  refreshWalletData: (showLoading?: boolean) => Promise<boolean>;
   isSyncing: boolean;
   error: string | null;
   onClearError: () => void;

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -27,7 +27,6 @@ interface WalletPageProps {
   unclaimedDeposits: DepositInfo[];
   refreshWalletData: (showLoading?: boolean) => Promise<void>;
   isSyncing: boolean;
-  lastSyncedAt: number | null;
   error: string | null;
   onClearError: () => void;
   onLogout: () => void;
@@ -46,7 +45,6 @@ const WalletPage: React.FC<WalletPageProps> = ({
   unclaimedDeposits,
   refreshWalletData,
   isSyncing,
-  lastSyncedAt,
   onLogout,
   hasRejectedDeposits,
   onOpenGetRefund,
@@ -239,7 +237,6 @@ const WalletPage: React.FC<WalletPageProps> = ({
           }}
           isBuyLoading={isBuyLoading}
           isSyncing={isSyncing}
-          lastSyncedAt={lastSyncedAt}
           refreshWalletData={() => refreshWalletData(false)}
           hasRejectedDeposits={hasRejectedDeposits}
           onOpenGetRefund={() => onOpenGetRefund('icon')}

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -27,6 +27,7 @@ interface WalletPageProps {
   unclaimedDeposits: DepositInfo[];
   refreshWalletData: (showLoading?: boolean) => Promise<void>;
   isSyncing: boolean;
+  lastSyncedAt: number | null;
   error: string | null;
   onClearError: () => void;
   onLogout: () => void;
@@ -45,6 +46,7 @@ const WalletPage: React.FC<WalletPageProps> = ({
   unclaimedDeposits,
   refreshWalletData,
   isSyncing,
+  lastSyncedAt,
   onLogout,
   hasRejectedDeposits,
   onOpenGetRefund,
@@ -237,6 +239,7 @@ const WalletPage: React.FC<WalletPageProps> = ({
           }}
           isBuyLoading={isBuyLoading}
           isSyncing={isSyncing}
+          lastSyncedAt={lastSyncedAt}
           refreshWalletData={() => refreshWalletData(false)}
           hasRejectedDeposits={hasRejectedDeposits}
           onOpenGetRefund={() => onOpenGetRefund('icon')}


### PR DESCRIPTION
This PR fixes stale wallet data in the PWA on iOS. 

When the user reopens the app, iOS PWA resumes the old page and does not reload it. If the background sync also fails, the app shows old data and gives no warning. The user cannot see new deposits, and the balance can stay incorrect for days.

A support case reported this problem: a user could not see an unclaimed deposit on iOS PWA, but the same wallet displayed the unclaimed deposits correctly on a Web browser.

The app now does a fresh sync each time it returns to the foreground, and it retries one time if the sync fails. If a refresh fails, the app keeps the pending deposit card visible.

**Reviewer note**: the foreground sync waits 1.5 seconds before it uses the network. On iOS 18 and later, WebKit requests that start directly on `visibilitychange` fail with "TypeError: Load failed".
