### PR TITLE
fix: make Lock Screen and Backup top-level Settings entries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,10 +79,6 @@ const AppContent: React.FC = () => {
   // 'unlocking', auto-'wallet' on reconnect) are layered in by
   // `currentScreen` below.
   const [userScreen, setUserScreen] = useState<Screen>('home');
-  // Where the open BackupPage was launched from: the side menu (web) or
-  // the Security & Backup page (native). Drives its back target and
-  // whether SecurityPage stays mounted beneath it.
-  const [backupSource, setBackupSource] = useState<'settings' | 'security'>('settings');
   const [refundAnimationDirection, setRefundAnimationDirection] = useState<'left' | 'up'>('left');
   const [buyProvidersSource, setBuyProvidersSource] = useState<'wallet' | 'settings'>('wallet');
   const [passkeySdkConnected, setPasskeySdkConnected] = useState(false);
@@ -222,8 +218,6 @@ const AppContent: React.FC = () => {
         setUserScreen('wallet');
         return true;
       case 'backup':
-        setUserScreen(backupSource === 'security' ? 'security' : 'settings');
-        return true;
       case 'security':
       case 'fiatCurrencies':
       case 'passkeySettings':
@@ -254,7 +248,7 @@ const AppContent: React.FC = () => {
         // (same as pressing Home). Matches standard Android UX.
         return false;
     }
-  }, [currentScreen, buyProvidersSource, backupSource]), true);
+  }, [currentScreen, buyProvidersSource]), true);
 
   // Render screens
   const renderCurrentScreen = () => {
@@ -352,7 +346,7 @@ const AppContent: React.FC = () => {
         onOpenBuyProviders={() => { setBuyProvidersSource('settings'); setUserScreen('buyProviders'); }}
         onOpenPasskeySettings={() => setUserScreen('passkeySettings')}
         onOpenSecurity={() => setUserScreen('security')}
-        onOpenBackup={() => { setBackupSource('settings'); setUserScreen('backup'); }}
+        onOpenBackup={() => setUserScreen('backup')}
       />
     );
 
@@ -533,36 +527,24 @@ const AppContent: React.FC = () => {
           </>
         );
 
-      // Security & Backup share one branch so SecurityPage stays
-      // mounted (gate passed, options state intact) underneath an
-      // opened BackupPage — returning from Backup must not re-run the
-      // PIN/biometric gate. On web, Backup opens directly from
-      // Settings and SecurityPage never mounts.
+      // Lock Screen and Backup are sibling drill-ins over Settings.
       case 'backup':
-      case 'security': {
-        const backupFromSecurity = backupSource === 'security';
+      case 'security':
         return (
           <>
             {renderWalletPage()}
             {renderSettingsPage()}
-            {(currentScreen === 'security' || backupFromSecurity) && (
-              <SecurityPage
-                onBack={() => setUserScreen('settings')}
-                onOpenBackup={() => {
-                  setBackupSource('security');
-                  setUserScreen('backup');
-                }}
-              />
+            {currentScreen === 'security' && (
+              <SecurityPage onBack={() => setUserScreen('settings')} />
             )}
             {currentScreen === 'backup' && (
               <BackupPage
                 closeStyle="back"
-                onBack={() => setUserScreen(backupFromSecurity ? 'security' : 'settings')}
+                onBack={() => setUserScreen('settings')}
               />
             )}
           </>
         );
-      }
 
       case 'restore':
         return (

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { WarningIcon, SpinnerIcon, EyeIcon, FaceIdIcon, FingerprintIcon, PasskeyIcon } from '../components/Icons';
 import SlideInPage from '../components/layout/SlideInPage';
+import { PinGate } from '../components/PinEntry';
+import { LoadingSpinner } from '../components/ui';
+import { isPinEnabled } from '@/services/appLock';
 import {
   isPasskeyMode,
   signInPinnedToActiveCredential,
@@ -12,7 +15,7 @@ import { useScreenCaptureProtection } from '@/utils/screenSecurity';
 
 interface BackupPageProps {
   onBack: () => void;
-  /** 'back' when opened from the Security & Backup page (native). */
+  /** 'back' when opened via drill-in nav from Settings. */
   closeStyle?: 'close' | 'back';
 }
 
@@ -22,6 +25,21 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
   const [isRevealed, setIsRevealed] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // App-lock gate at page entry: Backup opens directly from Settings,
+  // so when a PIN is set the phrase must sit behind the same gate the
+  // Lock Screen settings use. 'checking' avoids a one-frame content
+  // flash while the async PIN read resolves.
+  const [gate, setGate] = useState<'checking' | 'locked' | 'open'>('checking');
+  useEffect(() => {
+    let cancelled = false;
+    void isPinEnabled().then((pin) => {
+      if (!cancelled) setGate(pin ? 'locked' : 'open');
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Block screen capture for the whole Backup screen, from mount, so
   // protection is already active before the seed can render (the native
@@ -37,7 +55,9 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
   const [biometricSeedPresent, setBiometricSeedPresent] = useState(false);
 
   useEffect(() => {
-    if (isPasskey) return;
+    // Hold the silent seed read until the gate passes so the phrase
+    // never sits in memory behind a locked pad.
+    if (isPasskey || gate !== 'open') return;
     let cancelled = false;
     (async () => {
       if (deviceOnlyStorage.isSupported() && (await deviceOnlyStorage.hasStoredSeed())) {
@@ -68,7 +88,7 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
     return () => {
       cancelled = true;
     };
-  }, [isPasskey]);
+  }, [isPasskey, gate]);
 
   // Tracks whether passkey-based reveal failed once, so we can offer a
   // secureStorage fallback button in the error UI. We don't try
@@ -199,6 +219,18 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
           input; the card views flow from the top as before. */}
       <div className="p-4 min-h-full flex flex-col">
         <div className="max-w-xl mx-auto w-full space-y-6 flex-1 flex flex-col">
+          {gate === 'checking' && (
+            <div className="flex justify-center py-16">
+              <LoadingSpinner size="small" />
+            </div>
+          )}
+
+          {gate === 'locked' && (
+            <PinGate reason="Unlock Backup" onUnlocked={() => setGate('open')} />
+          )}
+
+          {gate === 'open' && (
+          <>
           {/* Passkey info card */}
           {isPasskey && (
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-6">
@@ -244,8 +276,7 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
           {/* Reveal button (mnemonic mode). When biometric unlock is
               enabled the seed is in the biometric-bound tier, so the
               tap triggers an OS prompt before revealing. App-lock
-              protection happens at page entry: on native the only way
-              here is through the gated Security & Backup page. */}
+              protection happens at page entry via the PIN gate above. */}
           {!isPasskey && !isRevealed && (mnemonic || biometricSeedPresent) && (
             <button
               onClick={mnemonic
@@ -396,6 +427,8 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
                 Could not find a recovery phrase for this wallet.
               </p>
             </div>
+          )}
+          </>
           )}
         </div>
       </div>

--- a/src/pages/BackupPage.tsx
+++ b/src/pages/BackupPage.tsx
@@ -3,7 +3,7 @@ import { WarningIcon, SpinnerIcon, EyeIcon, FaceIdIcon, FingerprintIcon, Passkey
 import SlideInPage from '../components/layout/SlideInPage';
 import { PinGate } from '../components/PinEntry';
 import { LoadingSpinner } from '../components/ui';
-import { isPinEnabled } from '@/services/appLock';
+import { isAppLockSupported, isPinEnabled } from '@/services/appLock';
 import {
   isPasskeyMode,
   signInPinnedToActiveCredential,
@@ -29,9 +29,13 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
   // App-lock gate at page entry: Backup opens directly from Settings,
   // so when a PIN is set the phrase must sit behind the same gate the
   // Lock Screen settings use. 'checking' avoids a one-frame content
-  // flash while the async PIN read resolves.
-  const [gate, setGate] = useState<'checking' | 'locked' | 'open'>('checking');
+  // flash while the async PIN read resolves; web has no app lock, so
+  // it opens synchronously (no spinner flash).
+  const [gate, setGate] = useState<'checking' | 'locked' | 'open'>(
+    () => (isAppLockSupported() ? 'checking' : 'open'),
+  );
   useEffect(() => {
+    if (gate !== 'checking') return;
     let cancelled = false;
     void isPinEnabled().then((pin) => {
       if (!cancelled) setGate(pin ? 'locked' : 'open');
@@ -39,6 +43,7 @@ const BackupPage: React.FC<BackupPageProps> = ({ onBack, closeStyle = 'close' })
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once at mount
   }, []);
 
   // Block screen capture for the whole Backup screen, from mount, so

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -1,10 +1,9 @@
 /**
- * Security & Backup page (native only), Misty Breez's model: the
- * recovery phrase entry and the app-lock settings live behind one
- * gate. No PIN set => Backup row + a "Create PIN" row. PIN set =>
- * the page opens behind an auth gate (biometrics first when enabled,
- * PIN pad as fallback) and offers: Backup, deactivate PIN, auto-lock
- * timeout, change PIN, enable <biometry>.
+ * Lock Screen page (native only). No PIN set => a "Create PIN" row.
+ * PIN set => the page opens behind an auth gate (biometrics first
+ * when enabled, PIN pad as fallback) and offers: deactivate PIN,
+ * auto-lock timeout, change PIN, enable <biometry>. Backup lives as
+ * its own top-level Settings entry; BackupPage gates itself.
  */
 
 import React, { useEffect, useRef, useState } from 'react';
@@ -41,12 +40,9 @@ type View =
 
 interface SecurityPageProps {
   onBack: () => void;
-  /** Opens the Backup page. Rendered only past the gate, so the
-   *  recovery phrase inherits the page-entry app-lock (Misty model). */
-  onOpenBackup: () => void;
 }
 
-const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => {
+const SecurityPage: React.FC<SecurityPageProps> = ({ onBack }) => {
   const [view, setView] = useState<View>('loading');
   const [autoLock, setAutoLock] = useState<number>(120);
   const [biometricGate, setBiometricGate] = useState(false);
@@ -156,22 +152,6 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => 
   };
 
   const renderBody = () => {
-    // Shared by the no-pin and options views: the recovery phrase entry
-    // lives here so it inherits the page-entry gate when a PIN is set.
-    const backupCard = (
-      <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-        <h3 className="font-display font-semibold text-spark-text-primary mb-3">Backup</h3>
-        <button
-          className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
-          type="button"
-          onClick={onOpenBackup}
-        >
-          <span>Show Recovery Phrase</span>
-          <ChevronRightIcon size="md" />
-        </button>
-      </div>
-    );
-
     switch (view) {
       case 'loading':
         return (
@@ -181,13 +161,12 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => 
         );
 
       case 'gate':
-        return <PinGate reason="Unlock Security settings" onUnlocked={() => setView('options')} />;
+        return <PinGate reason="Unlock Lock Screen settings" onUnlocked={() => setView('options')} />;
 
       case 'no-pin':
         return (
           <div className="space-y-4">
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Lock Screen</h3>
               <button
                 className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
                 type="button"
@@ -200,7 +179,6 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => 
                 <ChevronRightIcon size="md" />
               </button>
             </div>
-            {backupCard}
           </div>
         );
 
@@ -228,7 +206,6 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => 
         return (
           <div className="space-y-4">
             <div className="bg-spark-dark border border-spark-border rounded-2xl p-4 space-y-2">
-            <h3 className="font-display font-semibold text-spark-text-primary mb-3">Lock Screen</h3>
             {/* Deactivate PIN (Misty pattern: an always-on switch whose
                 only action is turning protection off) */}
             <div className="flex items-center justify-between px-4 py-3 border border-spark-border rounded-xl">
@@ -312,14 +289,13 @@ const SecurityPage: React.FC<SecurityPageProps> = ({ onBack, onOpenBackup }) => 
               <p className="text-spark-primary text-xs px-1 pt-1">{optionsError}</p>
             )}
             </div>
-            {backupCard}
           </div>
         );
     }
   };
 
   return (
-    <SlideInPage title="Security & Backup" onClose={onBack} slideFrom="left">
+    <SlideInPage title="Lock Screen" onClose={onBack} slideFrom="left">
       {/* min-h-full + flexed chain so the PIN views (gate, create,
           change) can split the viewport 1/3 header / 2/3 input; the
           list views just flow from the top as before. p-4 keeps the

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -3,7 +3,7 @@ import { FormGroup, FormInput, LoadingSpinner, PrimaryButton, Switch } from '../
 import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable } from '../services/settings';
 import type { Config, Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '@/contexts/WalletContext';
-import { CurrencyIcon, ChevronRightIcon, DownloadIcon, ShieldCheckIcon, TrashIcon, ExternalLinkIcon } from '../components/Icons';
+import { CurrencyIcon, ChevronRightIcon, DownloadIcon, KeyIcon, LockIcon, ShieldCheckIcon, TrashIcon, ExternalLinkIcon } from '../components/Icons';
 import { ACCOUNT_DELETION_GUIDE_URL } from '@/services/accountDeletion';
 import { openExternalUrl } from '@/utils/externalLink';
 import { isAppLockSupported } from '@/services/appLock';
@@ -197,18 +197,38 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
               The "Save Changes" footer applies the toggles + inputs;
               everything above it commits on tap. */}
 
-          {/* Backup. Native routes through the Security & Backup page
-              (Misty parity) so the recovery phrase sits behind the
-              app-lock gate. The PWA has no app lock, so it opens
-              Backup directly. */}
+          {/* Lock Screen (native only: app lock needs the Capacitor
+              shell). Backup is its own entry below; BackupPage runs its
+              own PIN gate when one is set. */}
+          {isAppLockSupported() && (
+            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
+              <h3 className="font-display font-semibold text-spark-text-primary mb-3">Security</h3>
+              <button
+                className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
+                type="button"
+                onClick={onOpenSecurity}
+              >
+                <div className="flex items-center gap-3">
+                  <LockIcon size="md" />
+                  <span>Lock Screen</span>
+                </div>
+                <ChevronRightIcon size="md" />
+              </button>
+            </div>
+          )}
+
+          {/* Backup */}
           <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
             <h3 className="font-display font-semibold text-spark-text-primary mb-3">Backup</h3>
             <button
               className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium border border-spark-border rounded-xl text-spark-text-secondary hover:text-spark-text-primary hover:bg-white/5 transition-colors"
               type="button"
-              onClick={isAppLockSupported() ? onOpenSecurity : onOpenBackup}
+              onClick={onOpenBackup}
             >
-              <span>Show Recovery Phrase</span>
+              <div className="flex items-center gap-3">
+                <KeyIcon size="md" />
+                <span>Recovery Phrase</span>
+              </div>
               <ChevronRightIcon size="md" />
             </button>
           </div>


### PR DESCRIPTION
## What

- Settings now has two top-level entries: **Security > Lock Screen** (native only) and **Backup > Recovery Phrase**, replacing the single Backup card that routed through the combined Security & Backup page.
- The row label "Show Recovery Phrase" is renamed to "Recovery Phrase".
- SecurityPage is retitled to "Lock Screen" and holds only the app-lock settings; its embedded Backup card is removed.

## Security note

The recovery phrase previously inherited the PIN/biometric gate by living behind the Security & Backup page. Since Backup now opens directly from Settings, BackupPage runs its own PinGate at page entry when a PIN is set, and holds the silent seed read until the gate passes. On web (no app lock) the gate resolves open immediately, matching current behavior.

## Also

- App.tsx drops the backupSource plumbing: Lock Screen and Backup are sibling drill-ins over Settings, hardware back from either returns to Settings.

## Testing

- npx tsc --noEmit clean
- npm test: 113/113 pass
- lint: no new warnings (4 pre-existing in untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)