### PR TITLE
fix: rename Buy Bitcoin Providers to Buy Bitcoin, hide Buy button with no providers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,6 @@ const AppContent: React.FC = () => {
   // whether SecurityPage stays mounted beneath it.
   const [backupSource, setBackupSource] = useState<'settings' | 'security'>('settings');
   const [refundAnimationDirection, setRefundAnimationDirection] = useState<'left' | 'up'>('left');
-  const [buyProvidersSource, setBuyProvidersSource] = useState<'wallet' | 'settings'>('wallet');
   const [passkeySdkConnected, setPasskeySdkConnected] = useState(false);
   // True when the user entered the passkey screen via the explicit
   // "Create New Wallet" CTA on browsers without `immediateGet`. Skips
@@ -226,6 +225,7 @@ const AppContent: React.FC = () => {
         return true;
       case 'security':
       case 'fiatCurrencies':
+      case 'buyProviders':
       case 'passkeySettings':
         setUserScreen('settings');
         return true;
@@ -233,9 +233,6 @@ const AppContent: React.FC = () => {
       case 'labels':
       case 'passkeyLocalState':
         setUserScreen('passkeySettings');
-        return true;
-      case 'buyProviders':
-        setUserScreen(buyProvidersSource === 'settings' ? 'settings' : 'wallet');
         return true;
       case 'restore':
       case 'generate':
@@ -254,7 +251,7 @@ const AppContent: React.FC = () => {
         // (same as pressing Home). Matches standard Android UX.
         return false;
     }
-  }, [currentScreen, buyProvidersSource, backupSource]), true);
+  }, [currentScreen, backupSource]), true);
 
   // Render screens
   const renderCurrentScreen = () => {
@@ -331,7 +328,6 @@ const AppContent: React.FC = () => {
             setUserScreen('getRefund');
           }}
           onOpenSettings={() => setUserScreen('settings')}
-          onOpenBuyProviders={() => { setBuyProvidersSource('wallet'); setUserScreen('buyProviders'); }}
           onBuyBitcoin={sdk.handleBuyBitcoin}
           network={sdk.config?.network}
           onDepositChanged={sdk.fetchUnclaimedDeposits}
@@ -349,7 +345,7 @@ const AppContent: React.FC = () => {
         onBack={() => setUserScreen('wallet')}
         config={sdk.config}
         onOpenFiatCurrencies={() => setUserScreen('fiatCurrencies')}
-        onOpenBuyProviders={() => { setBuyProvidersSource('settings'); setUserScreen('buyProviders'); }}
+        onOpenBuyProviders={() => setUserScreen('buyProviders')}
         onOpenPasskeySettings={() => setUserScreen('passkeySettings')}
         onOpenSecurity={() => setUserScreen('security')}
         onOpenBackup={() => { setBackupSource('settings'); setUserScreen('backup'); }}
@@ -518,16 +514,9 @@ const AppContent: React.FC = () => {
         return (
           <>
             {renderWalletPage()}
-            {buyProvidersSource === 'settings' && renderSettingsPage()}
+            {renderSettingsPage()}
             <BuyProvidersPage
-              onBack={() => setUserScreen(buyProvidersSource === 'settings' ? 'settings' : 'wallet')}
-              slideFrom={buyProvidersSource === 'settings' ? 'right' : 'up'}
-              // Wallet-sourced = modal-style presentation (slides up from
-              // the Buy button) → X close affordance in the header.
-              // Settings-sourced = drill-in nav (slides in from the
-              // right) → < back affordance. Matches iOS/Material
-              // conventions for modal vs. push navigation.
-              closeStyle={buyProvidersSource === 'settings' ? 'back' : 'close'}
+              onBack={() => setUserScreen('settings')}
               network={sdk.config?.network}
             />
           </>

--- a/src/pages/BuyProvidersPage.tsx
+++ b/src/pages/BuyProvidersPage.tsx
@@ -7,15 +7,6 @@ import { getBuyProviderSettings, saveBuyProviderSettings, ALL_BUY_PROVIDERS, typ
 
 interface BuyProvidersPageProps {
   onBack: () => void;
-  slideFrom?: 'up' | 'right';
-  /**
-   * Close affordance to show in the header. `'close'` (X, top-right)
-   * is the conventional modal dismiss used when the page is presented
-   * from the wallet's Buy button (`slideFrom="up"`). `'back'` (<,
-   * top-left) is the conventional drill-in dismiss used when reached
-   * via Settings → Buy Bitcoin Providers (`slideFrom="right"`).
-   */
-  closeStyle?: 'close' | 'back';
   network?: Network;
 }
 
@@ -34,7 +25,9 @@ const providerMeta: Record<BuyBitcoinProvider, { name: string; icon: React.React
   },
 };
 
-const BuyProvidersPage: React.FC<BuyProvidersPageProps> = ({ onBack, slideFrom = 'up', closeStyle = 'back', network }) => {
+// Reached only via Settings → Buy Bitcoin, so the presentation is
+// fixed drill-in nav: slide in from the right, < back affordance.
+const BuyProvidersPage: React.FC<BuyProvidersPageProps> = ({ onBack, network }) => {
   const isMainnet = network === 'mainnet';
   const [enabledProviders, setEnabledProviders] = useState<BuyBitcoinProvider[]>(getBuyProviderSettings);
   const [draggedItem, setDraggedItem] = useState<BuyBitcoinProvider | null>(null);
@@ -100,7 +93,7 @@ const BuyProvidersPage: React.FC<BuyProvidersPageProps> = ({ onBack, slideFrom =
   }, []);
 
   return (
-    <SlideInPage title="Buy Bitcoin Providers" closeStyle={closeStyle} onClose={onBack} slideFrom={slideFrom}>
+    <SlideInPage title="Buy Bitcoin" closeStyle="back" onClose={onBack} slideFrom="right">
       <div className="p-4 space-y-2">
         {/* Enabled providers — reorderable */}
         {enabledProviders.map((provider, index) => {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -236,7 +236,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                 >
                   <div className="flex items-center gap-3">
                     <CurrencyIcon size="md" />
-                    <span>Buy Bitcoin Providers</span>
+                    <span>Buy Bitcoin</span>
                   </div>
                   <ChevronRightIcon size="md" />
                 </button>

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { useWallet } from '../contexts/WalletContext';
 import { useToast } from '../contexts/ToastContext';
 import { logger, LogCategory } from '@/services/logger';
@@ -33,7 +33,6 @@ interface WalletPageProps {
   hasRejectedDeposits: boolean;
   onOpenGetRefund: (source?: 'menu' | 'icon') => void;
   onOpenSettings: () => void;
-  onOpenBuyProviders: () => void;
   onBuyBitcoin: (provider: BuyBitcoinProvider) => Promise<void>;
   network?: Network;
   onDepositChanged?: () => void;
@@ -49,7 +48,6 @@ const WalletPage: React.FC<WalletPageProps> = ({
   hasRejectedDeposits,
   onOpenGetRefund,
   onOpenSettings,
-  onOpenBuyProviders,
   onBuyBitcoin,
   network,
   onDepositChanged,
@@ -75,9 +73,10 @@ const WalletPage: React.FC<WalletPageProps> = ({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isBuyBitcoinOpen, setIsBuyBitcoinOpen] = useState(false);
   const [isBuyLoading, setIsBuyLoading] = useState(false);
-  // Re-read when menu closes (user may have changed providers in BuyProvidersPage)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const enabledBuyProviders = useMemo(() => filterProvidersByNetwork(getBuyProviderSettings(), network), [isMenuOpen, network]);
+  // Computed per render (cheap in-memory read) so the Buy button's
+  // visibility is fresh after any return from Settings; a memo keyed
+  // on menu state went stale when providers changed under an overlay.
+  const enabledBuyProviders = filterProvidersByNetwork(getBuyProviderSettings(), network);
   const [saveContactAddress, setSaveContactAddress] = useState<string | null>(null);
   // Bump these on each open so each dialog remounts and lazy-inits its
   // state, instead of relying on a reset-in-effect inside the dialog.
@@ -224,10 +223,10 @@ const WalletPage: React.FC<WalletPageProps> = ({
           walletInfo={walletInfo}
           scrollProgress={scrollProgress}
           onOpenMenu={() => setIsMenuOpen(true)}
-          onOpenBuyBitcoin={!isBuyBitcoinAvailable() ? undefined : () => {
-            if (enabledBuyProviders.length === 0) {
-              onOpenBuyProviders();
-            } else if (enabledBuyProviders.length === 1 && enabledBuyProviders[0] === 'moonpay') {
+          // Buy is hidden when no provider is enabled (Settings →
+          // Buy Bitcoin), not just when the platform disallows buying.
+          onOpenBuyBitcoin={!isBuyBitcoinAvailable() || enabledBuyProviders.length === 0 ? undefined : () => {
+            if (enabledBuyProviders.length === 1 && enabledBuyProviders[0] === 'moonpay') {
               // MoonPay can redirect directly; Cash App needs amount entry via the dialog.
               setIsBuyLoading(true);
               onBuyBitcoin(enabledBuyProviders[0]).finally(() => setIsBuyLoading(false));


### PR DESCRIPTION
## What

- The Settings row and the providers page title are renamed from "Buy Bitcoin Providers" to "Buy Bitcoin".
- The wallet header's Buy button is now hidden when no provider is enabled. Previously it stayed visible and tapping it opened the providers page.

## How

- WalletPage reads the enabled-providers list per render (in-memory cached read) instead of a useMemo keyed on menu state. The memo went stale when providers changed under the Settings overlay, which would have left the Buy button visible/hidden incorrectly until the next menu toggle.
- With the zero-provider tap gone, the wallet-sourced route to BuyProvidersPage is dead: WalletPage drops onOpenBuyProviders, BuyProvidersPage loses its slideFrom/closeStyle props (now fixed drill-in from Settings), and App.tsx drops the buyProvidersSource state.
- Hardware back from the providers page goes to Settings, as before.

## Testing

- npx tsc --noEmit clean, npm test 113/113, lint: no new warnings
- Verified live on web (Playwright): renamed row and page title; disabling both providers hides the Buy button immediately on return to the wallet; re-enabling a provider brings it back immediately
- Not exercised: iOS flag path (isBuyBitcoinAvailable) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)