### PR TITLE
fix: align balance suffix pill and give it a white foreground

### DIFF
--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -332,21 +332,26 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
               <span className="w-1.5 h-1.5 rounded-full bg-spark-primary animate-pulse" />
               Syncing
             </span>
+            {/* inline-flex + items-center keeps the suffix pill on the
+                same vertical axis as the BALANCE text (inline baseline
+                alignment sat the pill visibly lower, #300). */}
             <span
-              className={`absolute text-spark-text-muted text-xs font-display font-medium tracking-widest uppercase transition-opacity duration-300 ${
+              className={`absolute inline-flex items-center text-spark-text-muted text-xs font-display font-medium tracking-widest uppercase transition-opacity duration-300 ${
                 isSyncing ? 'opacity-0' : 'opacity-100'
               }`}
             >
               Balance
               <button
-                  type="button"
-                  onClick={handleSuffixTap}
-                  disabled={stableBalance.isToggling}
-                  className="inline-flex items-center cursor-pointer text-spark-text-muted/50 hover:text-spark-text-secondary transition-colors disabled:opacity-50 font-display text-xs font-medium tracking-widest uppercase"
-                >
-                  <span className="mx-1.5">·</span>
-                  <span className="px-1.5 py-0.5 rounded-full bg-white/5 hover:bg-white/10 active:scale-95 transition-all">{balanceSuffix}</span>
-                </button>
+                type="button"
+                onClick={handleSuffixTap}
+                disabled={stableBalance.isToggling}
+                className="inline-flex items-center cursor-pointer transition-colors disabled:opacity-50 font-display text-xs font-medium tracking-widest uppercase"
+              >
+                <span className="mx-1.5">·</span>
+                {/* White foreground so the tappable suffix reads as a
+                    button rather than blending into the muted label. */}
+                <span className="px-1.5 py-0.5 rounded-full text-spark-text-primary bg-white/5 hover:bg-white/10 active:scale-95 transition-all">{balanceSuffix}</span>
+              </button>
             </span>
           </div>
 


### PR DESCRIPTION
Fixes #300

## What

The sats/USD suffix button next to the BALANCE label was nearly invisible (muted color at 50% opacity, ~20% white effectively) and sat visibly below the label's axis due to inline baseline alignment.

- The label row is now inline-flex with items-center, so BALANCE, the dot, and the pill share one vertical centerline (measured: pill center y exactly equals label center y).
- The pill text is now spark-text-primary (pure white), per the issue's request. The dot separator stays muted so the pill reads as the tappable element. The redundant hover text color is dropped; hover feedback comes from the existing bg-white/10.

No size changes: font size, tracking, pill padding, and the row's fixed h-4 container are untouched, so there is no layout shift. Text is box-centered in the pill on both axes (6.0px left/right, 2.5px top/bottom, measured in the live DOM).

## Testing

- npx tsc --noEmit clean, npm test 113/113, lint: no new warnings
- Verified live at desktop and 375px mobile widths; syncing cross-fade and the stable-balance toggle are untouched (classes only)
- The USD variant (stable balance active) uses the identical classes and was not exercised live

🤖 Generated with [Claude Code](https://claude.com/claude-code)