### PR TITLE
feat(passkey): map native connectWithPasskey labels

### DIFF
--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -166,8 +166,14 @@ interface NativePasskeyPlugin {
   }): Promise<{ wallet: NativePluginWalletJson; labels: string[]; credentialId: string | null }>;
   connectWithPasskey(opts: {
     label?: string;
+    allowCredentials?: string[];
     excludeCredentials?: string[];
-  }): Promise<{ wallet: NativePluginWalletJson; registeredCredential: NativePluginCredentialJson | null }>;
+  }): Promise<{
+    wallet: NativePluginWalletJson;
+    /** Absent on native shells that predate the labels bridge. */
+    labels?: string[];
+    registeredCredential: NativePluginCredentialJson | null;
+  }>;
   listLabels(): Promise<{ labels: string[] }>;
   storeLabel(opts: { label: string }): Promise<void>;
   getKnownCredentialIds(): Promise<{ credentialIds: string[] }>;
@@ -314,14 +320,13 @@ class NativePasskey implements PasskeyApi {
     try {
       const r = await this.plugin().connectWithPasskey({
         label: request.label,
+        allowCredentials: request.allowCredentials?.map(bytesToBase64),
         excludeCredentials: request.excludeCredentials?.map(bytesToBase64),
       });
       return {
         wallet: decodeWallet(r.wallet),
-        // The native plugin doesn't surface discovery labels or the
-        // signed-in credential yet (needs a plugin change); the web impl
-        // below does. connectWithPasskey is web-only in the detecting flow.
-        labels: [],
+        // Native shells that predate the labels bridge omit the field.
+        labels: r.labels ?? [],
         credential: r.registeredCredential ? decodeCredential(r.registeredCredential) : null,
       };
     } catch (e) { rethrowAsTyped(e); }


### PR DESCRIPTION
This PR completes the glow-web part of #309.

The native plugin now sends the wallet labels in its `connectWithPasskey` result (breez/glow-app#127). This PR reads those labels. Before, the code always used an empty list.

The PR also sends the `allowCredentials` filter to the plugin. The plugin could always read this value. The TypeScript contract did not show it.

Old app shells do not send labels. The code then uses an empty list. So you can merge this PR before or after a glow-app release.

No screen uses the native `connectWithPasskey` call today. App behavior does not change.

Closes #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)