### PR TITLE
fix: keep the bottom of Settings clear of the Android navigation bar

### DIFF
--- a/src/components/layout/SlideInPage.tsx
+++ b/src/components/layout/SlideInPage.tsx
@@ -130,10 +130,18 @@ const SlideInPage: React.FC<SlideInPageProps> = ({
             </div>
           </header>
 
-          {/* Scrollable content */}
-          <div 
+          {/* Scrollable content. Pads for the bottom inset itself when
+              there is no footer: on Android 15+ the WebView is laid out
+              edge-to-edge under the navigation bar, so the last item in
+              a scrolled list otherwise ends up behind it (#129). With a
+              footer the footer owns that inset and padding here would
+              only add dead scroll space above it. */}
+          <div
             className="flex-1 overflow-y-auto min-h-0"
-            style={{ WebkitOverflowScrolling: 'touch' }}
+            style={{
+              WebkitOverflowScrolling: 'touch',
+              paddingBottom: footer ? undefined : safeAreaBottom,
+            }}
           >
             {children}
           </div>


### PR DESCRIPTION
This PR stops the Android navigation buttons from covering the last item at the bottom of Settings and other full-screen pages.

### Changes
- Pad the bottom of scrollable full-screen pages for the navigation bar when the page has no footer.
- Leave pages that already have a footer unchanged, since the footer accounts for it.

### Test plan
- On an Android 15 or newer device, open Settings, scroll to the bottom, and tap the version label five times to enable developer mode.

Fixes breez/glow-app#129