### PR TITLE
feat: make balance currency toggle read as a control

### DIFF
--- a/src/components/CollapsingWalletHeader.tsx
+++ b/src/components/CollapsingWalletHeader.tsx
@@ -4,7 +4,7 @@ import { safeAreaTop } from '../utils/safeAreaInsets';
 import { getFiatSettings } from '../services/settings';
 import { formatWithThinSpaces, formatWithSpaces } from '../utils/formatNumber';
 import { useAnimatedNumber } from '../hooks/useAnimatedNumber';
-import { MenuIcon, AlertTriangleIcon, CurrencyIcon, SpinnerIcon } from './Icons';
+import { MenuIcon, AlertTriangleIcon, CurrencyIcon, SpinnerIcon, SwapVerticalIcon } from './Icons';
 import { useStableBalance } from '../contexts/StableBalanceContext';
 import { useFiatData } from '../contexts/FiatDataContext';
 import { getTokenBalance, formatTokenAmount } from '../utils/tokenFormatting';
@@ -341,16 +341,23 @@ const CollapsingWalletHeader: React.FC<CollapsingWalletHeaderProps> = ({
               }`}
             >
               Balance
+              {/* Amber chip + swap glyph so the suffix reads as a
+                  currency-switch control, not part of the label (#300).
+                  Hover never fires on touch; active: is the mobile
+                  feedback path. Chip uses tighter tracking than the
+                  label so it stays compact and button-like. */}
               <button
                 type="button"
                 onClick={handleSuffixTap}
                 disabled={stableBalance.isToggling}
-                className="inline-flex items-center cursor-pointer transition-colors disabled:opacity-50 font-display text-xs font-medium tracking-widest uppercase"
+                aria-label={`Switch balance to ${stableBalance.isActive ? 'Bitcoin' : 'USD'}`}
+                className="group inline-flex items-center cursor-pointer transition-colors disabled:opacity-50 font-display text-xs font-medium uppercase"
               >
-                <span className="mx-1.5">·</span>
-                {/* White foreground so the tappable suffix reads as a
-                    button rather than blending into the muted label. */}
-                <span className="px-1.5 py-0.5 rounded-full text-spark-text-primary bg-white/5 hover:bg-white/10 active:scale-95 transition-all">{balanceSuffix}</span>
+                <span className="mx-1.5 tracking-widest">·</span>
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full tracking-wide text-spark-text-primary bg-white/10 border border-white/25 hover:bg-white/15 active:bg-white/20 active:scale-95 transition-all">
+                  <SwapVerticalIcon size="xs" className="w-2.5 h-2.5 transition-transform duration-300 group-active:rotate-180" />
+                  {balanceSuffix}
+                </span>
               </button>
             </span>
           </div>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -41,6 +41,12 @@ export const ChevronRightIcon: React.FC<IconProps> = ({ className = '', size = '
   </svg>
 );
 
+export const SwapVerticalIcon: React.FC<IconProps> = ({ className = '', size = 'md' }) => (
+  <svg className={`${sizeClasses[size]} ${className}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5" />
+  </svg>
+);
+
 // ============================================
 // ACTION ICONS
 // ============================================


### PR DESCRIPTION
## What

The sats/USD suffix next to BALANCE is the entry point to the stable balance flow, but it was styled as barely-visible highlighted text (bg-white/5) and easy to miss. This restyles it as a proper chip:

- Bordered chip: white/10 fill, white/25 border, text-spark-text-primary
- New SwapVerticalIcon (Icons.tsx) inside the chip signals "this switches currency"
- active: background bump for touch devices, where hover never fires
- Swap glyph rotates 180 degrees while pressed (300ms transform)
- State-aware aria-label: "Switch balance to USD" / "Switch balance to Bitcoin"
- Chip uses tracking-wide while the BALANCE label keeps tracking-widest, so the chip stays compact

## Verification

Verified live with Playwright against the dev wallet at 390x844: chip renders in the sats state, console clean on fresh load, accessibility snapshot announces the button as "Switch balance to USD". The USD state shares the same chip markup (only the suffix text changes). The pre-existing tsc error in passkeyService.ts is unrelated (present on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)