### PR TITLE
feat: turn on private mode for all wallets

### DIFF
--- a/src/hooks/buildConnectConfig.ts
+++ b/src/hooks/buildConnectConfig.ts
@@ -18,7 +18,6 @@ export function buildConnectConfig(overrideNetwork?: Network): Config {
   const network = (overrideNetwork ?? (urlParams.get('network') ?? 'mainnet')) as Network;
   const config: Config = defaultConfig(network);
   config.apiKey = breezApiKey;
-  config.privateEnabledDefault = false;
   config.stableBalanceConfig = {
     tokens: [{ label: USDB_TICKER, tokenIdentifier: USDB_TOKEN_IDENTIFIER }],
   };

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -1050,14 +1050,13 @@ export function useBreezSdk(
   // ----------------------------------------
 
   // Covers every connect path (onboarding, resume, label switch, migration
-  // adopt), which all land here once walletInfo is set.
+  // adopt), which all land here once the SDK instance is set.
   useEffect(() => {
-    const pubkey = walletInfo?.identityPubkey;
-    if (!sdk || !pubkey) return;
-    void ensureSparkPrivateMode(sdk, pubkey).catch((e) => {
+    if (!sdk) return;
+    void ensureSparkPrivateMode(sdk).catch((e) => {
       logger.warn(LogCategory.SDK, 'Failed to enable Spark private mode', { error: formatError(e) });
     });
-  }, [sdk, walletInfo?.identityPubkey]);
+  }, [sdk]);
 
   // LNURL domain body attribute
   useEffect(() => {

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -21,7 +21,7 @@ import { buildConnectConfig } from './buildConnectConfig';
 import { logger, LogCategory, logSdkMessage } from '../services/logger';
 import { formatError } from '../utils/formatError';
 import { isDepositRejected, clearRejectedDeposits } from '../services/depositState';
-import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, type BuyBitcoinProvider } from '../services/settings';
+import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, ensureSparkPrivateMode, type BuyBitcoinProvider } from '../services/settings';
 import { wipeAllLocalData } from '../services/accountDeletion';
 import { hideSplash } from '../main';
 import {
@@ -1048,6 +1048,16 @@ export function useBreezSdk(
   // ----------------------------------------
   // Effects
   // ----------------------------------------
+
+  // Covers every connect path (onboarding, resume, label switch, migration
+  // adopt), which all land here once walletInfo is set.
+  useEffect(() => {
+    const pubkey = walletInfo?.identityPubkey;
+    if (!sdk || !pubkey) return;
+    void ensureSparkPrivateMode(sdk, pubkey).catch((e) => {
+      logger.warn(LogCategory.SDK, 'Failed to enable Spark private mode', { error: formatError(e) });
+    });
+  }, [sdk, walletInfo?.identityPubkey]);
 
   // LNURL domain body attribute
   useEffect(() => {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -86,37 +86,8 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     if (typeof cfg.preferSparkOverLightning === 'boolean') return cfg.preferSparkOverLightning;
     return false;
   });
-  // Seed from the connected config's default so the toggle renders the
-  // right position before the async SDK read lands.
-  const [sparkPrivateModeEnabled, setSparkPrivateModeEnabled] = useState<boolean>(
-    () => config?.privateEnabledDefault !== false,
-  );
-  const [isLoadingUserSettings, setIsLoadingUserSettings] = useState<boolean>(true);
-
   const [isDownloadingLogs, setIsDownloadingLogs] = useState<boolean>(false);
   const [isExportingDb, setIsExportingDb] = useState<boolean>(false);
-
-  // Async SDK read for sparkPrivateModeEnabled. Stays in an effect
-  // because it awaits a Promise; setState happens post-await.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const us = await wallet.getUserSettings();
-        if (cancelled) return;
-        setSparkPrivateModeEnabled(us.sparkPrivateModeEnabled !== false);
-      } catch (e) {
-        logger.warn(LogCategory.SDK, 'Failed to load user settings from SDK', {
-          error: e instanceof Error ? e.message : String(e),
-        });
-      } finally {
-        if (!cancelled) setIsLoadingUserSettings(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [wallet]);
 
   // Persist dev mode to localStorage when toggled via secret tap
   useEffect(() => {
@@ -149,13 +120,6 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
         preferSparkOverLightning,
       };
       saveSettings(updated);
-    }
-    try {
-      await wallet.updateUserSettings({ sparkPrivateModeEnabled });
-    } catch (e) {
-      logger.warn(LogCategory.SDK, 'Failed to update SDK user settings', {
-        error: e instanceof Error ? e.message : String(e),
-      });
     }
     window.location.reload();
   };
@@ -364,27 +328,6 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
               <p className="text-xs text-spark-text-muted mt-2">
                 Changing network will reload the app and reconnect.
               </p>
-            </div>
-          )}
-
-          {/* Privacy */}
-          {isDevMode && (
-            <div className="bg-spark-dark border border-spark-border rounded-2xl p-4">
-              <div className="flex items-center gap-2 mb-3">
-                <h3 className="font-display font-semibold text-spark-text-primary">Privacy</h3>
-                {isLoadingUserSettings && <LoadingSpinner size="small" />}
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <span className="font-display font-medium text-spark-text-primary block">Private Mode</span>
-                  <span className="text-sm text-spark-text-muted">Hide your address from public explorers (not suitable for zaps)</span>
-                </div>
-                <Switch
-                  checked={sparkPrivateModeEnabled}
-                  onChange={() => setSparkPrivateModeEnabled(!sparkPrivateModeEnabled)}
-                  disabled={isLoadingUserSettings}
-                />
-              </div>
             </div>
           )}
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -86,7 +86,11 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     if (typeof cfg.preferSparkOverLightning === 'boolean') return cfg.preferSparkOverLightning;
     return false;
   });
-  const [sparkPrivateModeEnabled, setSparkPrivateModeEnabled] = useState<boolean>(true);
+  // Seed from the connected config's default so the toggle renders the
+  // right position before the async SDK read lands.
+  const [sparkPrivateModeEnabled, setSparkPrivateModeEnabled] = useState<boolean>(
+    () => config?.privateEnabledDefault !== false,
+  );
   const [isLoadingUserSettings, setIsLoadingUserSettings] = useState<boolean>(true);
 
   const [isDownloadingLogs, setIsDownloadingLogs] = useState<boolean>(false);

--- a/src/services/settings.test.ts
+++ b/src/services/settings.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// settings.ts caches localStorage reads in a module-level Map, so each case
+// re-imports to start from an empty cache as well as empty storage.
+async function loadSettings() {
+  vi.resetModules();
+  localStorage.clear();
+  return import('./settings');
+}
+
+function makeSdk(fail = false) {
+  const calls: { sparkPrivateModeEnabled: boolean }[] = [];
+  return {
+    calls,
+    updateUserSettings: async (request: { sparkPrivateModeEnabled: boolean }) => {
+      calls.push(request);
+      if (fail) throw new Error('offline');
+    },
+  };
+}
+
+describe('ensureSparkPrivateMode', () => {
+  let settings: Awaited<ReturnType<typeof loadSettings>>;
+
+  beforeEach(async () => {
+    settings = await loadSettings();
+  });
+
+  it('enables private mode for a wallet that has never been forced', async () => {
+    const sdk = makeSdk();
+    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
+    expect(sdk.calls).toEqual([{ sparkPrivateModeEnabled: true }]);
+  });
+
+  it('does not force again on a later connect, so an opt-out sticks', async () => {
+    const sdk = makeSdk();
+    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
+    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
+    expect(sdk.calls).toHaveLength(1);
+  });
+
+  it('forces each wallet on the device separately', async () => {
+    const sdk = makeSdk();
+    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
+    await settings.ensureSparkPrivateMode(sdk, 'pubkey-b');
+    expect(sdk.calls).toHaveLength(2);
+  });
+
+  it('leaves no marker when the SDK call fails, so the next connect retries', async () => {
+    const failing = makeSdk(true);
+    await expect(settings.ensureSparkPrivateMode(failing, 'pubkey-a')).rejects.toThrow('offline');
+
+    const sdk = makeSdk();
+    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
+    expect(sdk.calls).toEqual([{ sparkPrivateModeEnabled: true }]);
+  });
+});
+
+describe('buildConnectConfig', () => {
+  it('connects with private mode enabled by default', async () => {
+    vi.stubEnv('VITE_BREEZ_API_KEY', 'test-key');
+    const { buildConnectConfig } = await import('../hooks/buildConnectConfig');
+    expect(buildConnectConfig('mainnet').privateEnabledDefault).toBe(true);
+    vi.unstubAllEnvs();
+  });
+});

--- a/src/services/settings.test.ts
+++ b/src/services/settings.test.ts
@@ -1,58 +1,41 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { ensureSparkPrivateMode } from './settings';
 
-// settings.ts caches localStorage reads in a module-level Map, so each case
-// re-imports to start from an empty cache as well as empty storage.
-async function loadSettings() {
-  vi.resetModules();
-  localStorage.clear();
-  return import('./settings');
-}
-
-function makeSdk(fail = false) {
-  const calls: { sparkPrivateModeEnabled: boolean }[] = [];
+function makeSdk(sparkPrivateModeEnabled: boolean, failUpdate = false) {
+  const updates: { sparkPrivateModeEnabled: boolean }[] = [];
   return {
-    calls,
+    updates,
+    getUserSettings: async () => ({ sparkPrivateModeEnabled }),
     updateUserSettings: async (request: { sparkPrivateModeEnabled: boolean }) => {
-      calls.push(request);
-      if (fail) throw new Error('offline');
+      updates.push(request);
+      if (failUpdate) throw new Error('offline');
     },
   };
 }
 
 describe('ensureSparkPrivateMode', () => {
-  let settings: Awaited<ReturnType<typeof loadSettings>>;
-
-  beforeEach(async () => {
-    settings = await loadSettings();
+  it('turns private mode on when the wallet has it off', async () => {
+    const sdk = makeSdk(false);
+    await ensureSparkPrivateMode(sdk);
+    expect(sdk.updates).toEqual([{ sparkPrivateModeEnabled: true }]);
   });
 
-  it('enables private mode for a wallet that has never been forced', async () => {
-    const sdk = makeSdk();
-    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
-    expect(sdk.calls).toEqual([{ sparkPrivateModeEnabled: true }]);
+  it('keeps private mode on when the user turns it off out of band', async () => {
+    const sdk = makeSdk(false);
+    await ensureSparkPrivateMode(sdk);
+    await ensureSparkPrivateMode(sdk);
+    expect(sdk.updates).toHaveLength(2);
   });
 
-  it('does not force again on a later connect, so an opt-out sticks', async () => {
-    const sdk = makeSdk();
-    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
-    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
-    expect(sdk.calls).toHaveLength(1);
+  it('writes nothing when private mode is already on', async () => {
+    const sdk = makeSdk(true);
+    await ensureSparkPrivateMode(sdk);
+    expect(sdk.updates).toEqual([]);
   });
 
-  it('forces each wallet on the device separately', async () => {
-    const sdk = makeSdk();
-    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
-    await settings.ensureSparkPrivateMode(sdk, 'pubkey-b');
-    expect(sdk.calls).toHaveLength(2);
-  });
-
-  it('leaves no marker when the SDK call fails, so the next connect retries', async () => {
-    const failing = makeSdk(true);
-    await expect(settings.ensureSparkPrivateMode(failing, 'pubkey-a')).rejects.toThrow('offline');
-
-    const sdk = makeSdk();
-    await settings.ensureSparkPrivateMode(sdk, 'pubkey-a');
-    expect(sdk.calls).toEqual([{ sparkPrivateModeEnabled: true }]);
+  it('rejects when the SDK call fails, so the caller can log it', async () => {
+    const sdk = makeSdk(false, true);
+    await expect(ensureSparkPrivateMode(sdk)).rejects.toThrow('offline');
   });
 });
 

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -118,22 +118,21 @@ export function isCrossChainEnabled(): boolean {
 }
 
 /**
- * Turn on Spark private mode for this wallet, at most once.
+ * Hold every wallet in Spark private mode. Private mode is not optional in
+ * Glow, so this runs on every connect rather than one time.
  *
  * `Config.privateEnabledDefault` is applied only to storage the SDK has never
  * initialized, so wallets used before that default (or seeds restored from
- * another app) keep whatever they had. One shot per identity: a later opt-out
- * sticks. Rejects when the SDK call fails, leaving no marker so the next
- * connect retries.
+ * another app) keep whatever they had. Writes only when the setting is off,
+ * to keep repeat connects off the sync record.
  */
-export async function ensureSparkPrivateMode(
-  sdk: { updateUserSettings(request: { sparkPrivateModeEnabled: boolean }): Promise<unknown> },
-  identityPubkey: string,
-): Promise<void> {
-  const key = `sparkPrivateModeForced:${identityPubkey}`;
-  if (getCachedItem(key) === 'true') return;
+export async function ensureSparkPrivateMode(sdk: {
+  getUserSettings(): Promise<{ sparkPrivateModeEnabled: boolean }>;
+  updateUserSettings(request: { sparkPrivateModeEnabled: boolean }): Promise<unknown>;
+}): Promise<void> {
+  const current = await sdk.getUserSettings();
+  if (current.sparkPrivateModeEnabled) return;
   await sdk.updateUserSettings({ sparkPrivateModeEnabled: true });
-  setCachedItem(key, 'true');
 }
 
 export function getFiatSettings(): FiatSettings {

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -117,6 +117,25 @@ export function isCrossChainEnabled(): boolean {
   return getSettings().crossChainEnabled === true;
 }
 
+/**
+ * Turn on Spark private mode for this wallet, at most once.
+ *
+ * `Config.privateEnabledDefault` is applied only to storage the SDK has never
+ * initialized, so wallets used before that default (or seeds restored from
+ * another app) keep whatever they had. One shot per identity: a later opt-out
+ * sticks. Rejects when the SDK call fails, leaving no marker so the next
+ * connect retries.
+ */
+export async function ensureSparkPrivateMode(
+  sdk: { updateUserSettings(request: { sparkPrivateModeEnabled: boolean }): Promise<unknown> },
+  identityPubkey: string,
+): Promise<void> {
+  const key = `sparkPrivateModeForced:${identityPubkey}`;
+  if (getCachedItem(key) === 'true') return;
+  await sdk.updateUserSettings({ sparkPrivateModeEnabled: true });
+  setCachedItem(key, 'true');
+}
+
 export function getFiatSettings(): FiatSettings {
   try {
     const raw = getCachedItem(FIAT_SETTINGS_KEY);


### PR DESCRIPTION
This PR turns on private mode for every wallet and keeps it on. New
wallets start in private mode. Wallets that are already in use change to
private mode at the next connect. Wallets that come from a different app
also change.

Private mode is now always on. The developer setting that turned it off
is removed.