### PR TITLE
Keep a failed silent start from looking like a lost account

### DIFF
--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -493,7 +493,14 @@ export function useBreezSdk(
           try {
             await deviceOnlyStorage.storeSeed(seed);
           } catch {
-            // non-fatal; storage layer logged.
+            // Non-fatal for this session, but the next launch has
+            // nothing to reconnect from, so say so rather than letting
+            // it look like the app forgot the account on restart.
+            showToast(
+              'error',
+              'Could not save to this device',
+              'You may be asked to sign in again the next time you open Glow.',
+            );
           }
         } else if (passkeyLabel != null) {
           // Web passkey mode: never cache the PRF-derived seed.
@@ -937,6 +944,16 @@ export function useBreezSdk(
     setError(null);
     setIsLoading(true);
     try {
+      // Device-only is the default tier; the bound tier only exists on
+      // pre-app-lock installs. With nothing bound there is no biometric
+      // to retry, so this is a plain reconnect retry after a failed
+      // silent start.
+      if (!(await secureStorage.hasStoredSeed())) {
+        logger.info(LogCategory.AUTH, 'retryUnlock:deviceOnlyReconnect');
+        const seed = await deviceOnlyStorage.retrieveSeed();
+        await connectWallet(seed, false, undefined, 'secureStorage');
+        return;
+      }
       logger.info(LogCategory.AUTH, 'retryUnlock:callingRetrieveSeed');
       const seed = await secureStorage.retrieveSeed();
       await connectWallet(seed, false, undefined, 'secureStorage');
@@ -1185,6 +1202,17 @@ export function useBreezSdk(
             { error: formatError(e) },
           );
           setIsLoading(false);
+          // The seed is still in the vault unless the vault itself lost
+          // it, so anything else (connect threw, SDK init failed) must
+          // route to UnlockPage's retry. Falling through to 'no-wallet'
+          // showed the welcome screen after one transient failure and
+          // read as "the app forgot my account".
+          const vaultEmpty = e instanceof SecureStorageError
+            && (e.code === 'NO_STORED_SEED' || e.code === 'KEY_INVALIDATED');
+          if (!vaultEmpty) {
+            setError('Could not reconnect. Please try again.');
+            setStartupState('native-locked');
+          }
         }
       }
 
@@ -1202,7 +1230,9 @@ export function useBreezSdk(
           } catch (e) {
             logger.error(LogCategory.SDK, 'Failed to connect with saved mnemonic', { error: formatError(e) });
             setError('Failed to connect with saved mnemonic. Please try again.');
-            clearMnemonic();
+            // Deliberately keep the mnemonic: a failed connect is a
+            // network/SDK outcome, not proof the seed is bad, and
+            // clearing it here lost the only copy on the device.
             setIsLoading(false);
           }
         } else if (isPasskeyMode()) {

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -21,6 +21,7 @@ import {
   getActivePasskeyCredentialIdBytes,
   signInPinnedToActiveCredential,
   removeStaleCredential,
+  passkeyAvailability,
 } from '@/services/passkeyService';
 import {
   PasskeyAlreadyExistsError,
@@ -183,7 +184,10 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
     const run = async () => {
       let availability;
       try {
-        availability = await getPasskey().checkAvailability();
+        // Memoized: the welcome screen already warmed this behind the
+        // splash, so the tap lands on the WebAuthn call with the user
+        // activation still live (see passkeyAvailability).
+        availability = await passkeyAvailability();
       } catch (e) {
         // Documented to never throw; defensive fallback treats it as
         // a pass so the app doesn't hard-stop on a diagnostic check.
@@ -286,6 +290,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       // or on native / non-immediate browsers, which use the explicit flow.
       const switchPending = !!localStorage.getItem('passkeyPendingSwitchFromCredentialId');
       const api = getPasskey();
+      let ceremonyStartMs = 0;
       if (immediate && !switchPending && api.connectWithPasskey) {
         try {
           const activeCredId = getActivePasskeyCredentialIdBytes();
@@ -297,6 +302,11 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
           const userName = `Glow · ${createPasskeyTimestampLabel()}`;
           // Timed like register/signIn below: the label discovery inside
           // stalls on dead relays, and the timer isolates that from connect().
+          // Ceremony-scoped clock. `detectStartMs` also covers the
+          // capability probes and client build ahead of it, which on a
+          // cold browser profile dwarf the call itself and make a
+          // "did the prompt actually run?" read impossible.
+          ceremonyStartMs = Date.now();
           const response = await logger.time('[onboarding] passkey.connectWithPasskey', () =>
             api.connectWithPasskey!({
               allowCredentials: activeCredId ? [activeCredId] : undefined,
@@ -328,7 +338,17 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             && (errorName === 'NotAllowedError' || errorName === 'AbortError' || looksCancelled);
           const elapsedMs = Date.now() - detectStartMs;
           logger.warn(LogCategory.AUTH, 'connectWithPasskey failed', {
-            errorName, isTimedOut, isAlreadyExists, isCancelled, elapsedMs,
+            errorName,
+            errorMessage,
+            isTimedOut,
+            isAlreadyExists,
+            isCancelled,
+            elapsedMs,
+            // Zero means we never reached the call; a handful of ms
+            // means it fast-failed with no prompt shown (no credential
+            // silently available, or the tap's activation had lapsed).
+            ceremonyMs: ceremonyStartMs ? Date.now() - ceremonyStartMs : 0,
+            setupMs: ceremonyStartMs ? ceremonyStartMs - detectStartMs : elapsedMs,
           });
           if (isAlreadyExists) {
             // The active cred is gone but another Glow passkey is present, so

--- a/src/pages/UnlockPage.tsx
+++ b/src/pages/UnlockPage.tsx
@@ -38,6 +38,10 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
   const isWebPasskey = !secureStorage.isSupported();
 
   const [biometry, setBiometry] = useState<BiometryInfo | null>(null);
+  // Only pre-app-lock installs keep the seed behind a biometric. With
+  // nothing in that tier this page is a plain reconnect retry (the
+  // silent start failed), so it must not promise a Face ID prompt.
+  const [isBiometricTier, setIsBiometricTier] = useState(true);
 
   useEffect(() => {
     if (isWebPasskey) return;
@@ -45,6 +49,9 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
     getBiometryInfo().then((info) => {
       if (!cancelled) setBiometry(info);
     });
+    secureStorage.hasStoredSeed().then((stored) => {
+      if (!cancelled) setIsBiometricTier(stored);
+    }).catch(() => undefined);
     return () => {
       cancelled = true;
     };
@@ -52,10 +59,12 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
 
   const unlockLabel = isWebPasskey
     ? 'Unlock with passkey'
-    : biometry ? `Unlock with ${biometry.label}` : 'Unlock';
+    : !isBiometricTier ? 'Try Again'
+      : biometry ? `Unlock with ${biometry.label}` : 'Unlock';
   const unlockDescription = isWebPasskey
     ? 'Your wallet is locked. Unlock with your passkey to continue.'
-    : 'Your wallet is locked. Unlock with your biometric to continue.';
+    : !isBiometricTier ? 'Glow could not start up. Please try again.'
+      : 'Your wallet is locked. Unlock with your biometric to continue.';
   const UnlockIcon = isWebPasskey
     ? PasskeyIcon
     : biometry?.kind === 'face' ? FaceIdIcon : FingerprintIcon;
@@ -81,7 +90,7 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
 
           {/* Error banner */}
           {error && (
-            <AlertCard variant="error" title="Unlock failed">
+            <AlertCard variant="error" title={isBiometricTier ? 'Unlock failed' : 'Could not start'}>
               {error}
             </AlertCard>
           )}
@@ -92,7 +101,7 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
               disabled={isLoading}
               className="w-full flex items-center justify-center gap-2"
             >
-              <UnlockIcon size="md" />
+              {isBiometricTier && <UnlockIcon size="md" />}
               {unlockLabel}
             </PrimaryButton>
 

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -876,13 +876,46 @@ export function prfAvailability(): Promise<boolean> {
   return prfAvailablePromise;
 }
 
+let availabilityPromise: Promise<PasskeyAvailability> | null = null;
+
+/**
+ * Memoized `checkAvailability()`.
+ *
+ * The probe used to run twice per sign-in: once behind the splash for
+ * the welcome screen's flow pick, then again on PasskeyPage mount. It
+ * is a first-touch SDK call (and the domain-association check on
+ * native), so the second run put real work between the user's tap and
+ * the WebAuthn call. Immediate mediation needs the tap's transient
+ * activation to still be live when it fires, and on a cold profile (a
+ * fresh private window) that second probe was enough to lose it: the
+ * first attempt failed and only Try Again worked.
+ *
+ * A `notAssociated` result is not cached: that one can come from a
+ * transient probe failure, and pinning it would make the error screen's
+ * retry pointless.
+ */
+export function passkeyAvailability(): Promise<PasskeyAvailability> {
+  if (!availabilityPromise) {
+    availabilityPromise = getPasskey().checkAvailability()
+      .then((availability) => {
+        if (availability.type === 'notAssociated') availabilityPromise = null;
+        return availability;
+      })
+      .catch((e) => {
+        availabilityPromise = null;
+        throw e;
+      });
+  }
+  return availabilityPromise;
+}
+
 /** Collapse the SDK's four availability variants to a single bool. */
 export async function isPrfAvailable(): Promise<boolean> {
   const ua = navigator.userAgent;
   // Firefox PRF support is still unreliable; gate off entirely.
   if (/Firefox\//i.test(ua) && !/Seamonkey\//i.test(ua)) return false;
 
-  const availability = await getPasskey().checkAvailability();
+  const availability = await passkeyAvailability();
   return availability.type !== 'prfUnsupported';
 }
 


### PR DESCRIPTION
Restarting the app could drop you at the welcome screen asking for a recovery phrase or a fresh sign-in, even though your account was still safely on the device. One transient hiccup during the silent start was enough, and because the next launch usually worked it looked random.

What changed:

- A start that cannot reconnect now lands on the retry screen instead of onboarding. Only a device store that genuinely no longer holds the account routes to the welcome screen.
- That retry screen no longer asks for Face ID or a fingerprint when none is involved. It offers a plain Try Again, and keeps the biometric wording only for the older installs that still keep the key behind one.
- A failed connection no longer deletes the stored recovery phrase. A network failure is not evidence that the phrase is bad, and deleting it removed the only copy on the device.
- If saving to the device fails during setup, you are told at the time instead of finding out on the next launch.

Also in here, from a separate report: signing in with a passkey in a fresh private window failed on the first attempt and worked on Try Again. A capability check was running twice per sign-in, and the second run sat between the tap and the system prompt, which on a cold profile was long enough for the browser to no longer treat the prompt as tap-initiated. It now runs once. The failure breadcrumb also separates setup time from prompt time so a repeat report is unambiguous.

## Test plan

Needs a device (the reconnect paths are native only) and a private browser window.

- Set up an account, force quit, relaunch. It should reconnect silently, with no prompt.
- Put the device in airplane mode and relaunch. Expect the retry screen with a Try Again button and no biometric prompt, not the welcome screen. Restore the network and tap Try Again.
- On an install that predates the optional lock screen, relaunch once. The one time OS prompt should still appear and should not come back on later launches.
- Open the web app in a private window and sign in with a passkey. It should work on the first attempt.