### PR TITLE
Let a device with no passkey reach the create step

### DIFF
--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -633,21 +633,22 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
         }
         if (isCancelled) {
           // Native fast-fail no-creds was already routed silently.
-          // A slow cancel means the user has a passkey and dismissed
-          // the picker, so we refuse to offer Create. Web can't
+          // A slow cancel means the user probably has a passkey and
+          // dismissed the picker, so Create is demoted to a secondary
+          // action in the footer rather than the default. Web can't
           // distinguish no-creds from a hybrid-sheet dismiss (Chrome's
           // `uiMode: 'immediate'` surfaces the QR sheet whenever a
           // hybrid-paired device exists), so the web branch lets the
           // render decide via the two-CTA gate.
           if (Capacitor.isNativePlatform()) {
-            logger.info(LogCategory.AUTH, 'User dismissed passkey sheet (native); refusing to offer Create', {
+            logger.info(LogCategory.AUTH, 'User dismissed passkey sheet (native)', {
               errorCode,
               elapsedMs,
             });
             setError(
               isLikelyTimeout(elapsedMs)
                 ? 'Sign-in timed out. Please try again.'
-                : 'Sign-in cancelled. Please pick your passkey to continue.',
+                : 'Sign-in cancelled. Pick your passkey to continue, or create a new one.',
             );
             setErrorKind('sign-in-cancelled');
           } else {
@@ -1127,8 +1128,11 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
       );
     }
 
-    // Slow cancel on detecting: user dismissed a sheet (they have a
-    // passkey). Offering Create would lure a duplicate, so retry only.
+    // Slow cancel on detecting: user dismissed a sheet, so they probably
+    // have a passkey and Try Again stays the primary action. Create is
+    // offered as a secondary escape (this branch only fires for a device
+    // with no passkey history), or a first-timer whose OS still put a
+    // sheet in front of them has no way forward at all.
     // Bouncing through aasa-checking re-fires the detecting effect
     // (which only depends on [phase]).
     if (error && phase === 'detecting' && errorKind === 'sign-in-cancelled') {
@@ -1141,6 +1145,14 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
           }}>
             Try Again
           </PrimaryButton>
+          <SecondaryButton className="w-full" onClick={() => {
+            setError(null);
+            setErrorKind(null);
+            setIsNewUser(true);
+            setPhase('creating');
+          }}>
+            Create Passkey
+          </SecondaryButton>
         </div>
       );
     }

--- a/src/services/passkeyService.ts
+++ b/src/services/passkeyService.ts
@@ -301,7 +301,12 @@ class NativePasskey implements PasskeyApi {
       const r = await this.plugin().signIn({
         label: request.label,
         allowCredentials: request.allowCredentials?.map(bytesToBase64),
-        preferImmediatelyAvailableCredentials: request.preferImmediatelyAvailableCredentials,
+        // Always true on native: it suppresses the cross-device sheet so a
+        // device with no passkey fast-fails as CREDENTIAL_NOT_FOUND and the
+        // caller can route to create. The caller's flag is the web
+        // immediate-mediation capability, which is false on native, and
+        // forwarding it re-opens the picker on a device with nothing to pick.
+        preferImmediatelyAvailableCredentials: true,
       });
       return {
         wallet: decodeWallet(r.wallet),


### PR DESCRIPTION
A device with no passkey cannot create one in the app.

The user installs the app. The user selects the passkey option. The app shows a sign-in sheet. The user closes the sheet. The app shows only a Try Again button. The user cannot create a passkey. This occurs on iOS and on Android. Users must create the passkey in the web app first.

Cause: at start, the app does a silent check for a passkey on the device. A recent change sends a browser-only setting to the app. This setting tells the platform to show a sign-in sheet. Thus the check is not silent. The app reads the closed sheet as a cancelled sign-in. Then it does not offer to create a passkey.

Changes:

- The app ignores the browser-only setting. It always does the silent check. A device with no passkey goes directly to the create step.
- The cancel screen shows a Create button below the Try Again button.
- The browser flow does not change.

Tests:

1. Remove all Glow passkeys from the device and from the cloud account.
2. Install the app and open it.
3. Select the passkey option. The app must go directly to the create step. It must not show a sign-in sheet.
4. On a device that has a Glow passkey, sign in. Then start again and close the prompt. The screen must show a Try Again button and a Create button.
5. Do these tests on iOS and on Android.