### PR TITLE
fix(android): keep bottom sheets from closing themselves after opening

### DIFF
--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -270,10 +270,15 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       const bottom = Math.max(0, stableViewportH - kb);
       // Index 2 (full) or the collapsed [0, 1] ladder rest at y 0 (top
       // of the keyboard). The content snap rests contentPx px above it.
-      const targetY =
+      const restY =
         !useContentSnap || idx >= 2
           ? 0
           : Math.max(0, bottom - (contentPx ?? bottom));
+      // A stale --keyboard-height (hide events missed while
+      // backgrounded) inflates stableViewportH and computes a rest
+      // below the live viewport; clamp so the sheet can never park
+      // fully off-screen.
+      const targetY = Math.min(restY, Math.max(0, window.innerHeight - 96));
       if (lastReposTargetRef.current === targetY) return;
       lastReposTargetRef.current = targetY;
       if (animated) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -69,10 +69,17 @@ if (Capacitor.isNativePlatform()) {
   // warning; we don't store the handle because main.tsx runs once at
   // startup and the listener lifetime is the app lifetime.
   let keyboardHideClassTimer: ReturnType<typeof setTimeout> | null = null;
+  let keyboardFreeInnerHeight: number | null = null;
   void Keyboard.addListener('keyboardWillShow', (info) => {
     if (keyboardHideClassTimer) {
       clearTimeout(keyboardHideClassTimer);
       keyboardHideClassTimer = null;
+    }
+    // Keyboard-free baseline for the stale-state check below. Only
+    // captured while the keyboard is down: a field switch fires
+    // willShow again with the viewport already shrunk.
+    if (!document.documentElement.classList.contains('keyboard-visible')) {
+      keyboardFreeInnerHeight = window.innerHeight;
     }
     document.documentElement.style.setProperty(
       '--keyboard-height',
@@ -134,6 +141,29 @@ if (Capacitor.isNativePlatform()) {
       document.documentElement.classList.remove('keyboard-visible');
     }, 250);
     logger.debug(LogCategory.UI, 'Keyboard will hide');
+  });
+
+  // Android fires no keyboard hide events when the app leaves the
+  // foreground with the keyboard up (Home, app switch): the var and
+  // class above then stay stale, and the next sheet mount seeds its
+  // keyboard-free height one keyboard too tall, parking the sheet
+  // below the viewport. The window does resize back to full height
+  // right away, so a keyboard-free-height resize while the class is
+  // still set IS the missed hide.
+  window.addEventListener('resize', () => {
+    if (
+      keyboardFreeInnerHeight !== null &&
+      window.innerHeight >= keyboardFreeInnerHeight &&
+      document.documentElement.classList.contains('keyboard-visible')
+    ) {
+      if (keyboardHideClassTimer) {
+        clearTimeout(keyboardHideClassTimer);
+        keyboardHideClassTimer = null;
+      }
+      document.documentElement.style.setProperty('--keyboard-height', '0px');
+      document.documentElement.classList.remove('keyboard-visible');
+      logger.debug(LogCategory.UI, 'Cleared stale keyboard state on resize');
+    }
   });
 }
 


### PR DESCRIPTION
Fixes #321

## Problem

On Android, opening the send sheet shortly after returning to the app could make it vanish the moment it finished expanding, and every retry did the same. Leaving the app with the keyboard open delivers no hide signal, so the app kept believing the keyboard was up; the next sheet then positioned itself against a screen one keyboard taller than reality and landed entirely below the visible area.

## Fix

Two layers. The app now treats the window returning to its full height while keyboard state is still marked as the missed hide signal and resets that state on the spot. As a safety net, a sheet can no longer position itself fully off screen; in the worst case its handle and title stay visible and usable.

## Verification

Reproduced the field recording exactly on an Android 16 emulator with live instrumentation: the stale state parks the sheet one frame after its open animation, identical to the report. With the fix, the same flows keep the sheet on screen, and typing in the sheet, switching fields, and closing with the keyboard up all behave as before (125 unit tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)