### PR TITLE
fix: don't report a sign-in failure on a fresh install

### DIFF
--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -536,14 +536,25 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
               setErrorKind('switch-recovery');
               return;
             }
-            logger.warn(LogCategory.AUTH, 'Fast no-cred on returning user, treating as Settings deletion', {
+            logger.warn(LogCategory.AUTH, 'Fast no-cred after retry, treating as deletion', {
               errorCode,
               isCredentialNotFound,
               isCancelled,
               elapsedMs,
+              isFreshInstall: isFreshInstallRef.current,
             });
             await clearPasskeyHistory();
             if (cancelled) return;
+            if (isFreshInstallRef.current) {
+              // `passkeyRegistered` was adopted from the synced credential
+              // registry at startup, not from real history on this device,
+              // and the credential it named is already deleted. The wipe
+              // above just dropped that claim, so this is a new user: route
+              // like one instead of reporting a sign-in that never happened.
+              setIsNewUser(true);
+              setPhase('creating');
+              return;
+            }
             setError(
               'Your Glow passkey is no longer on this device. You can create a new one.',
             );


### PR DESCRIPTION
## The problem

A tester does a fresh install. The Get Started screen shows an error: "Sign-in failed. Your Glow passkey is no longer on this device."

The tester did not sign in on that device. The error is not correct.

The tester restarts the app. The error does not come back.

## The cause

Glow keeps a list of the known passkeys. The phone keeps this list in the account storage, not in the app. An uninstall does not delete the list. A new install gets the list again.

At start, Glow reads the list. If the list is not empty, Glow decides that the person used this device before. Glow then tries to sign in.

If the person deleted the passkeys, the list is not correct. The sign-in fails. Glow shows the error.

Glow then deletes the incorrect list. This is why a restart looks correct. At the next start the list is empty.

## The change

Glow deletes the incorrect list, as before. After that deletion, the person is a new user. Glow now shows the usual start screen and no error.

A person who used a passkey on this device, and then deleted it, still gets the error. That message stays correct.

Before this step, Glow tries the sign-in one more time. This retry gives the account sync more time. The retry does not change.

## Test plan

1. Install Glow. Create a passkey.
2. Delete the passkey in the settings of the phone.
3. Install Glow again. The usual start screen must show. No error must show.
4. Sign in. Delete the passkey in the settings of the phone. Do not install again. The error must show.
5. Sign in as usual. The behavior must not change.