### PR TITLE
fix: pre-release fixes for the store submission

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense, lazy } from 'react';
 import { WalletProvider, WalletInfoProvider, WalletStatusProvider } from './contexts/WalletContext';
 import LoadingSpinner from './components/LoadingSpinner';
-import PaymentReceivedCelebration from './components/PaymentReceivedCelebration';
+import PaymentCelebration from './components/PaymentCelebration';
 import InstallPrompt from './components/InstallPrompt';
 import OfflineBanner from './components/OfflineBanner';
 import StagingGate from './components/StagingGate';
@@ -580,7 +580,7 @@ const AppContent: React.FC = () => {
                   behind the lock screen would burn it unseen. Deferring
                   the mount plays it in full after unlock. */}
               {sdk.celebrationPayment !== null && !appLock.locked && (
-                <PaymentReceivedCelebration
+                <PaymentCelebration
                   payment={sdk.celebrationPayment}
                   onClose={sdk.dismissCelebration}
                 />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -604,6 +604,10 @@ const AppContent: React.FC = () => {
                   suppressAutoBiometric={currentScreen === 'unlocking' || currentScreen === 'unlock'}
                   unlockWithPin={appLock.unlockWithPin}
                   unlockWithBiometric={appLock.unlockWithBiometric}
+                  onForgotPin={async () => {
+                    await handleLogout();
+                    appLock.unlockAfterWipe();
+                  }}
                 />
               )}
             </StableBalanceProvider>

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,66 @@
+/**
+ * Last-resort boundary around the whole tree. Without one, any throw in
+ * a render or lifecycle unmounts the root and leaves a blank screen: on
+ * a native build there is no address bar and no reload, so the only way
+ * out is force-quitting, and a throw sourced from persisted state
+ * reproduces on every launch.
+ *
+ * Reload is the recovery action because the failures this catches are
+ * transient render throws (a malformed third-party payload reaching a
+ * parser mid-render). "Erase and start over" deliberately is NOT offered
+ * here: a render bug must never be a route to deleting an account.
+ */
+
+import React from 'react';
+import { logger, LogCategory } from '../services/logger';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class AppErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    logger.error(LogCategory.UI, 'Unhandled render error', {
+      error: error.message,
+      componentStack: info.componentStack ?? undefined,
+    });
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <div className="min-h-dvh w-full flex flex-col items-center justify-center gap-6 bg-spark-surface px-6 text-center">
+        <img src="/assets/Glow_Logo.svg" alt="Glow" className="w-24 h-24 object-contain" />
+        <div className="space-y-2">
+          <h1 className="font-display text-xl font-bold text-spark-text-primary">
+            Something went wrong
+          </h1>
+          <p className="text-sm text-spark-text-secondary">
+            Glow hit an unexpected error. Your funds are safe: reloading does not
+            change anything stored on this device.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="px-6 py-3 rounded-xl bg-spark-primary font-display font-semibold text-white"
+        >
+          Reload Glow
+        </button>
+      </div>
+    );
+  }
+}
+
+export default AppErrorBoundary;

--- a/src/components/LockScreen.tsx
+++ b/src/components/LockScreen.tsx
@@ -4,12 +4,18 @@
  * once automatically and stays retriable from the pad's fingerprint
  * button. PIN always works as fallback. Hardware back is absorbed so
  * Android can't pop the lock.
+ *
+ * The lock covers every screen including Backup, and the PIN has no
+ * reset, so the "Forgot your PIN?" escape is the only alternative to
+ * reinstalling. It erases all local data, so it is confirm-gated.
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { PinEntry, PinScreenLayout } from './PinEntry';
 import { getBiometryInfo, BiometryKind } from '../services/secureStorage';
 import { useBackButton } from '../hooks/useBackButton';
+import { ConfirmDialog } from './ui';
+import { isPasskeyMode } from '@/services/passkeyService';
 
 interface LockScreenProps {
   biometricGate: boolean;
@@ -19,6 +25,10 @@ interface LockScreenProps {
   suppressAutoBiometric?: boolean;
   unlockWithPin: (pin: string) => Promise<boolean>;
   unlockWithBiometric: () => Promise<void>;
+  /** Erase-everything escape for a forgotten PIN. The PIN is not
+   *  recoverable and the lock covers the whole app (including Backup),
+   *  so without this the only way out is reinstalling. */
+  onForgotPin: () => Promise<void>;
 }
 
 const LockScreen: React.FC<LockScreenProps> = ({
@@ -26,8 +36,12 @@ const LockScreen: React.FC<LockScreenProps> = ({
   suppressAutoBiometric = false,
   unlockWithPin,
   unlockWithBiometric,
+  onForgotPin,
 }) => {
   useBackButton(useCallback(() => true, []), true);
+
+  const [showForgotConfirm, setShowForgotConfirm] = useState(false);
+  const isPasskey = isPasskeyMode();
 
   // With the biometric gate on, the pad stays hidden until the OS
   // prompt settles: it only appears when the user cancels or biometrics
@@ -88,6 +102,14 @@ const LockScreen: React.FC<LockScreenProps> = ({
               biometryKind={biometryKind}
             />
           </PinScreenLayout>
+
+          <button
+            type="button"
+            onClick={() => setShowForgotConfirm(true)}
+            className="mx-auto mt-6 shrink-0 text-sm text-spark-text-muted underline hover:text-spark-text-secondary transition-colors"
+          >
+            Forgot your PIN?
+          </button>
         </div>
       ) : (
         // Biometric pending: replicate the splash exactly (the same 144
@@ -98,6 +120,20 @@ const LockScreen: React.FC<LockScreenProps> = ({
           <img src="/assets/Glow_Logo.svg" alt="Glow" className="w-36 h-36 object-contain" />
         </div>
       )}
+
+      {/* Above this overlay's own z-[100000]: the dialog portals to body. */}
+      <ConfirmDialog
+        isOpen={showForgotConfirm}
+        variant="danger"
+        zClassName="z-[100001]"
+        title="Forgot your PIN?"
+        message={isPasskey
+          ? "The PIN can't be recovered. The only way back in is to erase all Glow data on this device and sign in again with your passkey."
+          : "The PIN can't be recovered. The only way back in is to erase all Glow data on this device and restore from your recovery phrase. Make sure you have it saved."}
+        confirmLabel="Erase"
+        onConfirm={() => { setShowForgotConfirm(false); void onForgotPin(); }}
+        onCancel={() => setShowForgotConfirm(false)}
+      />
     </div>
   );
 };

--- a/src/components/PaymentCelebration.tsx
+++ b/src/components/PaymentCelebration.tsx
@@ -7,12 +7,15 @@ import { getTokenAmountFromPayment, formatTokenAmount, buildTokenDisplayConfig }
 import GlowLogo from './GlowLogo';
 import { hapticLight } from '@/utils/haptics';
 
-interface PaymentReceivedCelebrationProps {
+interface PaymentCelebrationProps {
   payment: Payment;
   onClose: () => void;
 }
 
-const PaymentReceivedCelebration: React.FC<PaymentReceivedCelebrationProps> = ({ payment, onClose }) => {
+const PaymentCelebration: React.FC<PaymentCelebrationProps> = ({ payment, onClose }) => {
+  // Sends only reach here when the send sheet was dismissed mid-payment,
+  // so this is the only report the user gets of the outcome.
+  const isSent = payment.paymentType === 'send';
   const stableBalance = useStableBalance();
   const { fiatCurrencies } = useFiatData();
   const [isVisible, setIsVisible] = useState(false);
@@ -87,7 +90,7 @@ const PaymentReceivedCelebration: React.FC<PaymentReceivedCelebrationProps> = ({
 
         {/* Title */}
         <h2 className="text-2xl font-display font-bold text-spark-text-primary mb-6 animate-fade-in-up" style={{ animationDelay: '0.2s' }}>
-          Payment Received
+          {isSent ? 'Payment Sent' : 'Payment Received'}
         </h2>
 
         {/* Amount with brand glow */}
@@ -95,7 +98,7 @@ const PaymentReceivedCelebration: React.FC<PaymentReceivedCelebrationProps> = ({
           <div className="absolute inset-0 blur-2xl rounded-full" style={{ background: 'rgba(212,165,116,0.35)' }} />
           {displayText ? (
             <span className="relative text-5xl font-display font-bold text-spark-primary">
-              +{(() => {
+              {isSent ? '-' : '+'}{(() => {
                 const match = displayText.match(/^([^\d-]+)(.*)/);
                 if (match) return <><span className="text-3xl opacity-70">{match[1]}</span>{match[2]}</>;
                 return displayText;
@@ -103,6 +106,7 @@ const PaymentReceivedCelebration: React.FC<PaymentReceivedCelebrationProps> = ({
             </span>
           ) : (
             <span className="relative inline-flex items-center gap-1 text-5xl font-mono font-bold text-spark-primary">
+              {isSent && '-'}
               <span className="text-3xl opacity-70">₿</span>
               {formatSatsAmount(Number(payment.amount))}
             </span>
@@ -119,4 +123,4 @@ const PaymentReceivedCelebration: React.FC<PaymentReceivedCelebrationProps> = ({
   );
 };
 
-export default PaymentReceivedCelebration;
+export default PaymentCelebration;

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -546,6 +546,10 @@ export const ConfirmDialog: React.FC<{
   confirmLabel?: string;
   cancelLabel?: string;
   variant?: 'danger' | 'warning' | 'default';
+  /** Stacking override for callers that themselves sit above z-[70]
+   *  (the lock screen is z-[100000]); the portal target is document.body,
+   *  so the default would render underneath them. */
+  zClassName?: string;
   onConfirm: () => void;
   onCancel: () => void;
 }> = ({
@@ -556,6 +560,7 @@ export const ConfirmDialog: React.FC<{
   confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
   variant = 'default',
+  zClassName = 'z-[70]',
   onConfirm,
   onCancel,
 }) => {
@@ -588,7 +593,7 @@ export const ConfirmDialog: React.FC<{
       // transform, which makes position:fixed resolve relative to that
       // transformed ancestor and shoves the dialog off-screen whenever
       // the sheet is snapped or keyboard-lifted.
-      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[70] p-4 transition-opacity duration-300">
+      <div className={`fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center ${zClassName} p-4 transition-opacity duration-300`}>
         <DialogCard maxWidth="sm">
           <div className="text-center">
             <h3 className="font-display text-lg font-bold text-spark-text-primary mb-3">

--- a/src/features/send/SendPaymentDialog.tsx
+++ b/src/features/send/SendPaymentDialog.tsx
@@ -16,6 +16,7 @@ import ConfirmStep from './steps/ConfirmStep';
 import ProcessingStep from './steps/ProcessingStep';
 import ResultStep from './steps/ResultStep';
 import ContactsSubView from './components/ContactsSubView';
+import { setSendSheetOpen } from './sendSheetVisibility';
 import { PrepareLnurlPayRequest } from '@breeztech/breez-sdk-spark';
 import { logger, LogCategory } from '@/services/logger';
 import { formatError } from '@/utils/formatError';
@@ -37,6 +38,14 @@ const SendPaymentDialog: React.FC<SendPaymentDialogProps> = ({ isOpen, onClose, 
   const { findContactByAddress } = useContactsContext();
   const [showContactsView, setShowContactsView] = useState(false);
   const [selectedContactAddress, setSelectedContactAddress] = useState<string | null>(null);
+
+  // Publish sheet visibility so the SDK event handler knows whether this
+  // sheet is still around to report the payment outcome (it is dismissible
+  // mid-send). Mount/unmount, because the parent keys a fresh mount per open.
+  useEffect(() => {
+    setSendSheetOpen(true);
+    return () => setSendSheetOpen(false);
+  }, []);
 
   // Parent (WalletPage) bumps `sendDialogSession` on every open and passes
   // it as `key`, so each open is a fresh mount: hooks re-init, useState

--- a/src/features/send/sendSheetVisibility.ts
+++ b/src/features/send/sendSheetVisibility.ts
@@ -1,0 +1,23 @@
+/**
+ * Whether the send sheet is currently on screen.
+ *
+ * The sheet is dismissible mid-payment (backdrop tap, hardware back), and
+ * the SDK call keeps running after it closes. The success toast is
+ * suppressed for sends because ResultStep normally reports the outcome,
+ * so a user who walked away is told nothing, and an unreported SUCCESS is
+ * the dangerous direction: the natural response is to send again.
+ *
+ * Module-level rather than context so the SDK event handler can read it
+ * without a re-render coupling between the sheet and the app root. Same
+ * shape as `utils/backButton.ts`.
+ */
+
+let sendSheetOpen = false;
+
+export function setSendSheetOpen(open: boolean): void {
+  sendSheetOpen = open;
+}
+
+export function isSendSheetOpen(): boolean {
+  return sendSheetOpen;
+}

--- a/src/features/send/workflows/LnurlWorkflow.tsx
+++ b/src/features/send/workflows/LnurlWorkflow.tsx
@@ -92,11 +92,18 @@ const LnurlWorkflow: React.FC<LnurlWorkflowProps> = ({ parsed, recipientLabel, b
     && feesIncluded;
 
   const description = useMemo(() => {
-    const metadataArr = JSON.parse(parsed.metadataStr);
-    for (let i = 0; i < metadataArr.length; i++) {
-      if (metadataArr[i][0] === "text/plain") {
-        return metadataArr[i][1];
+    // metadataStr comes from a third-party LNURL-pay host, so it is
+    // untrusted: an unguarded parse here throws during render, which
+    // takes the whole tree down rather than failing this one payment.
+    try {
+      const metadataArr: unknown = JSON.parse(parsed.metadataStr);
+      if (Array.isArray(metadataArr)) {
+        for (const entry of metadataArr) {
+          if (Array.isArray(entry) && entry[0] === 'text/plain') return entry[1];
+        }
       }
+    } catch {
+      // Fall through to the URL.
     }
     return parsed.url;
   }, [parsed]);

--- a/src/hooks/useAppLock.ts
+++ b/src/hooks/useAppLock.ts
@@ -35,6 +35,10 @@ export interface AppLockState {
   /** Never rejects: cancel / unavailable leaves the lock in place and
    *  the PIN pad as fallback. */
   unlockWithBiometric: () => Promise<void>;
+  /** Drop the lock without verifying anything. Only for the forgotten-PIN
+   *  escape, which erases the account the PIN was protecting: clearing the
+   *  PIN alone would leave this overlay mounted with nothing behind it. */
+  unlockAfterWipe: () => void;
 }
 
 export function useAppLock(): AppLockState {
@@ -127,5 +131,7 @@ export function useAppLock(): AppLockState {
     if (await tryAuthenticateBiometric('Unlock Glow')) setLocked(false);
   }, []);
 
-  return { locked, biometricGate, unlockWithPin, unlockWithBiometric };
+  const unlockAfterWipe = useCallback(() => setLocked(false), []);
+
+  return { locked, biometricGate, unlockWithPin, unlockWithBiometric, unlockAfterWipe };
 }

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -43,7 +43,7 @@ import {
   isPasskeyMigrated,
 } from '../services/passkeyService';
 import { LEGACY_RP_ID, SHARED_RP_ID, rpId as defaultRpId } from '../services/passkeyPrfProvider';
-import { secureStorage, deviceOnlyStorage, SecureStorageError } from '../services/secureStorage';
+import { secureStorage, deviceOnlyStorage, SecureStorageError, resetSecureStorageInit } from '../services/secureStorage';
 import { clearPin, isAppLockSupported } from '../services/appLock';
 
 
@@ -615,6 +615,11 @@ export function useBreezSdk(
     // signing back in is a fresh discovery (no pinned credential).
     try { await clearKnownCredentials(); } catch { /* non-fatal */ }
     await wipeAllLocalData();
+    // The wipe took the vault's install markers with it. Without this the
+    // once-per-process init memo still reads "initialized", so a re-onboard
+    // in this same session persists a seed with no marker beside it, and the
+    // next cold start mistakes that for a reinstall and wipes it.
+    resetSecureStorageInit();
     logger.clear();
 
     // Always reset all state, even if disconnect threw.

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -44,6 +44,7 @@ import {
 } from '../services/passkeyService';
 import { LEGACY_RP_ID, SHARED_RP_ID, rpId as defaultRpId } from '../services/passkeyPrfProvider';
 import { secureStorage, deviceOnlyStorage, SecureStorageError, resetSecureStorageInit } from '../services/secureStorage';
+import { isSendSheetOpen } from '../features/send/sendSheetVisibility';
 import { clearPin, isAppLockSupported } from '../services/appLock';
 
 
@@ -377,7 +378,14 @@ export function useBreezSdk(
         if (!hasConversionInfo && isReceived && !isMigrationInProgress()) {
           setCelebrationPayment(event.payment);
         }
-        // Send toast suppressed: ResultStep dialog already shows success
+        // A send normally reports itself through the sheet's ResultStep, so
+        // nothing fires here. But the sheet is dismissible mid-payment and
+        // the SDK call outlives it, and an unreported SUCCESS is the
+        // dangerous direction: the user assumes it failed and sends again.
+        // Reuse the same celebration when the sheet is no longer on screen.
+        if (!hasConversionInfo && !isReceived && !isSendSheetOpen() && !isMigrationInProgress()) {
+          setCelebrationPayment(event.payment);
+        }
       }
       refreshWalletData(false);
     } else if (event.type === 'paymentPending') {
@@ -388,6 +396,11 @@ export function useBreezSdk(
       logger.info(LogCategory.PAYMENT, 'Payment failed event received', {
         payment: JSON.parse(JSON.stringify(event.payment)),
       });
+      // Same reasoning as the send celebration above: with the sheet gone
+      // there is nothing else to tell the user the payment did not go out.
+      if (event.payment.paymentType === 'send' && !isSendSheetOpen()) {
+        showToastRef.current('error', 'Payment Failed', 'The payment did not go through. Your funds were not sent.');
+      }
     } else if (event.type === 'claimedDeposits') {
       logger.info(LogCategory.PAYMENT, 'Deposits claimed', { count: event.claimedDeposits.length });
       showToastRef.current('success', 'Deposits Claimed Successfully', `${event.claimedDeposits.length} deposits were claimed`);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { Capacitor, registerPlugin } from '@capacitor/core';
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { Keyboard } from '@capacitor/keyboard';
 import App from './App';
+import AppErrorBoundary from './components/AppErrorBoundary';
 // Font faces are declared in index.css (pointing at @fontsource's woff2 files)
 // rather than importing @fontsource's own stylesheets, which hardcode
 // font-display: swap. See the comment there.
@@ -324,8 +325,12 @@ async function init() {
     }
 
     // Render the app - splash stays visible until App signals it's ready
+    // The splash is torn down below, so an uncaught render throw would
+    // leave a flat black screen with no reload affordance on native.
     ReactDOM.createRoot(document.getElementById('root')!).render(
-      <App />
+      <AppErrorBoundary>
+        <App />
+      </AppErrorBoundary>
     );
     logger.info(LogCategory.UI, 'Application initialized successfully');
 

--- a/src/pages/RestorePage.tsx
+++ b/src/pages/RestorePage.tsx
@@ -26,7 +26,10 @@ const RestorePage: React.FC<RestorePageProps> = ({
   useScreenCaptureProtection(true);
 
   const handleSubmit = async () => {
-    const cleaned = mnemonic.trim().replace(/\s+/g, ' ');
+    // Lowercased because BIP39 wordlists are: a typed phrase arrives
+    // sentence-cased from the mobile keyboard and would be rejected as an
+    // unknown word. Pasting hides this, which is why it reads as fine.
+    const cleaned = mnemonic.trim().replace(/\s+/g, ' ').toLowerCase();
     const wordCount = cleaned.split(' ').length;
 
     if (wordCount !== 12 && wordCount !== 24) {
@@ -75,6 +78,12 @@ const RestorePage: React.FC<RestorePageProps> = ({
             onChange={(e) => setMnemonic(e.target.value)}
             className="w-full h-36 px-4 py-3 text-spark-text-primary bg-spark-dark border border-spark-border rounded-xl focus:border-spark-primary focus:ring-2 focus:ring-spark-primary/20 resize-none font-mono text-sm"
             placeholder="word1 word2 word3 ..."
+            // A mobile keyboard otherwise sentence-cases and autocorrects
+            // BIP39 words into something the SDK rejects.
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
             data-testid="mnemonic-input"
           />
         </div>

--- a/src/pages/UnlockPage.tsx
+++ b/src/pages/UnlockPage.tsx
@@ -7,8 +7,10 @@
  * interactive and the placeholder stays purely decorative.
  *
  * Presents a primary "Unlock with <biometry>" action and a secondary
- * "Use a different wallet" escape that clears the stored seed and
- * routes back to welcome.
+ * "Erase and start over" escape that clears the stored seed and routes
+ * back to welcome. A plain connect failure also lands here, so that
+ * escape is confirm-gated: it is destructive and one tap away from a
+ * user who is only offline.
  *
  * Layout mirrors `feat/password-encrypted-seed-storage`'s UnlockPage so
  * that when both native secure storage and the password vault coexist
@@ -16,10 +18,11 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { PrimaryButton, SecondaryButton } from '../components/ui';
+import { PrimaryButton, SecondaryButton, ConfirmDialog } from '../components/ui';
 import { FaceIdIcon, FingerprintIcon, PasskeyIcon } from '../components/Icons';
 import { AlertCard } from '../components/AlertCard';
 import { getBiometryInfo, BiometryInfo, secureStorage } from '../services/secureStorage';
+import { isPasskeyMode } from '../services/passkeyService';
 
 interface UnlockPageProps {
   isLoading: boolean;
@@ -38,6 +41,11 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
   const isWebPasskey = !secureStorage.isSupported();
 
   const [biometry, setBiometry] = useState<BiometryInfo | null>(null);
+  // This escape erases every local artifact, and the screen it lives on is
+  // reachable from a plain connect failure (offline launch), so it is gated
+  // behind the same confirm the side-menu logout uses.
+  const [showEraseConfirm, setShowEraseConfirm] = useState(false);
+  const isPasskey = isPasskeyMode();
   // Only pre-app-lock installs keep the seed behind a biometric. With
   // nothing in that tier this page is a plain reconnect retry (the
   // silent start failed), so it must not promise a Face ID prompt.
@@ -106,15 +114,27 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
             </PrimaryButton>
 
             <SecondaryButton
-              onClick={onAbandon}
+              onClick={() => setShowEraseConfirm(true)}
               disabled={isLoading}
               className="w-full"
             >
-              Use a Different Wallet
+              Erase and Start Over
             </SecondaryButton>
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={showEraseConfirm}
+        variant="danger"
+        title="Erase and start over"
+        message={isPasskey
+          ? "This deletes all Glow data stored on this device. You'll need your passkey to access your funds again."
+          : "This deletes all Glow data stored on this device. Make sure you've saved your recovery phrase: you'll need it to access your funds again."}
+        confirmLabel="Erase"
+        onConfirm={() => { setShowEraseConfirm(false); void onAbandon(); }}
+        onCancel={() => setShowEraseConfirm(false)}
+      />
     </div>
   );
 };

--- a/src/services/secureStorage.test.ts
+++ b/src/services/secureStorage.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression guard for the fresh-install marker invariant.
+ *
+ * The markers gate a vault wipe: a missing marker means "reinstall", and
+ * the init pass then clears both tiers. Logout wipes localStorage AND
+ * Preferences, which takes the markers with it, so anything that stores a
+ * seed afterwards must leave a marker beside it. Otherwise the NEXT cold
+ * start reads a funded vault as a fresh install and deletes it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Preferences } from '@capacitor/preferences';
+import { wipeAllLocalData } from './accountDeletion';
+
+const INSTALL_MARKER_KEY = 'glow.secureStorageInitialized';
+
+vi.mock('@capacitor/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@capacitor/core')>();
+  return {
+    ...actual,
+    Capacitor: { ...actual.Capacitor, isNativePlatform: () => true },
+  };
+});
+
+/** Stands in for the Keychain / Keystore: survives module resets, like the
+ *  real vault survives a process restart. */
+const vault: { deviceOnly: string | null; bound: string | null } = {
+  deviceOnly: null,
+  bound: null,
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).window = globalThis;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).Capacitor = {
+  Plugins: {
+    NativeVault: {
+      hasStoredSeedDeviceOnly: async () => ({ stored: vault.deviceOnly !== null }),
+      storeSeedDeviceOnly: async ({ seed }: { seed: string }) => { vault.deviceOnly = seed; },
+      retrieveSeedDeviceOnly: async () => ({ seed: vault.deviceOnly! }),
+      clearSeedDeviceOnly: async () => { vault.deviceOnly = null; },
+      hasStoredSeed: async () => ({ stored: vault.bound !== null }),
+      storeSeed: async ({ seed }: { seed: string }) => { vault.bound = seed; },
+      retrieveSeed: async () => ({ seed: vault.bound! }),
+      clearSeed: async () => { vault.bound = null; },
+    },
+  },
+};
+
+/** Re-import with a clean module registry: the init memo is module-level,
+ *  so this is what a cold start looks like. */
+async function coldStart() {
+  vi.resetModules();
+  return import('./secureStorage');
+}
+
+const SEED = { type: 'mnemonic', mnemonic: 'abandon ability able about' } as const;
+
+describe('secure storage install marker', () => {
+  beforeEach(async () => {
+    vault.deviceOnly = null;
+    vault.bound = null;
+    localStorage.clear();
+    await Preferences.clear();
+  });
+
+  it('writes the marker when a seed is stored', async () => {
+    const { deviceOnlyStorage } = await coldStart();
+    await deviceOnlyStorage.storeSeed(SEED);
+
+    expect((await Preferences.get({ key: INSTALL_MARKER_KEY })).value).not.toBeNull();
+    expect(vault.deviceOnly).not.toBeNull();
+  });
+
+  it('keeps the seed across a cold start once the marker is set', async () => {
+    const first = await coldStart();
+    await first.deviceOnlyStorage.storeSeed(SEED);
+
+    const second = await coldStart();
+    expect(await second.deviceOnlyStorage.hasStoredSeed()).toBe(true);
+    expect(vault.deviceOnly).not.toBeNull();
+  });
+
+  it('wipes a vault whose marker is missing (the fresh-install path still works)', async () => {
+    const first = await coldStart();
+    await first.deviceOnlyStorage.storeSeed(SEED);
+
+    // Exactly what a logout wipe leaves behind: seed in the vault, no marker.
+    localStorage.clear();
+    await Preferences.clear();
+
+    const second = await coldStart();
+    expect(await second.deviceOnlyStorage.hasStoredSeed()).toBe(false);
+  });
+
+  it('re-marks a seed stored after a logout wipe, so the next cold start keeps it', async () => {
+    const session = await coldStart();
+    await session.deviceOnlyStorage.storeSeed(SEED);
+
+    // Logout: erases the vault and every local store, markers included.
+    await session.deviceOnlyStorage.clearSeed();
+    await wipeAllLocalData();
+    session.resetSecureStorageInit();
+
+    // Re-onboard in the SAME session, no app restart.
+    await session.deviceOnlyStorage.storeSeed(SEED);
+    expect((await Preferences.get({ key: INSTALL_MARKER_KEY })).value).not.toBeNull();
+
+    // The account must survive the next launch.
+    const relaunch = await coldStart();
+    expect(await relaunch.deviceOnlyStorage.hasStoredSeed()).toBe(true);
+  });
+});

--- a/src/services/secureStorage.ts
+++ b/src/services/secureStorage.ts
@@ -414,6 +414,36 @@ function ensureSharedInitialized(): Promise<void> {
 }
 
 /**
+ * Drop the once-per-process memo so the next vault call re-runs the init
+ * pipeline. Logout wipes localStorage AND Preferences, which takes the
+ * install markers with it; without this reset the memo keeps reporting
+ * "already initialized", a seed stored by a same-session re-onboard gets
+ * no marker written beside it, and the NEXT cold start reads the missing
+ * marker as a reinstall and wipes a live vault. Call after any wipe that
+ * can clear the markers.
+ */
+export function resetSecureStorageInit(): void {
+  sharedInitPromise = null;
+}
+
+/**
+ * Record that this install owns a populated vault. Called after every
+ * successful store so a seed can never coexist with an absent marker:
+ * the markers gate a wipe, and a WebView storage eviction can drop them
+ * while the Keychain / Keystore entry survives (see `readDurableMarker`).
+ */
+async function markVaultInitialized(): Promise<void> {
+  try {
+    if (await readDurableMarker(INSTALL_MARKER_KEY)) return;
+    const now = new Date().toISOString();
+    await writeDurableMarker(INSTALL_MARKER_KEY, now);
+    await writeDurableMarker(F3_MIGRATION_MARKER_KEY, now);
+  } catch {
+    // Best-effort: a failed marker write must not fail the store itself.
+  }
+}
+
+/**
  * Sequential init pipeline. Order matters: the F3 migration must run
  * AFTER the fresh-install cleanup, so that on a fresh install we
  * only wipe once (via the install-marker path) and skip the F3 wipe
@@ -600,6 +630,7 @@ class NativeSecureStorage implements SecureStorage {
       // Storage policy (Keychain accessibility, Keystore key params) is
       // owned by the plugin's native side.
       await getNativeVault().storeSeed({ seed: JSON.stringify(blob) });
+      await markVaultInitialized();
       logSecureStorageSuccess('storeSeed');
     } catch (err) {
       const code = mapNativeVaultErrorCode(err);
@@ -716,6 +747,7 @@ class NativeDeviceOnlyStorage implements SecureStorage {
     };
     try {
       await getNativeVault().storeSeedDeviceOnly({ seed: JSON.stringify(blob) });
+      await markVaultInitialized();
       logSecureStorageSuccess('storeSeedDeviceOnly');
     } catch (err) {
       const code = mapNativeVaultErrorCode(err);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,10 @@ export default defineConfig(({ mode }) => {
       target: 'esnext',
       outDir: 'dist',
       assetsDir: 'assets',
-      sourcemap: true,
+      // Dev only. A production map ships the full unminified source of the
+      // seed, app-lock and passkey services inside the IPA / AAB, readable
+      // by unzipping the store binary.
+      sourcemap: mode !== 'production',
       chunkSizeWarningLimit: 1700,
     },
     optimizeDeps: {


### PR DESCRIPTION
A pre-release review turned up a set of ways the app could fail in front
of a real user even though the normal path works. These are the fixes
worth having before the store submission. Each one is its own commit, so
any can be dropped independently.

### An account could be erased a launch after it was created

Logging out clears every local store, and that includes the markers
recording that this device has already been set up. The setup pass runs
once per launch and had already run, so it was not repeated, and an
account created straight after logging out was saved without those
markers. On the next cold start the app read that as a brand new device
and erased it. Someone who logged out, set up again, received funds, and
then closed the app would reopen it to an empty welcome screen.

The setup pass now repeats after a logout, and the markers are written
every time an account is saved. A test covers the whole sequence.

### Two screens could trap or wipe by accident

The unlock screen is also where a failed startup lands, so simply opening
the app without a connection showed it. Its second button erased
everything on the device, with no confirmation and a label that read like
an account picker. It now says what it does and asks first.

The lock screen had no exit at all. A forgotten PIN meant reinstalling,
and the recovery phrase sat behind the same PIN, so there was no way to
prepare for that beforehand. It now offers the same confirmed erase,
which is the honest version of the only option that ever existed.

### A typed recovery phrase was rejected

The phrase field was the only free-text input in the app still letting
the mobile keyboard capitalise and autocorrect it, and the words were
never lowercased. Recovery words are always lowercase, so anyone typing
their phrase on a new device was told it was invalid. Pasting worked,
which is why this went unnoticed.

### A closed send sheet left the outcome unknown

The send sheet can be dismissed while the payment is still going out, and
the payment carries on without it. Nothing then reported the result. A
send that had actually succeeded looked like nothing happened, and
sending again was the natural response. A completed send now shows the
same confirmation a received payment does, and a failed one raises a
message, in both cases only when the sheet is no longer there to say so.

### An error could leave a blank screen with no way back

An unexpected error while drawing the screen took the interface down and
left it blank. There is no address bar to reload from, so force-quitting
was the only escape, and an error caused by something saved on the device
returned on every launch. There is now a fallback screen with a reload
action, plus a fix for the one case that could trigger it from outside
the app: payment details returned by another server were read without
checking they were well formed.

### Source maps were shipping to the stores

Release builds carried the app's full readable source inside the store
binaries. Maps are still produced for development builds.

## Test plan

Worth confirming on a device, since these are the paths static review
cannot reach:

- Log out, set up again in the same session, force-quit, reopen. The
  account should still be there.
- Open the app in airplane mode. Confirm the second button on the screen
  you land on now asks before erasing.
- Set a PIN with no biometric gate, then use the new way out.
- Type (do not paste) a recovery phrase on the restore screen.
- Start a small send and press back while it is going out. You should be
  told the result.