### PR TITLE
fix: sign in instead of creating a second passkey when PRF is not ready

### DIFF
--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -851,6 +851,7 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
         const action = connectActionRef.current;
         const underlying = e instanceof Error ? e.message : String(e);
         const elapsedMs = Date.now() - connectStartMs;
+        const errorCode = (e as { code?: string })?.code;
         // Setup-path 'already exists' anchors back to 'creating' to
         // hit the already-exists render branch. Android Chrome's
         // Credential Manager swallows InvalidStateError into a generic
@@ -875,13 +876,33 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             setErrorKind('already-exists');
             return;
           }
+          // register() creates the credential, then immediately asserts
+          // against it to evaluate PRF. Google Password Manager can take
+          // a moment to index the new credential, so that assertion can
+          // report no credential for one that now exists. Retrying
+          // register would mint a second, orphaned passkey, so pivot to
+          // sign-in the way the already-exists path does.
+          if (e instanceof PasskeyCredentialNotFoundError
+            || errorCode === 'CREDENTIAL_NOT_FOUND'
+            || /CredentialNotFound|No credentials available/i.test(errMsg)) {
+            logger.warn(LogCategory.AUTH, 'Register could not assert the new credential, pivoting to sign-in', {
+              errorCode,
+              elapsedMs,
+            });
+            localStorage.setItem('passkeyRegistered', '1');
+            setIsNewUser(false);
+            detectingFailCountRef.current = 0;
+            setPhase('creating');
+            setError('Your passkey was created but was not ready to use yet. Use it to sign in.');
+            setErrorKind('already-exists');
+            return;
+          }
         }
         // PasskeyTimedOutError covers the OS inactivity timeout
         // (~60s); cancel falls back to .code / .name / message
         // heuristics (no typed class).
         const errorName = e instanceof Error ? e.name : '';
         const errorMessage = e instanceof Error ? e.message : '';
-        const errorCode = (e as { code?: string })?.code;
         const messageLooksCancelled = /cancel{1,2}ed|cancellation/i.test(errorMessage);
         const isTimedOut = e instanceof PasskeyTimedOutError;
         const isCancelled = !isTimedOut && (

--- a/src/pages/PasskeyPage.tsx
+++ b/src/pages/PasskeyPage.tsx
@@ -876,15 +876,12 @@ const PasskeyPage: React.FC<PasskeyPageProps> = ({
             setErrorKind('already-exists');
             return;
           }
-          // register() creates the credential, then immediately asserts
-          // against it to evaluate PRF. Google Password Manager can take
-          // a moment to index the new credential, so that assertion can
-          // report no credential for one that now exists. Retrying
-          // register would mint a second, orphaned passkey, so pivot to
-          // sign-in the way the already-exists path does.
-          if (e instanceof PasskeyCredentialNotFoundError
-            || errorCode === 'CREDENTIAL_NOT_FOUND'
-            || /CredentialNotFound|No credentials available/i.test(errMsg)) {
+          // register() creates the credential, then asserts against it to
+          // evaluate PRF. When that assertion outruns the credential
+          // manager's indexing it reports no credential for one that now
+          // exists. Retrying register would mint a second, orphaned
+          // passkey, so pivot to sign-in the way already-exists does.
+          if (e instanceof PasskeyCredentialNotFoundError || errorCode === 'CREDENTIAL_NOT_FOUND') {
             logger.warn(LogCategory.AUTH, 'Register could not assert the new credential, pivoting to sign-in', {
               errorCode,
               elapsedMs,


### PR DESCRIPTION
## The problem

A tester creates a passkey on a fresh install. The screen shows an error: "Couldn't connect. Something went wrong. Please try again."

The tester taps Retry. The second attempt works.

## The cause

Creation of a passkey is two steps. The phone makes the credential. The app then uses that credential at once, to derive the account.

Google Password Manager needs a short time to index a new credential. The second step can therefore report that no passkey is present, for a passkey that the phone made a moment before.

Logs from the tester show this. The creation runs for 11.5 seconds and then fails with "No credentials available". The tester retries 7 seconds later and it works.

## Why a retry is not sufficient

Retry ran the full creation again. The phone makes a second passkey.

The first passkey is still on the phone. It holds a different account, and nothing points to that account any more. If the person later selects that passkey from the list of the phone, they see an empty account. This is a poor outcome, so the app must not make the second passkey.

## The change

The app now offers sign-in, not retry. This is the same recovery that the app gives when it finds a passkey on the phone already.

Sign-in uses the passkey from the failed attempt. The person gets the account of that passkey, and the phone keeps one passkey.

If the creation truly failed, and no passkey is present, the sign-in finds nothing and the app returns to creation. The recovery is safe in both cases.

## Test plan

This failure is a timing effect and is hard to cause on demand. Test the paths near it:

1. Create a passkey on a fresh install. Creation must complete as before.
2. Create a passkey on a phone that has one already. The message about the existing passkey must show, and sign-in must work.
3. Close the prompt during creation. The cancel message must show.

For the tester who reported this: please open Google Password Manager and count the Glow entries. Each entry carries the time of its creation in the name. Two entries confirm the second passkey.