### PR TITLE
fix: point the account deletion guide at the production host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ grep "methodName" ~/Documents/GitHub/spark-sdk/packages/wasm/bundler/breez_sdk_s
 
 | Branch | SDK Source | Deployment |
 |--------|------------|------------|
-| `main` | npm release | breez-glow.vercel.app (prod) |
+| `main` | npm release | glow-app.co (prod) |
 | `staging` | npm pre-release | breez-glow-staging.vercel.app |
 | feature branches | `npm link` local | Local dev |
 

--- a/src/services/accountDeletion.ts
+++ b/src/services/accountDeletion.ts
@@ -9,7 +9,7 @@ import { closeLogDatabase } from './logStorage';
  * must be saved first. Linked from the logout confirm dialog and the
  * post-deletion confirmation screen.
  */
-export const ACCOUNT_DELETION_GUIDE_URL = 'https://breez-glow.vercel.app/delete-account.html';
+export const ACCOUNT_DELETION_GUIDE_URL = 'https://glow-app.co/delete-account.html';
 
 /**
  * Erase every client-side artifact of the account: localStorage,


### PR DESCRIPTION
The "Delete Account" entry in Settings, and the same link in the logout confirmation, opened the guide on the preview deployment's address rather than the one Glow is actually published on. Both now open it on glow-app.co.

The guide page itself is unchanged. Also corrected the production address in the branch table in the repo's own notes, which is where the stale one came from.

## Test plan

- Open Settings then Delete Account and confirm the guide opens on glow-app.co and renders.
- Start logout, follow the guide link from the confirmation, confirm the same.