### PR TITLE
fix: keep LN address on one line while editing

### DIFF
--- a/src/features/receive/LightningAddressDisplay.tsx
+++ b/src/features/receive/LightningAddressDisplay.tsx
@@ -89,6 +89,10 @@ const EditingForm: React.FC<EditingFormProps> = ({
             }}
             enterKeyHint="done"
             inputMode="text"
+            // A textarea (not an input) to keep Android's autofill bar away,
+            // so it soft-wraps a long username onto a second row. wrap="off"
+            // makes it scroll horizontally like a single-line field (#328).
+            wrap="off"
             autoCapitalize="none"
             autoCorrect="off"
             autoComplete="off"


### PR DESCRIPTION
Closes #328

Long LN address usernames now stay on one line while editing and scroll horizontally instead of wrapping.

The field remains a multiline input to avoid Android's autofill bar, but wrapping is disabled to match one-line input behavior.