### PR TITLE
fix: turn off silent passkey detection on the web

### DIFF
--- a/src/services/passkeyPrfProvider.test.ts
+++ b/src/services/passkeyPrfProvider.test.ts
@@ -10,14 +10,21 @@ beforeEach(() => {
 });
 
 describe('supportsImmediateGet', () => {
-  it('is web-only: false on native', async () => {
-    isNative = true;
+  // Pinned off even where the browser advertises the capability: immediate
+  // mediation cannot tell "no passkey" from "prompt dismissed", so a
+  // returning user can look new and get a duplicate passkey.
+  it('is off in browsers that advertise immediateGet', async () => {
+    isNative = false;
+    vi.stubGlobal('PublicKeyCredential', {
+      getClientCapabilities: async () => ({ immediateGet: true }),
+    });
     const { supportsImmediateGet } = await import('./passkeyPrfProvider');
     await expect(supportsImmediateGet()).resolves.toBe(false);
+    vi.unstubAllGlobals();
   });
 
-  it('returns false in browsers without the capability API', async () => {
-    isNative = false;
+  it('is off on native', async () => {
+    isNative = true;
     const { supportsImmediateGet } = await import('./passkeyPrfProvider');
     await expect(supportsImmediateGet()).resolves.toBe(false);
   });
@@ -30,7 +37,8 @@ describe('canSilentlyDetectPasskey', () => {
     await expect(canSilentlyDetectPasskey()).resolves.toBe(true);
   });
 
-  it('follows the immediateGet capability in browsers', async () => {
+  // Drives HomePage's two-CTA gate and PasskeyPage's explicit signIn flow.
+  it('is false in browsers, so web takes the two-CTA flow', async () => {
     isNative = false;
     const { canSilentlyDetectPasskey } = await import('./passkeyPrfProvider');
     await expect(canSilentlyDetectPasskey()).resolves.toBe(false);

--- a/src/services/passkeyPrfProvider.ts
+++ b/src/services/passkeyPrfProvider.ts
@@ -104,42 +104,30 @@ export async function signalUnknownCredentials(credentialIdsBase64: string[]): P
 }
 
 /**
- * Whether this browser honors WebAuthn immediate mediation
- * (`mediation: 'immediate'`), probed once via
- * `getClientCapabilities('public-key').immediateGet`. Web-only:
- * `immediateGet` is a browser capability, so native short-circuits to
- * false (its own fast-fail on `preferImmediatelyAvailableCredentials` is
- * a separate mechanism). For the login-UX gate use
- * `canSilentlyDetectPasskey`; pass this raw flag to web `signIn`.
+ * Whether the web sign-in probe may use WebAuthn immediate mediation
+ * (`uiMode: 'immediate'`). Pinned off: it reports "no credential" both
+ * when there is none and when the user dismissed the prompt (browsers
+ * collapse the two so a site cannot enumerate passkey holders), and it
+ * reports none for a user who does hold one in Chrome/Arc incognito.
+ * Either way a returning user looks new, and the single-CTA flow answers
+ * that by registering a second passkey owning an unreachable account.
+ * Native is unaffected: `preferImmediatelyAvailableCredentials` is a
+ * separate mechanism with a typed no-credential result.
+ *
+ * ponytail: kept as a function with its call sites rather than inlining
+ * `false`, so re-enabling once browsers distinguish the two errors is a
+ * one-line change here.
  */
-let cachedImmediateGet: boolean | null | undefined;
 export async function supportsImmediateGet(): Promise<boolean> {
-  if (native) return false;
-  if (cachedImmediateGet === true) return true;
-  if (cachedImmediateGet === false || cachedImmediateGet === null) return false;
-  try {
-    if (typeof PublicKeyCredential === 'undefined'
-        || typeof (PublicKeyCredential as { getClientCapabilities?: unknown }).getClientCapabilities !== 'function') {
-      cachedImmediateGet = null;
-      return false;
-    }
-    const caps = await (PublicKeyCredential as unknown as {
-      getClientCapabilities: (kind: string) => Promise<{ immediateGet?: boolean }>;
-    }).getClientCapabilities('public-key');
-    cachedImmediateGet = caps?.immediateGet === true;
-  } catch {
-    cachedImmediateGet = null;
-  }
-  return cachedImmediateGet === true;
+  return false;
 }
 
 /**
  * Whether the device can silently detect an existing passkey (probe and
  * fast-fail through to create without flashing a sheet). Gates the
- * single-CTA "Get Started" login. Native does this inherently; web only
- * where the browser advertises immediate mediation. Umbrella over the
- * web-only `supportsImmediateGet` so neither has to lie about the other
- * (this is true on native; that is not).
+ * single-CTA "Get Started" login. Native does this inherently; web goes
+ * through `supportsImmediateGet`, which is off, so web always takes the
+ * explicit two-CTA flow.
  */
 export async function canSilentlyDetectPasskey(): Promise<boolean> {
   if (native) return true;


### PR DESCRIPTION
## What

The web sign-in screen goes back to two buttons, sign in or create, instead of the single Get Started button that tried to work out on its own whether you already had a passkey. Phones and tablets are unchanged and keep the single button.

## Why

The silent check cannot tell "this browser holds no passkey" apart from "the person dismissed the prompt". Browsers deliberately report both the same way, so that a site cannot work out which visitors are carrying a passkey. That is not a gap waiting on a browser update, it is the intended behaviour.

So the single-button flow had to guess, and a wrong guess is expensive: someone who already has a passkey gets treated as a newcomer and a second passkey is created, owning an account that nothing points to.

Private windows turn that from occasional into certain. Chrome refuses silent detection there outright, to stop sites linking a private session back to a normal one, so everyone in a private window looks new. That was reproduced on both Chrome and Arc: a person who definitely had a passkey was offered a fresh one instead.

One extra button is a much cheaper thing to get wrong. Sign in or create is also what people are used to seeing.

This also retires two related problems on the web path for free. The old flow leaned on a timing guess to interpret the failure, which misfired on slower machines and turned a normal first tap into a "you cancelled" error. And a passkey that got created but was not immediately usable was reported as a plain failure, so trying again could leave a second one behind. Neither applies to the explicit flow.

## Notes

The change is one function. Every route into silent detection already went through it, so turning it off there switches the whole path over, and turning it back on later (if browsers ever separate the two failures) is the same one line.

Follow-up, deliberately left out of this change: the combined sign-in-or-create call is now unused from this app's side and can be deleted here, but not in the same change that switches flows. The phone and tablet plugins still implement it, and the single button there is unaffected: it has never used that call, it uses the ordinary sign-in together with the platform's own silent check.
