### PR TITLE
chore: add browser policy headers and move two inline scripts to files

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+  <!-- First element in <head>: a CSP meta only governs resources the parser
+       reaches after it. Carries the policy on the surfaces that have no
+       response headers of our own (iOS capacitor://localhost); on the hosted
+       PWA it coexists with the vercel.json header, which adds the
+       header-only directives (frame-ancestors, upgrade-insecure-requests).
+       Keep the shared directives byte-identical with vercel.json and
+       glow-app's capacitor.config.ts. -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https: wss:; worker-src 'self' blob:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; manifest-src 'self'" />
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
   
@@ -134,49 +142,7 @@
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
   
-  <!-- Service Worker Registration. Web only.
-       In the native shell the assets are already on-device and offline-capable,
-       so the service worker buys nothing: its "network" is just the local asset
-       server, yet it still intercepts every request and re-copies the JS bundle
-       and the multi-megabyte WASM into Cache Storage on every cold start. Skip
-       it there, and unregister (plus drop its caches) for installs that picked
-       one up from an earlier build. -->
-  <script>
-    (function () {
-      if (!('serviceWorker' in navigator)) return;
-
-      // The native bridge injects window.Capacitor before page scripts run.
-      var cap = window.Capacitor;
-      var isNative = !!(cap && (typeof cap.isNativePlatform === 'function'
-        ? cap.isNativePlatform()
-        : (cap.platform && cap.platform !== 'web')));
-
-      if (isNative) {
-        navigator.serviceWorker.getRegistrations()
-          .then(function (regs) { regs.forEach(function (r) { r.unregister(); }); })
-          .catch(function () { /* nothing registered — fine */ });
-        if (window.caches && caches.keys) {
-          caches.keys()
-            .then(function (keys) {
-              keys.filter(function (k) { return k.indexOf('glow-') === 0; })
-                .forEach(function (k) { caches.delete(k); });
-            })
-            .catch(function () { /* no cache storage — fine */ });
-        }
-        return;
-      }
-
-      window.addEventListener('load', function () {
-        navigator.serviceWorker.register('/sw.js')
-          .then(function (registration) {
-            console.log('SW registered:', registration.scope);
-          })
-          .catch(function (error) {
-            console.log('SW registration failed:', error);
-          });
-      });
-    })();
-  </script>
+  <script src="/sw-register.js" defer></script>
 </body>
 
 </html>

--- a/public/delete-account.html
+++ b/public/delete-account.html
@@ -11,6 +11,7 @@
   <title>How to delete your Glow account</title>
   <meta name="description" content="How to delete your Glow account and remove your passkey." />
   <link rel="icon" href="/icons/Glow_favicon.png" />
+  <script src="/delete-account.js" defer></script>
   <style>
     :root {
       --void: #ffffff;
@@ -109,19 +110,8 @@
 </head>
 
 <body>
-  <!-- Escape hatch when this page loads inside an installed PWA's own
-       window (in-scope navigation shows no browser chrome, so there is
-       no other way back). Hidden in normal tabs and in the app's
-       overlay iframe. -->
-  <script>
-    if (window.self === window.top
-        && (window.matchMedia('(display-mode: standalone)').matches || navigator.standalone === true)) {
-      document.body.classList.add('standalone');
-    }
-  </script>
   <main>
-    <button type="button" class="back-bar"
-      onclick="if (history.length > 1) { history.back(); } else { location.href = '/'; }">
+    <button type="button" class="back-bar">
       &larr; Back to Glow
     </button>
     <h1>How to delete your Glow account</h1>

--- a/public/delete-account.js
+++ b/public/delete-account.js
@@ -1,0 +1,20 @@
+// Escape hatch when this page loads inside an installed PWA's own window
+// (in-scope navigation shows no browser chrome, so there is no other way
+// back). Hidden in normal tabs and in the app's overlay iframe.
+//
+// A separate file, not an inline <script> / onclick: the CSP ships
+// script-src 'self' with no 'unsafe-inline'.
+(function () {
+  if (window.self === window.top
+    && (window.matchMedia('(display-mode: standalone)').matches || navigator.standalone === true)) {
+    document.documentElement.classList.add('standalone');
+  }
+
+  var back = document.querySelector('.back-bar');
+  if (back) {
+    back.addEventListener('click', function () {
+      if (history.length > 1) history.back();
+      else location.href = '/';
+    });
+  }
+})();

--- a/public/sw-register.js
+++ b/public/sw-register.js
@@ -1,0 +1,44 @@
+// Service Worker Registration. Web only.
+// In the native shell the assets are already on-device and offline-capable,
+// so the service worker buys nothing: its "network" is just the local asset
+// server, yet it still intercepts every request and re-copies the JS bundle
+// and the multi-megabyte WASM into Cache Storage on every cold start. Skip
+// it there, and unregister (plus drop its caches) for installs that picked
+// one up from an earlier build.
+//
+// A separate file, not an inline <script>: the CSP ships script-src 'self'
+// with no 'unsafe-inline'.
+(function () {
+  if (!('serviceWorker' in navigator)) return;
+
+  // The native bridge injects window.Capacitor before page scripts run.
+  var cap = window.Capacitor;
+  var isNative = !!(cap && (typeof cap.isNativePlatform === 'function'
+    ? cap.isNativePlatform()
+    : (cap.platform && cap.platform !== 'web')));
+
+  if (isNative) {
+    navigator.serviceWorker.getRegistrations()
+      .then(function (regs) { regs.forEach(function (r) { r.unregister(); }); })
+      .catch(function () { /* nothing registered: fine */ });
+    if (window.caches && caches.keys) {
+      caches.keys()
+        .then(function (keys) {
+          keys.filter(function (k) { return k.indexOf('glow-') === 0; })
+            .forEach(function (k) { caches.delete(k); });
+        })
+        .catch(function () { /* no cache storage: fine */ });
+    }
+    return;
+  }
+
+  window.addEventListener('load', function () {
+    navigator.serviceWorker.register('/sw.js')
+      .then(function (registration) {
+        console.log('SW registered:', registration.scope);
+      })
+      .catch(function (error) {
+        console.log('SW registration failed:', error);
+      });
+  });
+})();

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,23 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "rm -rf node_modules/@breeztech && npm install"
+  "installCommand": "rm -rf node_modules/@breeztech && npm install",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy-Report-Only",
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https: wss:; worker-src 'self' blob:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; manifest-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+        },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(self), microphone=(), geolocation=(), payment=(), publickey-credentials-create=(self), publickey-credentials-get=(self)"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Adds standard browser policy headers to the hosted build, and moves the last two inline `<script>` blocks into files so no page carries inline code.

| File | Change |
|---|---|
| `index.html` | Policy meta tag, first in `<head>`. Service worker registration moves out to `public/sw-register.js`. |
| `public/delete-account.html` | Inline script and inline `onclick` move out to `public/delete-account.js`. |
| `vercel.json` | Response headers. `installCommand` unchanged. |

**Rollout:** report-only for now. It reports to the console and blocks nothing. A follow-up changes the header name after 1 to 2 weeks of a clean console.

**Do not tighten these three:**

- `'wasm-unsafe-eval'`: the SDK module does not start without it.
- `blob:` in `worker-src`: the QR decoder starts its worker from a blob URL.
- wide `connect-src`: payments fetch from arbitrary hosts, so a host list breaks sending.

**Checked** on browser, Android WebView and iOS WebView: wallet create and connect, QR scan, passkey, send, sockets, service worker, first paint. No console messages from app code.