### PR TITLE
chore: tidy up diagnostics and dev toggles

### DIFF
--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -21,7 +21,7 @@ import { buildConnectConfig } from './buildConnectConfig';
 import { logger, LogCategory, logSdkMessage } from '../services/logger';
 import { formatError } from '../utils/formatError';
 import { isDepositRejected, clearRejectedDeposits } from '../services/depositState';
-import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, ensureSparkPrivateMode, type BuyBitcoinProvider } from '../services/settings';
+import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, ensureSparkPrivateMode, isDevMode, type BuyBitcoinProvider } from '../services/settings';
 import { wipeAllLocalData } from '../services/accountDeletion';
 import { hideSplash } from '../main';
 import {
@@ -77,7 +77,17 @@ async function initSdkLogging() {
   // (the connect path surfaces the real error to the user).
   try {
     await sdkReady();
-    initLogging({ log: (entry: LogEntry) => logSdkMessage(entry.level, entry.line) });
+    // Capped at INFO by default: the SDK's own default keeps DEBUG on for
+    // its crates, and those lines dump request and response payloads into
+    // logs that are shareable from Settings and from the pre-auth passkey
+    // screen. Dev mode lifts the cap for the visit, so verbose logs can
+    // still be collected from a released build (`?dev=true`) when a report
+    // needs them. Undefined restores the SDK default.
+    const verbose = import.meta.env.DEV || isDevMode();
+    initLogging(
+      { log: (entry: LogEntry) => logSdkMessage(entry.level, entry.line) },
+      verbose ? undefined : 'info',
+    );
   } catch {
     /* SDK unavailable; skip the log bridge. */
   }
@@ -362,9 +372,13 @@ export function useBreezSdk(
     } else if (event.type === 'paymentSucceeded') {
       const paymentId = event.payment.id;
       const alreadyShown = shownPaymentIdsRef.current.has(paymentId);
+      // Identifiers only: the full payment carries the preimage and the
+      // bolt11, and these logs end up in user-shared archives.
       logger.debug(LogCategory.PAYMENT, 'Payment succeeded event received', {
         alreadyShown,
-        payment: JSON.parse(JSON.stringify(event.payment)),
+        paymentId,
+        paymentType: event.payment.paymentType,
+        method: event.payment.method,
       });
       if (!alreadyShown) {
         shownPaymentIdsRef.current.add(paymentId);
@@ -390,11 +404,15 @@ export function useBreezSdk(
       refreshWalletData(false);
     } else if (event.type === 'paymentPending') {
       logger.info(LogCategory.PAYMENT, 'Payment pending event received', {
-        payment: JSON.parse(JSON.stringify(event.payment)),
+        paymentId: event.payment.id,
+        paymentType: event.payment.paymentType,
+        method: event.payment.method,
       });
     } else if (event.type === 'paymentFailed') {
       logger.info(LogCategory.PAYMENT, 'Payment failed event received', {
-        payment: JSON.parse(JSON.stringify(event.payment)),
+        paymentId: event.payment.id,
+        paymentType: event.payment.paymentType,
+        method: event.payment.method,
       });
       // Same reasoning as the send celebration above: with the sheet gone
       // there is nothing else to tell the user the payment did not go out.

--- a/src/pages/PasskeySettingsPage.tsx
+++ b/src/pages/PasskeySettingsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '../components/Icons';
 import { LEGACY_RP_ID, SHARED_RP_ID } from '../services/passkeyPrfProvider';
 import { getPasskeyRpId } from '../services/passkeyService';
+import { isDevMode as isDevModeEnabled } from '../services/settings';
 
 interface PasskeySettingsPageProps {
   onBack: () => void;
@@ -54,7 +55,7 @@ const PasskeySettingsPage: React.FC<PasskeySettingsPageProps> = ({
   // Dev-only RP-ID switch: only meaningful when a distinct shared RP ID is
   // configured. Lets a tester sign in under the legacy vs shared RP ID to
   // exercise the passkey-RP migration path.
-  const isDevMode = localStorage.getItem('spark-dev-mode') === 'true';
+  const isDevMode = isDevModeEnabled();
   const sharedRpConfigured = !!SHARED_RP_ID && SHARED_RP_ID !== LEGACY_RP_ID;
   const [activeRpId] = useState<string>(getPasskeyRpId() ?? LEGACY_RP_ID);
   const [switchingRp, setSwitchingRp] = useState<string | null>(null);

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,18 +1,17 @@
-import React, { useEffect, useState } from 'react';
-import { FormGroup, FormInput, LoadingSpinner, PrimaryButton, Switch } from '../components/ui';
-import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable } from '../services/settings';
+import React, { useEffect, useRef, useState } from 'react';
+import { ConfirmDialog, FormGroup, FormInput, LoadingSpinner, PrimaryButton, Switch } from '../components/ui';
+import { PinGate } from '../components/PinEntry';
+import { getSettings, saveSettings, UserSettings, isBuyBitcoinAvailable, isDevMode as isDevModeEnabled, setDevMode } from '../services/settings';
 import type { Config, Network } from '@breeztech/breez-sdk-spark';
 import { useWallet } from '@/contexts/WalletContext';
 import { CurrencyIcon, ChevronRightIcon, DownloadIcon, KeyIcon, LockIcon, ShieldCheckIcon, TrashIcon, ExternalLinkIcon } from '../components/Icons';
 import { ACCOUNT_DELETION_GUIDE_URL } from '@/services/accountDeletion';
 import { openExternalUrl } from '@/utils/externalLink';
-import { isAppLockSupported } from '@/services/appLock';
+import { isAppLockSupported, isPinEnabled } from '@/services/appLock';
 import SlideInPage from '../components/layout/SlideInPage';
 import { logger, LogCategory } from '@/services/logger';
 import { shareOrDownloadLogs, exportDatabaseState } from '@/services/logExport';
 import { useSecretTap } from '@/hooks/useSecretTap';
-
-const DEV_MODE_STORAGE_KEY = 'spark-dev-mode';
 
 interface SettingsPageProps {
   onBack: () => void;
@@ -39,10 +38,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     activated: isDevMode,
     tapCount: devTapCount,
     threshold: devTapThreshold,
-  } = useSecretTap(5, 2000, () =>
-    new URLSearchParams(window.location.search).get('dev') === 'true'
-    || localStorage.getItem(DEV_MODE_STORAGE_KEY) === 'true'
-  );
+  } = useSecretTap(5, 2000, isDevModeEnabled);
   // Network and persisted settings only change via handlers that
   // reload the page, so reading once at mount is sufficient.
   const [selectedNetwork, setSelectedNetwork] = useState<Network>(
@@ -89,9 +85,16 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   const [isDownloadingLogs, setIsDownloadingLogs] = useState<boolean>(false);
   const [isExportingDb, setIsExportingDb] = useState<boolean>(false);
 
-  // Persist dev mode to localStorage when toggled via secret tap
+  // Persist the tap toggle only. The first run is skipped because the
+  // hook seeds from `?dev=true`, and writing that would turn a link into
+  // a permanent local change.
+  const devModeSeeded = useRef(false);
   useEffect(() => {
-    localStorage.setItem(DEV_MODE_STORAGE_KEY, String(isDevMode));
+    if (!devModeSeeded.current) {
+      devModeSeeded.current = true;
+      return;
+    }
+    setDevMode(isDevMode);
   }, [isDevMode]);
 
   const handleNetworkChange = (network: Network) => {
@@ -124,7 +127,17 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     window.location.reload();
   };
 
+  // The database export carries the whole payment history off the device,
+  // so it goes behind the app lock. Where there is no lock to check
+  // against (web, or no PIN set) a confirm step is all that is available.
+  const [exportGate, setExportGate] = useState<'pin' | 'confirm' | null>(null);
+
   const handleExportDb = async () => {
+    setExportGate((await isPinEnabled()) ? 'pin' : 'confirm');
+  };
+
+  const runExportDb = async () => {
+    setExportGate(null);
     setIsExportingDb(true);
     try {
       const info = await wallet.getInfo({});
@@ -156,6 +169,16 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
       Save Changes
     </PrimaryButton>
   ) : undefined;
+
+  // Same shape as BackupPage: the gate replaces the page body, and the
+  // header's close button is the way out.
+  if (exportGate === 'pin') {
+    return (
+      <SlideInPage title="Settings" onClose={() => setExportGate(null)} slideFrom="left">
+        <PinGate reason="Export database" onUnlocked={() => { void runExportDb(); }} />
+      </SlideInPage>
+    );
+  }
 
   return (
     <SlideInPage title="Settings" onClose={onBack} slideFrom="left" footer={footer}>
@@ -434,6 +457,16 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={exportGate === 'confirm'}
+        title="Export Database"
+        message="This saves your full payment history, including invoices and contacts, to a file you can share. Only do this if you were asked for it, and only send it to someone you trust."
+        confirmLabel="Export"
+        variant="warning"
+        onConfirm={() => { void runExportDb(); }}
+        onCancel={() => setExportGate(null)}
+      />
     </SlideInPage>
   );
 };

--- a/src/services/logExport.test.ts
+++ b/src/services/logExport.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import JSZip from 'jszip';
+
+// Two sessions started inside the same second, plus the one this load
+// owns. logger.ts pulls its session helpers from here too, so the mock
+// has to cover those as well.
+vi.mock('./logStorage', () => ({
+  isStorageAvailable: () => true,
+  peekCurrentSessionId: () => '1785977460000-live',
+  getAllSessions: async () => [
+    { id: '1785977450100-aaa', startedAt: '2026-08-06T00:50:50.100Z', endedAt: 'x', logs: 'one' },
+    { id: '1785977450900-bbb', startedAt: '2026-08-06T00:50:50.900Z', endedAt: 'x', logs: 'two' },
+    { id: '1785977460000-live', startedAt: '2026-08-06T00:51:00.000Z', logs: 'live, stale copy' },
+  ],
+  startSession: async () => 'session',
+  saveSessionLogs: async () => {},
+  endSession: async () => {},
+}));
+
+describe('getAllLogsAsZip', () => {
+  it('writes the live session once and keeps same-second sessions apart', async () => {
+    const { getAllLogsAsZip } = await import('./logExport');
+
+    const zip = await JSZip.loadAsync(await getAllLogsAsZip());
+    const names = Object.keys(zip.files);
+
+    expect(names.filter((n) => n.includes('_glow_current'))).toHaveLength(1);
+    // The live session is not repeated as a stale historical file, and the
+    // two same-second sessions both survive instead of overwriting.
+    expect(names.filter((n) => n.includes('_glow_session')).sort()).toEqual([
+      '1785977450_glow_session_aaa.txt',
+      '1785977450_glow_session_bbb.txt',
+    ]);
+  });
+});

--- a/src/services/logExport.ts
+++ b/src/services/logExport.ts
@@ -1,5 +1,5 @@
 import { logger, LogCategory, redactDeep } from './logger';
-import { getAllSessions, isStorageAvailable } from './logStorage';
+import { getAllSessions, isStorageAvailable, peekCurrentSessionId } from './logStorage';
 import JSZip from 'jszip';
 import { Capacitor } from '@capacitor/core';
 import { Share } from '@capacitor/share';
@@ -26,9 +26,19 @@ export const getAllLogsAsZip = async (): Promise<Blob> => {
   if (isStorageAvailable()) {
     try {
       const sessions = await getAllSessions();
-      for (const session of sessions) {
+      // The live session is already written above, in full. Its stored copy
+      // trails that by one persist interval, so exporting both leaves two
+      // near-identical files and the stale one on top. Skipped by id rather
+      // than by a missing end time: a session cut short by a crash also has
+      // no end time, and those are worth keeping.
+      const activeSessionId = peekCurrentSessionId();
+      for (const [index, session] of sessions.entries()) {
+        if (session.id === activeSessionId) continue;
         const sessionTimestamp = Math.floor(new Date(session.startedAt).getTime() / 1000);
-        const filename = `${sessionTimestamp}_glow_session.txt`;
+        // Whole seconds alone collide when two sessions start in the same
+        // one (a quick reload), and the zip would keep only the last.
+        const suffix = session.id.split('-')[1] ?? String(index);
+        const filename = `${sessionTimestamp}_glow_session_${suffix}.txt`;
         const sessionHeader = [
           `Glow Log Export`,
           `Session ID: ${session.id}`,

--- a/src/services/logExport.ts
+++ b/src/services/logExport.ts
@@ -1,4 +1,4 @@
-import { logger, LogCategory } from './logger';
+import { logger, LogCategory, redactDeep } from './logger';
 import { getAllSessions, isStorageAvailable } from './logStorage';
 import JSZip from 'jszip';
 import { Capacitor } from '@capacitor/core';
@@ -96,9 +96,13 @@ export const exportDatabaseState = async (identityPubkey: string, network: strin
   }
 
   try {
+    // The SDK database holds the full payment history: bolt11 invoices,
+    // payment preimages, and the cached Breez JWT in `settings`. The dump
+    // is for debugging state machines, not for carrying credentials, so
+    // every row goes through the log redactor first.
     const objectStores: Record<string, unknown[]> = {};
     for (const name of db.objectStoreNames) {
-      objectStores[name] = await dumpIndexedDBStore(db, name);
+      objectStores[name] = redactDeep(await dumpIndexedDBStore(db, name)) as unknown[];
     }
 
     const json = JSON.stringify({

--- a/src/services/logStorage.ts
+++ b/src/services/logStorage.ts
@@ -246,6 +246,15 @@ export async function startSession(): Promise<string> {
 }
 
 /**
+ * The session this page load writes to, or null before initSession.
+ * Unlike getCurrentSessionId this never starts one: reading the session
+ * for an export must not create a session as a side effect.
+ */
+export function peekCurrentSessionId(): string | null {
+  return currentSessionId;
+}
+
+/**
  * Get current session ID, starting a new session if needed
  */
 export async function getCurrentSessionId(): Promise<string> {

--- a/src/services/logStorage.ts
+++ b/src/services/logStorage.ts
@@ -1,11 +1,11 @@
 /**
- * Secure log storage service for persisting logs across sessions.
+ * Log storage for persisting logs across sessions: up to MAX_SESSIONS
+ * sessions in IndexedDB, one unified stream each, oldest pruned first.
  *
- * Features:
- * - Encrypts logs using AES-GCM with a derived key
- * - Stores up to MAX_SESSIONS sessions in IndexedDB
- * - Single unified log stream per session
- * - Automatic cleanup of oldest sessions when limit reached
+ * Logs are AES-GCM encrypted, but the key lives in the same database, so
+ * this only protects against a raw read of the storage files. Anything
+ * running in the origin decrypts at will: treat the store as readable by
+ * the device, and keep secrets out of the logs (see logger's scrubber).
  */
 
 const DB_NAME = 'glow-logs';
@@ -76,68 +76,66 @@ async function openDatabase(): Promise<IDBDatabase> {
   });
 }
 
+function storeEncryptionKey(database: IDBDatabase, key: CryptoKey): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(KEY_STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(KEY_STORE_NAME);
+    const request = store.put({ id: 'main', key });
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+  });
+}
+
 /**
- * Get or create encryption key
- * Key is stored in IndexedDB and persists across sessions
+ * Get or create the encryption key, persisted across sessions.
+ *
+ * The key is non-extractable and stored as a `CryptoKey`: raw bytes in
+ * the record would hand a storage dump the ciphertext and the key to
+ * open it in one file.
  */
 async function getEncryptionKey(): Promise<CryptoKey> {
   if (encryptionKey) return encryptionKey;
 
   const database = await openDatabase();
 
-  // Try to load existing key
-  const existingKey = await new Promise<CryptoKey | null>((resolve, reject) => {
+  const stored = await new Promise<unknown>((resolve, reject) => {
     const transaction = database.transaction(KEY_STORE_NAME, 'readonly');
     const store = transaction.objectStore(KEY_STORE_NAME);
     const request = store.get('main');
 
     request.onerror = () => reject(request.error);
-    request.onsuccess = async () => {
-      if (request.result?.key) {
-        try {
-          const imported = await crypto.subtle.importKey(
-            'raw',
-            request.result.key,
-            { name: 'AES-GCM', length: 256 },
-            true,
-            ['encrypt', 'decrypt']
-          );
-          resolve(imported);
-        } catch {
-          resolve(null);
-        }
-      } else {
-        resolve(null);
-      }
-    };
+    request.onsuccess = () => resolve(request.result?.key ?? null);
   });
 
-  if (existingKey) {
-    encryptionKey = existingKey;
-    return existingKey;
+  if (stored instanceof CryptoKey) {
+    encryptionKey = stored;
+    return stored;
   }
 
-  // Generate new key
-  const newKey = await crypto.subtle.generateKey(
-    { name: 'AES-GCM', length: 256 },
-    true,
-    ['encrypt', 'decrypt']
-  );
+  // Records written before the key was non-extractable hold raw bytes.
+  // Import them (so existing sessions still decrypt) and overwrite the
+  // record with the CryptoKey, which drops the bytes from storage.
+  const migrated = stored
+    ? await crypto.subtle
+        .importKey('raw', stored as BufferSource, { name: 'AES-GCM', length: 256 }, false, [
+          'encrypt',
+          'decrypt',
+        ])
+        .catch(() => null)
+    : null;
 
-  // Export and store key
-  const exportedKey = await crypto.subtle.exportKey('raw', newKey);
+  const key =
+    migrated ??
+    (await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, [
+      'encrypt',
+      'decrypt',
+    ]));
 
-  await new Promise<void>((resolve, reject) => {
-    const transaction = database.transaction(KEY_STORE_NAME, 'readwrite');
-    const store = transaction.objectStore(KEY_STORE_NAME);
-    const request = store.put({ id: 'main', key: exportedKey });
+  await storeEncryptionKey(database, key);
 
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve();
-  });
-
-  encryptionKey = newKey;
-  return newKey;
+  encryptionKey = key;
+  return key;
 }
 
 /**

--- a/src/services/logger.test.ts
+++ b/src/services/logger.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { logger, LogCategory } from './logger';
+import { logger, LogCategory, scrubSecrets, redactDeep } from './logger';
+
+// A published BIP39 test vector, never a real wallet's phrase.
+const MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 
 describe('logger', () => {
   beforeEach(() => {
@@ -141,5 +145,68 @@ describe('logger', () => {
     expect(logs[0].message).toBe('[onboarding] step.begin');
     expect(logs[1].message).toBe('[onboarding] step.error');
     expect(logs[1].level).toBe('WARN');
+  });
+
+  it('scrubs secrets out of the message string, not just the context', () => {
+    logger.info(LogCategory.SDK_INTERNAL, `paying lnbc${'q'.repeat(60)} now`);
+
+    expect(logger.getLogs()[0].message).toBe('paying [REDACTED] now');
+  });
+});
+
+describe('scrubSecrets', () => {
+  it('redacts secret-shaped values inside free-form text', () => {
+    const secrets = [
+      MNEMONIC,
+      `lnbc1pvjluez${'q'.repeat(60)}`,
+      'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnbG93In0.dBjftJeZ4CVPmB92K27uhbUJU1p1r1wPWnvVpvcMOOO',
+      'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+    ];
+
+    // Punctuation delimiters: "before" and friends are themselves BIP39
+    // words, so a word-delimited fixture tests the wrong thing.
+    for (const secret of secrets) {
+      expect(scrubSecrets(`>> ${secret} <<`)).toBe('>> [REDACTED] <<');
+    }
+  });
+
+  it('redacts hex only when the line says it is secret material', () => {
+    const hex = 'a'.repeat(64);
+
+    expect(scrubSecrets(`settled with preimage ${hex}`)).toBe('settled with preimage [REDACTED]');
+    expect(scrubSecrets(`derived seed ${hex}`)).toBe('derived seed [REDACTED]');
+  });
+
+  it('keeps what support needs: identifiers, pubkeys, and prose', () => {
+    // The SDK reports claim and deposit failures as text with the txid
+    // inline. Blanking it would leave the failure untraceable.
+    const txid = 'a'.repeat(64);
+    expect(scrubSecrets(`Claimed utxo ${txid}:0`)).toBe(`Claimed utxo ${txid}:0`);
+
+    const pubkey = `03${'a'.repeat(64)}`;
+    expect(scrubSecrets(`peer ${pubkey} connected`)).toBe(`peer ${pubkey} connected`);
+
+    const prose = 'failed to claim the deposit because the node never answered within the window';
+    expect(scrubSecrets(prose)).toBe(prose);
+  });
+});
+
+describe('redactDeep', () => {
+  it('blanks sensitive keys, scrubs values, keeps ids and shape', () => {
+    const paymentId = 'f'.repeat(64);
+    const out = redactDeep({
+      payments: [{ id: paymentId, preimage: 'x', note: `phrase: ${MNEMONIC}` }],
+      settings: [
+        { key: 'breez_jwt', value: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnIn0.c2lnbmF0dXJlXw' },
+      ],
+      count: 1,
+    });
+
+    expect(out).toEqual({
+      // Row ids survive, so the export can still be followed row to row.
+      payments: [{ id: paymentId, preimage: '[REDACTED]', note: 'phrase: [REDACTED]' }],
+      settings: [{ key: 'breez_jwt', value: '[REDACTED]' }],
+      count: 1,
+    });
   });
 });

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -12,6 +12,7 @@
  * - Persistent encrypted storage across sessions (up to 10 sessions)
  */
 
+import { wordlists } from 'bip39';
 import { isConsoleLoggingEnabled } from './settings';
 import {
   isStorageAvailable,
@@ -76,26 +77,102 @@ const SENSITIVE_KEYS = [
   'invoice',
 ];
 
+const REDACTED = '[REDACTED]';
+
+/** Secret shapes that must never reach the buffer whatever field they
+ *  arrive in. Key-name matching alone misses SDK log lines and error
+ *  strings, which are free-form text with the secret inline. */
+const SECRET_PATTERNS = [
+  /\b(?:lnbcrt|lntbs|lnbc|lntb|lnsb)[0-9a-z]{40,}/gi, // bolt11
+  /\blnurl1[0-9a-z]{20,}/gi,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g, // jwt
+  /\b(?:xprv|tprv|yprv|zprv|uprv|vprv)[1-9A-HJ-NP-Za-km-z]{50,}/g, // extended privkey
+];
+
+/** 32 bytes of hex and up: a preimage, a txid, and a payment hash are all
+ *  this shape, so the value alone cannot say which it is. */
+const HEX_BLOB = /\b[0-9a-fA-F]{64,}\b/g;
+
+/** What decides it is the line's own wording. Blanking every hex blob
+ *  costs more than it buys: the SDK reports claim, deposit, and exit
+ *  failures as text with the txid inline, and those are the failures we
+ *  are usually asked to explain. So hex goes only when the line says it
+ *  is carrying secret material. */
+const SECRET_LABEL = /preimage|mnemonic|\bseed\b|entropy|passphrase|private[_ ]?key|secret/i;
+
+const BIP39_WORDS = new Set(wordlists.english);
+
+/** Shortest phrase BIP39 defines. */
+const MNEMONIC_MIN_WORDS = 12;
+
+/**
+ * Redact runs of 12+ whitespace-separated wordlist words. Every word is
+ * checked, so prose has to be a valid phrase to match: scanning for runs
+ * rather than regex-matching a shape is what keeps a phrase quoted
+ * mid-sentence from hiding inside a longer, non-matching run.
+ */
+function redactMnemonics(text: string): string {
+  const spans: Array<[number, number]> = [];
+  let start = -1;
+  let end = -1;
+  let words = 0;
+
+  for (const match of text.matchAll(/[a-z]+/g)) {
+    const at = match.index ?? 0;
+    const isWord = BIP39_WORDS.has(match[0]);
+    // Anything but whitespace between two words breaks the phrase.
+    const joined = words > 0 && /^\s+$/.test(text.slice(end, at));
+
+    if (isWord && (words === 0 || joined)) {
+      if (words === 0) start = at;
+      words++;
+    } else {
+      if (words >= MNEMONIC_MIN_WORDS) spans.push([start, end]);
+      words = isWord ? 1 : 0;
+      start = at;
+    }
+    end = at + match[0].length;
+  }
+  if (words >= MNEMONIC_MIN_WORDS) spans.push([start, end]);
+
+  // Back to front so the earlier spans keep their offsets.
+  return spans.reduceRight((out, [from, to]) => out.slice(0, from) + REDACTED + out.slice(to), text);
+}
+
+/** Redact secret-shaped values inside a free-form string. */
+export function scrubSecrets(text: string): string {
+  let out = text;
+  for (const pattern of SECRET_PATTERNS) out = out.replace(pattern, REDACTED);
+  if (SECRET_LABEL.test(out)) out = out.replace(HEX_BLOB, REDACTED);
+  return redactMnemonics(out);
+}
+
+/**
+ * Blank values under a sensitive key name, scrub every remaining string
+ * for secret-shaped content. Arrays and dates keep their shape: this
+ * also runs over the SDK database export, where a mangled row is a
+ * broken export.
+ */
+export function redactDeep(value: unknown): unknown {
+  if (typeof value === 'string') return scrubSecrets(value);
+  if (Array.isArray(value)) return value.map(redactDeep);
+  if (value instanceof Date) return value;
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, v]) => {
+        const lowerKey = key.toLowerCase();
+        if (SENSITIVE_KEYS.some((k) => lowerKey.includes(k.toLowerCase()))) return [key, REDACTED];
+        return [key, redactDeep(v)];
+      }),
+    );
+  }
+  return value;
+}
+
 /** Sanitize context object by redacting sensitive values */
 function sanitizeContext(ctx?: Record<string, unknown>): Record<string, unknown> | undefined {
   if (!ctx) return undefined;
-
-  const sanitized: Record<string, unknown> = {};
-
-  for (const [key, value] of Object.entries(ctx)) {
-    const lowerKey = key.toLowerCase();
-    const isSensitive = SENSITIVE_KEYS.some((k) => lowerKey.includes(k.toLowerCase()));
-
-    if (isSensitive) {
-      sanitized[key] = '[REDACTED]';
-    } else if (typeof value === 'object' && value !== null) {
-      sanitized[key] = sanitizeContext(value as Record<string, unknown>);
-    } else {
-      sanitized[key] = value;
-    }
-  }
-
-  return sanitized;
+  return redactDeep(ctx) as Record<string, unknown>;
 }
 
 /** Core logging function */
@@ -109,7 +186,9 @@ function log(
     timestamp: new Date().toISOString(),
     level,
     category,
-    message,
+    // SDK lines and error strings carry their secrets inline, so the
+    // message needs the value scrubber too, not just the context.
+    message: scrubSecrets(message),
     context: sanitizeContext(context),
   };
 

--- a/src/services/settings.test.ts
+++ b/src/services/settings.test.ts
@@ -39,6 +39,30 @@ describe('ensureSparkPrivateMode', () => {
   });
 });
 
+describe('dev mode', () => {
+  // The URL flag is read once at module load, so each "page load" is a
+  // module reset with a fresh URL. localStorage survives, as on a device.
+  async function load(search = '') {
+    vi.resetModules();
+    window.history.replaceState({}, '', `/${search}`);
+    return import('./settings');
+  }
+
+  it('a ?dev=true link lasts for the page load only; the toggle persists', async () => {
+    localStorage.clear();
+
+    const linked = await load('?dev=true');
+    expect(linked.isDevMode()).toBe(true);
+    expect(localStorage.getItem('spark-dev-mode')).toBeNull();
+
+    const plain = await load();
+    expect(plain.isDevMode()).toBe(false);
+
+    plain.setDevMode(true);
+    expect((await load()).isDevMode()).toBe(true);
+  });
+});
+
 describe('buildConnectConfig', () => {
   it('connects with private mode enabled by default', async () => {
     vi.stubEnv('VITE_BREEZ_API_KEY', 'test-key');

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -256,6 +256,26 @@ export function clearNetworkOverride(): void {
   }
 }
 
+const DEV_MODE_KEY = 'spark-dev-mode';
+
+/**
+ * `?dev=true` in the URL, read once per page load. Deliberately never
+ * written to storage: a link would otherwise leave the dev surfaces
+ * (database export, network switch) on for the life of the install, with
+ * nothing on screen saying so. Only the settings tap toggle persists.
+ */
+const devModeFromUrl =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('dev') === 'true';
+
+export function isDevMode(): boolean {
+  return devModeFromUrl || localStorage.getItem(DEV_MODE_KEY) === 'true';
+}
+
+export function setDevMode(enabled: boolean): void {
+  localStorage.setItem(DEV_MODE_KEY, String(enabled));
+}
+
 /**
  * Check if console logging is enabled.
  * Controlled via VITE_CONSOLE_LOGGING env var when present; defaults to dev mode.


### PR DESCRIPTION
Housekeeping pass over the diagnostic tools.

## What changed
- Logs are trimmed as they are written. Long values and payment details stay out, so a shared log is still useful but carries less.
- Outside development builds the app keeps fewer internal messages.
- The database export asks for confirmation first, and uses the device unlock where the app has one. It also leaves out data it does not need.
- The log archive now holds one file per session. The session in progress could appear twice before, with one copy a few seconds behind.
- A developer link now applies to the current visit only. It no longer stays on after a reload. The in-app toggle is unchanged.

## Notes
No change to balances, payments, or wallet behaviour. Unit tests cover the trimming rules, the archive contents, and the developer toggle.