### PR TITLE
fix: keep a way back when a link leaves the app

### DIFF
--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -217,6 +217,10 @@ const SideMenu: React.FC<SideMenuProps> = ({ isOpen, onClose, onLogout, onOpenSe
                 href="https://breez.technology/sdk/"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={(e) => {
+                  e.preventDefault();
+                  void openExternalUrl('https://breez.technology/sdk/');
+                }}
                 className="block text-xs text-spark-text-muted text-center hover:text-spark-text-secondary transition-colors"
               >
                 Powered by Breez SDK

--- a/src/features/buy/hooks/useBuyBitcoin.ts
+++ b/src/features/buy/hooks/useBuyBitcoin.ts
@@ -10,6 +10,7 @@ import { logger, LogCategory } from '../../../services/logger';
 import { formatError } from '../../../utils/formatError';
 import { type TokenDisplayConfig } from '../../../utils/tokenFormatting';
 import { toSdkAmountNumber, type Sats } from '../../../types/sats';
+import { isStandalonePwa, openExternalUrl } from '../../../utils/externalLink';
 import {
   getBuyProviderSettings,
   filterProvidersByNetwork,
@@ -196,6 +197,11 @@ export function useBuyBitcoin({
         // page.
         if (mobileTab) {
           mobileTab.location.href = response.url;
+        } else if (isStandalonePwa()) {
+          // window.open returns null in an installed PWA, so this is the
+          // normal path there: navigating the standalone window itself
+          // would leave no way back.
+          await openExternalUrl(response.url);
         } else {
           window.location.href = response.url;
         }

--- a/src/hooks/useBreezSdk.ts
+++ b/src/hooks/useBreezSdk.ts
@@ -20,6 +20,7 @@ import { useLatest } from './useLatest';
 import { buildConnectConfig } from './buildConnectConfig';
 import { logger, LogCategory, logSdkMessage } from '../services/logger';
 import { formatError } from '../utils/formatError';
+import { isStandalonePwa, openExternalUrl } from '../utils/externalLink';
 import { isDepositRejected, clearRejectedDeposits } from '../services/depositState';
 import { setCachedStableTicker, clearNetworkOverride, clearStableRestorePrompted, ensureSparkPrivateMode, isDevMode, type BuyBitcoinProvider } from '../services/settings';
 import { wipeAllLocalData } from '../services/accountDeletion';
@@ -1087,6 +1088,11 @@ export function useBreezSdk(
         await Browser.open({ url: response.url });
       } else if (newTab) {
         newTab.location.href = response.url;
+      } else if (isStandalonePwa()) {
+        // window.open returns null in an installed PWA, so this is the normal
+        // path there, not a blocked-popup edge: navigating the standalone
+        // window itself would leave no way back.
+        await openExternalUrl(response.url);
       } else {
         window.location.href = response.url;
       }

--- a/src/utils/externalLink.ts
+++ b/src/utils/externalLink.ts
@@ -31,7 +31,12 @@ export async function openExternalUrl(url: string): Promise<void> {
   anchor.remove();
 }
 
-const isStandalonePwa = (): boolean =>
+/**
+ * Installed-PWA display mode. A standalone window has no address bar and no
+ * back affordance, so navigating it away from the app strands the user until
+ * they relaunch.
+ */
+export const isStandalonePwa = (): boolean =>
   window.matchMedia?.('(display-mode: standalone)').matches
   || (navigator as Navigator & { standalone?: boolean }).standalone === true;
 


### PR DESCRIPTION
Opening a buy provider from an installed Glow could navigate the app's own window, which has no address bar and no back gesture, so the only way back was relaunching. Links now open in a browser view that closes back into the app.

Same fix for the side menu footer link, which was leaving to the system browser on native.