### PR TITLE
fix: drop the word "wallet" from user-facing copy

### DIFF
--- a/src/components/StableBalanceToggleFlow.tsx
+++ b/src/components/StableBalanceToggleFlow.tsx
@@ -217,7 +217,7 @@ const StableBalanceToggleFlow: React.FC<StableBalanceToggleFlowProps> = ({
         {...(restorePrompt ? {
           title: 'USD Balance Detected',
           description:
-            "We've detected USD funds in your wallet. Would you like to switch to USD mode?" +
+            "We've detected USD funds. Would you like to switch to USD mode?" +
             '\n\n' +
             'Your balance will be held in USD. Incoming BTC is automatically converted to USD, ' +
             'and outgoing payments are converted back to BTC.',

--- a/src/features/passkey-migration/steps/DoneStep.tsx
+++ b/src/features/passkey-migration/steps/DoneStep.tsx
@@ -31,8 +31,8 @@ const DoneStep: React.FC<DoneStepProps> = ({ onDone, lnAddressFailures = [] }) =
         </ul>
         <p className="text-xs text-spark-warning mt-2 text-center">
           {lnAddressFailures.length === 1
-            ? "Payments sent to it will continue to arrive in your old wallet until the transfer is complete."
-            : "Payments sent to them will continue to arrive in your old wallets until the transfers are complete."}
+            ? "Payments sent to it will continue to arrive under your old passkey until the transfer is complete."
+            : "Payments sent to them will continue to arrive under your old passkey until the transfers are complete."}
         </p>
       </div>
     )}

--- a/src/pages/RestorePage.tsx
+++ b/src/pages/RestorePage.tsx
@@ -53,7 +53,7 @@ const RestorePage: React.FC<RestorePageProps> = ({
         className="w-full"
         data-testid="restore-confirm-button"
       >
-        {isLoading ? 'Restoring...' : 'Restore Wallet'}
+        {isLoading ? 'Restoring...' : 'Restore'}
       </PrimaryButton>
     </div>
   );
@@ -69,7 +69,7 @@ const RestorePage: React.FC<RestorePageProps> = ({
         </div>
 
         <p className="text-spark-text-secondary text-center mb-6">
-          Enter your 12 or 24-word recovery phrase to restore your wallet. Words should be separated by spaces.
+          Enter your 12 or 24-word recovery phrase to restore Glow. Words should be separated by spaces.
         </p>
 
         <div className="relative">

--- a/src/pages/UnlockPage.tsx
+++ b/src/pages/UnlockPage.tsx
@@ -70,9 +70,9 @@ const UnlockPage: React.FC<UnlockPageProps> = ({
     : !isBiometricTier ? 'Try Again'
       : biometry ? `Unlock with ${biometry.label}` : 'Unlock';
   const unlockDescription = isWebPasskey
-    ? 'Your wallet is locked. Unlock with your passkey to continue.'
+    ? 'Glow is locked. Unlock with your passkey to continue.'
     : !isBiometricTier ? 'Glow could not start up. Please try again.'
-      : 'Your wallet is locked. Unlock with your biometric to continue.';
+      : 'Glow is locked. Unlock with your biometric to continue.';
   const UnlockIcon = isWebPasskey
     ? PasskeyIcon
     : biometry?.kind === 'face' ? FaceIdIcon : FingerprintIcon;


### PR DESCRIPTION
Five strings across the restore, unlock and passkey migration screens. Each one either says Glow or drops the noun, whichever reads better there.