### PR TITLE
fix: stop offering to convert change on the restore prompt

### DIFF
--- a/src/components/StableBalanceToggleFlow.tsx
+++ b/src/components/StableBalanceToggleFlow.tsx
@@ -199,8 +199,16 @@ const StableBalanceToggleFlow: React.FC<StableBalanceToggleFlowProps> = ({
 
   const handleDisclaimerAccept = useCallback(() => {
     setStableDisclaimerAccepted();
+    // The restore prompt only turns the mode on. Sats that came back with the
+    // restore are left to the SDK, which auto-converts them once they clear its
+    // dynamic minimum: quoting a conversion here only ever offers to convert
+    // change that is too small to convert, and then fails.
+    if (restorePrompt) {
+      void stableBalance.toggleStableBalance(USDB_TICKER).then(onComplete);
+      return;
+    }
     startEstimation();
-  }, [startEstimation]);
+  }, [restorePrompt, stableBalance, onComplete, startEstimation]);
 
   const handleConfirm = useCallback(() => {
     executeToggle();


### PR DESCRIPTION
Saying yes to the USD prompt after a restore offered to convert whatever change came back with it. Change under the minimum conversion amount cannot be converted, so the only thing that dialog can do is tell you the balance is too low. It now just switches the mode on, and the change converts on its own once it clears the minimum.