### PR TITLE
fix: show the refund sheet when you press Continue

### DIFF
--- a/src/components/ui/sheets/BottomSheet.tsx
+++ b/src/components/ui/sheets/BottomSheet.tsx
@@ -111,6 +111,12 @@ export interface BottomSheetContainerProps {
   fullHeight?: boolean;
   /** Whether to show a backdrop overlay */
   showBackdrop?: boolean;
+  /**
+   * Stacking order of the sheet root. Raise it past any opaque overlay
+   * the sheet opens from: SlideInPage is z-60, so a sheet left at the
+   * default opens behind it and reads as a dead button.
+   */
+  zIndex?: number;
 }
 
 export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
@@ -122,6 +128,7 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
   maxHeightVh = 100,
   fullHeight = false,
   showBackdrop = false,
+  zIndex = 50,
 }) => {
   const sheetRef = useRef<SheetRef>(null);
   const [contentPx, setContentPx] = useState<number | null>(null);
@@ -480,7 +487,7 @@ export const BottomSheetContainer: React.FC<BottomSheetContainerProps> = ({
       // whole window. The old hand-rolled sheet was absolute inside the
       // column and inherited this for free. The backdrop is a separate
       // fixed child and still covers the full viewport.
-      style={{ zIndex: 50, maxWidth: '56rem', marginInline: 'auto' }}
+      style={{ zIndex, maxWidth: '56rem', marginInline: 'auto' }}
       // Portal into #root, not document.body: the web viewport
       // manager pins #root against Safari's focus pan, and sheets
       // portaled outside it stayed uncompensated. That is what let a

--- a/src/pages/GetRefundPage.test.tsx
+++ b/src/pages/GetRefundPage.test.tsx
@@ -57,6 +57,11 @@ describe('GetRefundPage deposit card', () => {
     ) as HTMLElement;
     expect(sheetRoot).not.toBeNull();
     expect(Number(sheetRoot.style.zIndex)).toBeGreaterThan(SLIDE_IN_PAGE_Z);
+    // The backdrop is what dims the page behind the sheet; without it
+    // the sheet arrives over an undimmed page and is easy to miss.
+    expect(
+      document.querySelector('.react-modal-sheet-backdrop'),
+    ).not.toBeNull();
   });
 });
 

--- a/src/pages/GetRefundPage.test.tsx
+++ b/src/pages/GetRefundPage.test.tsx
@@ -41,6 +41,25 @@ function sheetButton(label: string) {
   return within(actions).getByText(label);
 }
 
+// SlideInPage wraps the page in a z-60 opaque overlay. The sheet
+// portals to #root as that overlay's sibling, so anything at or below
+// this stacks behind the page and the card's Continue reads as dead.
+const SLIDE_IN_PAGE_Z = 60;
+
+describe('GetRefundPage deposit card', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('opens the refund sheet above the slide-in page', async () => {
+    await renderPage();
+
+    const sheetRoot = document.querySelector(
+      '.react-modal-sheet-root',
+    ) as HTMLElement;
+    expect(sheetRoot).not.toBeNull();
+    expect(Number(sheetRoot.style.zIndex)).toBeGreaterThan(SLIDE_IN_PAGE_Z);
+  });
+});
+
 // The sheet's Continue must never be pressable in a state its handler
 // rejects: the press is swallowed with no feedback.
 describe('GetRefundPage address step', () => {

--- a/src/pages/GetRefundPage.test.tsx
+++ b/src/pages/GetRefundPage.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import type { BreezSdk, DepositInfo } from '@breeztech/breez-sdk-spark';
+import { WalletProvider } from '@/contexts/WalletContext';
+import { createMockClient } from '@/test/mocks/mockWalletApi';
+import { rejectDeposit } from '@/services/depositState';
+import GetRefundPage from './GetRefundPage';
+
+const DEPOSIT: DepositInfo = {
+  txid: 'a'.repeat(64),
+  vout: 0,
+  amountSats: 50_000,
+  isMature: true,
+};
+
+async function renderPage() {
+  rejectDeposit(DEPOSIT.txid, DEPOSIT.vout);
+  const client = createMockClient() as unknown as BreezSdk;
+  client.listUnclaimedDeposits = vi
+    .fn()
+    .mockResolvedValue({ deposits: [DEPOSIT] });
+
+  render(
+    <WalletProvider client={client} isConnected>
+      <GetRefundPage onBack={vi.fn()} />
+    </WalletProvider>,
+  );
+
+  // Card Continue opens the refund sheet on the address step.
+  fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
+  const destination = await screen.findByPlaceholderText('bc1q...');
+  return { destination };
+}
+
+// react-modal-sheet keeps its root visibility:hidden until the open
+// animation runs, which it never does here. That empties every
+// accessible name inside the sheet, so role queries cannot reach these
+// buttons: match on text and scope to the step's action row.
+function sheetButton(label: string) {
+  const actions = screen.getByText('Cancel').parentElement as HTMLElement;
+  return within(actions).getByText(label);
+}
+
+// The sheet's Continue must never be pressable in a state its handler
+// rejects: the press is swallowed with no feedback.
+describe('GetRefundPage address step', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('advances to fee selection once a destination is entered', async () => {
+    const { destination } = await renderPage();
+    fireEvent.change(destination, { target: { value: 'bc1qdest' } });
+
+    const continueButton = sheetButton('Continue');
+    expect(continueButton).toBeEnabled();
+
+    fireEvent.click(continueButton);
+    expect(await screen.findByText('Select Fee Rate')).toBeInTheDocument();
+  });
+
+  it('disables Continue after Cancel clears the selected deposit', async () => {
+    const { destination } = await renderPage();
+    fireEvent.change(destination, { target: { value: 'bc1qdest' } });
+
+    // Cancel nulls selectedDeposit, but the sheet body stays mounted
+    // through the close animation and keeps the typed destination.
+    fireEvent.click(sheetButton('Cancel'));
+
+    expect(sheetButton('Continue')).toBeDisabled();
+  });
+});

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -290,7 +290,9 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
         </div>
       </div>
       {/* Refund Flow Bottom Sheet */}
-      <BottomSheetContainer isOpen={isRefundFlowOpen} onClose={closeRefundFlow}>
+      {/* Above SlideInPage's z-60 wrapper: the sheet portals to #root as
+          its sibling, so at the default z-50 it opens behind the page. */}
+      <BottomSheetContainer isOpen={isRefundFlowOpen} onClose={closeRefundFlow} zIndex={70}>
         <BottomSheetCard>
           <DialogHeader
             title={refundStep === 'result' ? (refundSuccess ? 'Refund Sent' : 'Refund Failed') : 'Refund to Bitcoin'}

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -226,7 +226,14 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                   const refundedTxId = getRefundTxId(dep);
                   const txKey = `deposit-tx-${idx}`;
                   const refundKey = `deposit-refund-${idx}`;
-                  const borderClass = isRefunded ? 'border-spark-success/30' : 'border-spark-border';
+                  // Marks which deposit the open sheet is refunding: the
+                  // sheet covers only part of the list behind it.
+                  const isSelected = isRefundFlowOpen
+                    && selectedDeposit?.txid === dep.txid
+                    && selectedDeposit?.vout === dep.vout;
+                  const borderClass = isSelected
+                    ? 'border-spark-primary'
+                    : isRefunded ? 'border-spark-success/30' : 'border-spark-border';
 
                   return (
                     <div
@@ -292,7 +299,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
       {/* Refund Flow Bottom Sheet */}
       {/* Above SlideInPage's z-60 wrapper: the sheet portals to #root as
           its sibling, so at the default z-50 it opens behind the page. */}
-      <BottomSheetContainer isOpen={isRefundFlowOpen} onClose={closeRefundFlow} zIndex={70}>
+      <BottomSheetContainer isOpen={isRefundFlowOpen} onClose={closeRefundFlow} zIndex={70} showBackdrop>
         <BottomSheetCard>
           <DialogHeader
             title={refundStep === 'result' ? (refundSuccess ? 'Refund Sent' : 'Refund Failed') : 'Refund to Bitcoin'}

--- a/src/pages/GetRefundPage.tsx
+++ b/src/pages/GetRefundPage.tsx
@@ -323,7 +323,7 @@ const GetRefundPage: React.FC<GetRefundPageProps> = ({ onBack, animationDirectio
                   </SecondaryButton>
                   <PrimaryButton
                     onClick={handleContinueToFeeSelection}
-                    disabled={!destination.trim()}
+                    disabled={!selectedDeposit || !destination.trim()}
                     className="flex-1"
                   >
                     Continue


### PR DESCRIPTION
### Problem

On the Get Refund page, you press Continue on a deposit card. Nothing occurs. The page does not change.

### Cause

The sheet opened correctly. You could not see it.

`SlideInPage` puts the Get Refund page in an opaque overlay at `z-60`. The sheet portals to `#root` as a sibling of that overlay, at `z-50`. The sheet therefore opened behind the page. The backdrop was off, so the screen did not dim either. Nothing showed that the press had an effect.

Get Refund is the only page that opens a sheet from inside a `SlideInPage`. No other sheet has this fault.

### Changes

1. `BottomSheetContainer` accepts a `zIndex` prop. The default stays 50, so all other sheets keep their present order. Get Refund uses 70, above the page.
2. The backdrop is on for this sheet. It dims the page and adds tap-to-dismiss.
3. The deposit card that the sheet refunds shows a primary border. The sheet hides only part of the list, so this connects the two.

### Secondary fix

The Continue button on the address step became available when you typed an address, but its handler also needs a selected deposit. Cancel clears the deposit and keeps the typed address, and the sheet stays on screen during its close animation. A press in that period did nothing. The button is now unavailable when no deposit is selected.

### Tests

New file `src/pages/GetRefundPage.test.tsx`:

- The sheet opens above the slide-in page layer, with a backdrop.
- Continue moves to the fee step after you enter an address.
- Continue is unavailable after Cancel.

The sheet test and the Cancel test both failed before their fixes. The fee-step test guards against disabling the button too much.